### PR TITLE
hfile.c: Initialize fversion local variable in HIread_version()

### DIFF
--- a/hdf/src/hfile.c
+++ b/hdf/src/hfile.c
@@ -113,6 +113,8 @@
    HIread_version       -- reads a version tag from a file
    + */
 
+#include <string.h>
+
 #define HMASTER
 #include "hdf.h"
 #undef HMASTER
@@ -3421,9 +3423,10 @@ PRIVATE int
 HIread_version(int32 file_id)
 {
   filerec_t  *file_rec;
-  uint8       fversion[LIBVER_LEN];
   CONSTR(FUNC, "Hread_version");
   int         ret_value = SUCCEED;
+  uint8       fversion[LIBVER_LEN];
+  memset(fversion, 0, sizeof(fversion));
 
   HEclear();
 


### PR DESCRIPTION
A fuzzer was able to produce input that caused fversion to be used uninitialized.  The fuzzer:

https://gist.github.com/schwehr/0af040cb15ab4117f9737697722f9d42