### PR TITLE
add cmake define for H4_HAVE_WINSOCK2_H

### DIFF
--- a/config/cmake/h4config.h.in
+++ b/config/cmake/h4config.h.in
@@ -38,6 +38,9 @@
 /* Define to 1 if you have the `fork' function. */
 #cmakedefine H4_HAVE_FORK @H4_HAVE_FORK@
 
+/* Define to 1 if you have the <winsock2.h> header file. */
+#cmakedefine H4_HAVE_WINSOCK2_H @H4_HAVE_WINSOCK2_H@
+
 /* Define to 1 if you have the `htonl' function. */
 #cmakedefine H4_HAVE_HTONL @H4_HAVE_HTONL@
 


### PR DESCRIPTION
In [xdrstdio.c](https://github.com/HDFGroup/hdf4/blob/f6903b6ad6643a79d29c1cd53fac9dc4d6820031/mfhdf/xdr/xdrstdio.c) winsock2.h is not included due to missing cmake define, leading to unresolved symbols for htonl() when building xdr. 