### PR TITLE
Revert back to ubuntu latest by installing libtirpc-dev for XDR functionality no longer in libc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
             generator: "-G Ninja"
           - name: "Ubuntu Autotools GCC"
             artifact: "LinuxA.tar.xz"
-            os: ubuntu-latest
+            os: ubuntu-20.04
             build_type: "Release"
             netcdf: enable
             java: disable
@@ -89,7 +89,7 @@ jobs:
       run: sudo apt-get install -y ninja-build libtirpc-dev
       if: matrix.os == 'ubuntu-latest'
     - name: Install Autotools Dependencies (Linux)
-      run: sudo apt-get install -y automake autoconf libtool libtool-bin libtirpc-dev
+      run: sudo apt-get install -y automake autoconf libtool libtool-bin
       if: matrix.generator == 'autogen'
     - name: Install Dependencies (Windows)
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 #            generator: "-G \"Visual Studio 16 2019\" -A x64"
           - name: "Ubuntu Latest GCC"
             artifact: "Linux.tar.xz"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_type: "Release"
             netcdf: ON
             java: ON
@@ -61,7 +61,7 @@ jobs:
 #            generator: "-G Ninja"
           - name: "Ubuntu Debug GCC"
             artifact: "LinuxDBG.tar.xz"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_type: "Debug"
             netcdf: ON
             java: ON
@@ -71,7 +71,7 @@ jobs:
             generator: "-G Ninja"
           - name: "Ubuntu Autotools GCC"
             artifact: "LinuxA.tar.xz"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_type: "Release"
             netcdf: enable
             java: disable
@@ -89,7 +89,7 @@ jobs:
     steps:
     - name: Install Dependencies (Linux)
       run: sudo apt-get install ninja-build
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
     - name: Install Autotools Dependencies (Linux)
       run: sudo apt-get install automake autoconf libtool libtool-bin
       if: matrix.generator == 'autogen'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,10 +88,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Install Dependencies (Linux)
-      run: sudo apt-get install ninja-build
+      run: sudo apt-get install -y ninja-build libtirpc-dev
       if: matrix.os == 'ubuntu-latest'
     - name: Install Autotools Dependencies (Linux)
-      run: sudo apt-get install automake autoconf libtool libtool-bin
+      run: sudo apt-get install -y automake autoconf libtool libtool-bin libtirpc-dev
       if: matrix.generator == 'autogen'
     - name: Install Dependencies (Windows)
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,7 @@ name: hdf4 dev CI
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
     paths-ignore:
-    - '.github/**'
     - 'release_notes/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -37,7 +37,7 @@ jobs:
 #            generator: "-G \"Visual Studio 16 2019\" -A x64"
           - name: "Ubuntu Latest GCC"
             artifact: "Linux.tar.xz"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_type: "Release"
             netcdf: ON
             java: ON
@@ -57,7 +57,7 @@ jobs:
 #            generator: "-G Ninja"
           - name: "Ubuntu Debug GCC"
             artifact: "LinuxDBG.tar.xz"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_type: "Debug"
             netcdf: ON
             java: ON
@@ -67,7 +67,7 @@ jobs:
             generator: "-G Ninja"
           - name: "Ubuntu Autotools GCC"
             artifact: "LinuxA.tar.xz"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_type: "Release"
             netcdf: enable
             java: disable
@@ -85,7 +85,7 @@ jobs:
     steps:
     - name: Install Dependencies (Linux)
       run: sudo apt-get install ninja-build
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
     - name: Install Autotools Dependencies (Linux)
       run: sudo apt-get install automake autoconf libtool libtool-bin
       if: matrix.generator == 'autogen'


### PR DESCRIPTION
Did not figure out what needed to be changed for the autoconf build to work

Also allow other branches to test so that other folks can test in their forks if they enable github actions.