### PR TITLE
Fix build error with msvc x86

### DIFF
--- a/mfhdf/xdr/xdrstdio.c
+++ b/mfhdf/xdr/xdrstdio.c
@@ -44,6 +44,10 @@ static char sccsid[] = "@(#)xdr_stdio.c 1.16 87/08/11 Copyr 1984 Sun Micro";
 
 #include <stdio.h>
 
+#ifdef _MSC_VER
+#include <Winsock2.h>
+#endif
+
 #ifdef H4_HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
Fixes the following warnings and link error when building hdf-4_2_15 with Visual Studio 2022 v17.4 for x86 (32-bit):

```
xdrstdio.c
D:\Build\_build\hdf-4_2_15\mfhdf\xdr\xdrstdio.c(125): warning C4013: 'ntohl' undefined; assuming extern returning int
D:\Build\_build\hdf-4_2_15\mfhdf\xdr\xdrstdio.c(141): warning C4013: 'htonl' undefined; assuming extern returning int

...

[ 37%] Linking C executable ..\..\bin\xdrtest.exe
LINK: command "C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1434~1.319\bin\Hostx86\x86\link.exe /nologo @CMakeFiles\xdrtest.dir\objects1.rsp /out:..\..\bin\xdrtest.exe /implib:..\..\bin\xdrtest.lib /pdb:D:\Build\_build\hdf-4_2_15\_build-vc17-win32\bin\xdrtest.pdb /version:0.0 /machine:X86 /INCREMENTAL:NO /subsystem:console ..\..\bin\libxdr.lib Ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:..\..\bin\xdrtest.exe.manifest" failed (exit code 1120) with the following output:
libxdr.lib(xdrstdio.c.obj) : error LNK2019: unresolved external symbol _ntohl referenced in function _xdrstdio_getlong
libxdr.lib(xdrstdio.c.obj) : error LNK2019: unresolved external symbol _htonl referenced in function _xdrstdio_putlong
..\..\bin\xdrtest.exe : fatal error LNK1120: 2 unresolved externals
```