### PR TITLE
Porting to m1 - part 1 (initial attempt to pass tests on m1)

### DIFF
--- a/hdf/src/hconv.h
+++ b/hdf/src/hconv.h
@@ -59,7 +59,7 @@
 /* CONSTANT DEFINITIONS                                                      */
 /*****************************************************************************/
 /* Generally Big-Endian machines */
-#if !defined(INTEL86) && !defined(MIPSEL) && !defined(DEC_ALPHA) && !defined(I860) && !defined(SUN386) && !(defined(__ia64) && !(defined(hpux) || defined(__hpux))) && !defined(__x86_64__)
+#if !defined(__APPLE__) && !defined(INTEL86) && !defined(MIPSEL) && !defined(I860) && !defined(SUN386) && !(defined(__ia64) && !(defined(hpux) || defined(__hpux))) && !defined(__x86_64__)
 #       define UI8_IN     DFKnb1b   /* Unsigned Integer, 8 bits */
 #       define UI8_OUT    DFKnb1b
 #       define SI16_IN    DFKnb2b   /* S = Signed */
@@ -90,7 +90,7 @@
 #       define LF64_IN    DFKsb8b
 #       define LF64_OUT   DFKsb8b
 
-#else  /* must be INTEL86 || MIPSEL || DEC_ALPHA || I860 || SUN386 || IA64 || Linux64 (Generally, little-endian machines */
+#else  /* must be __APPLE__ || INTEL86 || MIPSEL || I860 || SUN386 || IA64 || Linux64 (Generally, little-endian machines */
 #   define UI8_IN     DFKnb1b   /* Big-Endian IEEE support */
 #   define UI8_OUT    DFKnb1b   /* The s in DFKsb2b is for swap */
 #   define SI16_IN    DFKsb2b
@@ -121,7 +121,7 @@
 #   define LF64_IN    DFKnb8b
 #   define LF64_OUT   DFKnb8b
 
-#endif /* !INTEL86 && !MIPS && !DEC_ALPHA && !I860 && !SUN386 && !IA64 && !Linux64*/
+#endif /* !INTEL86 && !MIPS && !I860 && !SUN386 && !IA64 && !Linux64*/
 
 /* All Machines currently use the same routines */
 /* for Native mode "conversions" */

--- a/hdf/src/hdatainfo.h
+++ b/hdf/src/hdatainfo.h
@@ -11,7 +11,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* $Id: hproto.h 5400 2010-04-22 03:45:32Z bmribler $ */
+/* $Id: hdatainfo.h 5400 2010-04-22 03:45:32Z bmribler $ */
 
 #ifndef _HDATAINFO_H
 #define _HDATAINFO_H

--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -88,6 +88,10 @@
 #include <limits.h>
 #include <string.h>
 
+/* Temporarily eliminate implicit declaration of funcion 'yyerror' */
+int yylex(void);
+void yyerror(char* s);
+
 #include "H4api_adpt.h"
 
 

--- a/mfhdf/dumper/hdp_vd.c
+++ b/mfhdf/dumper/hdp_vd.c
@@ -474,7 +474,7 @@ void printHeader(
       fprintf(fp, "   name = %s;", curr_vd->name);
 
    /* print class name - Note that vdclass can be NULL */
-   if( curr_vd->clss[0] == '\0' || curr_vd->clss == NULL )
+   if( curr_vd->clss[0] == '\0' )
       fprintf(fp, " class = <Undefined>;\n");
    else
       fprintf(fp, " class = %s;\n", curr_vd->clss);

--- a/mfhdf/hdiff/hdiff.h
+++ b/mfhdf/hdiff/hdiff.h
@@ -4,13 +4,10 @@
  *   /hdf/src/master/mfhdf/ncdump/ncdump.h,v 1.1 1993/04/21 21:51:19 chouck Exp
  *********************************************************************/
 
-
-
-
 #ifndef HDIFF_H__
 #define HDIFF_H__
 
-
+#include <unistd.h>
 #include "hdf.h"
 #include "mfhdf.h"
 #include "hdiff_table.h"
@@ -193,6 +190,13 @@ uint32 diff_sds(int32 sd1_id,
                 int32 ref2,
                 diff_opt_t *opt);
 
+/* added to temporarily remove implicit declaration of func until can fix better */
+ /* extern int      getopt          PROTO((
+                                       int  argc,
+                                       char **argv,
+                                       char *opts
+                                       ));
+ */ 
 
 
 #endif

--- a/mfhdf/libsrc/array.c
+++ b/mfhdf/libsrc/array.c
@@ -172,7 +172,9 @@ nclong xdr_f_infinity = 0x7f800000;
 #ifdef H4_WORDS_BIGENDIAN
 nclong xdr_d_infinity[2] = {0x7ff00000,0x00000000};
 #else
-nclong xdr_d_infinity[2] = {0x00000000,0x7ff00000};
+nclong xdr_d_infinity[2] = {0x00000000,0x0000f07f};
+ /* nclong xdr_d_infinity[2] = {0x00000000,0x7ff00000};
+ */ 
 #endif /* H4_WORDS_BIGENDIAN */
 #endif /* USE_D_LONG_PUN */
 
@@ -629,7 +631,11 @@ xdr_NC_array(xdrs, app)
         xdr_NC_fnct = xdr_shorts ;
         goto func ;
     case NC_LONG :
+#if (_MIPS_SZLONG == 64) || defined __APPLE__ || (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__ 
         xdr_NC_fnct = xdr_int ;
+#else
+        xdr_NC_fnct = xdr_long ;
+#endif
         goto loop ;
     case NC_FLOAT :
         xdr_NC_fnct = xdr_float ;

--- a/mfhdf/libsrc/cdf.c
+++ b/mfhdf/libsrc/cdf.c
@@ -3384,7 +3384,11 @@ NC_var *vp ;
         break ;
     case NC_LONG :
         alen /= 4 ;
+#if (_MIPS_SZLONG == 64) || defined __APPLE__ || (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__ 
         xdr_NC_fnct = xdr_int ;
+#else
+        xdr_NC_fnct = xdr_long ;
+#endif
         break ;
     case NC_FLOAT :
         alen /= 4 ;

--- a/mfhdf/libsrc/file.c
+++ b/mfhdf/libsrc/file.c
@@ -22,6 +22,7 @@
 
 #ifdef H4_HAVE_UNISTD_H
 #include <unistd.h> /* access(), F_OK */
+int access(const char *main_arg, int n);
 #endif
 
 #include    <string.h>

--- a/mfhdf/libsrc/local_nc.h
+++ b/mfhdf/libsrc/local_nc.h
@@ -122,6 +122,7 @@ typedef    unsigned long    u_long;
 #endif /* MAX_VXR_ENTRIES */
 
 #ifdef HDF
+
 /* VIX record for CDF variable data storage */
 typedef struct vix_t_def {
     int32              nEntries;                    /* number of entries in this vix */
@@ -825,15 +826,6 @@ HDFLIBAPI bool_t nssdc_write_cdf
 
 HDFLIBAPI bool_t nssdc_xdr_cdf
     PROTO((XDR *xdrs, NC **handlep));
-
-HDFLIBAPI intn HDiscdf
-    (const char *filename);
-
-HDFLIBAPI intn HDisnetcdf
-    (const char *filename);
-
-HDFLIBAPI intn HDisnetcdf64
-    (const char *filename);
 
 #endif /* HDF */
 

--- a/mfhdf/libsrc/mfhdf.h
+++ b/mfhdf/libsrc/mfhdf.h
@@ -64,6 +64,15 @@ typedef enum
 extern "C" {
 #endif
 
+HDFLIBAPI intn HDiscdf
+    (const char *filename);
+
+HDFLIBAPI intn HDisnetcdf
+    (const char *filename);
+
+HDFLIBAPI intn HDisnetcdf64
+    (const char *filename);
+
 HDFLIBAPI int32 SDstart
     (const char *name, int32 accs);
 

--- a/mfhdf/libsrc/netcdf.h.in
+++ b/mfhdf/libsrc/netcdf.h.in
@@ -293,7 +293,7 @@ typedef double        ncdouble;
 /*
  * Variables/attributes of type NC_LONG should use the C type 'nclong'
  */
-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__
+#if (_MIPS_SZLONG == 64) || __APPLE__ || defined __ia64 || (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__
 /*
  * LP64 (also known as 4/8/8) denotes long and pointer as 64 bit types.
  * http://www.unix.org/version2/whatsnew/lp64_wp.html
@@ -548,6 +548,9 @@ HDFLIBAPI int ncattdel    PROTO((
     int        cdfid,
     int        varid,
     const char*    name
+));
+HDFLIBAPI const char *nctype   PROTO((
+    nc_type datatype
 ));
 HDFLIBAPI int nctypelen    PROTO((
     nc_type    datatype

--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -665,7 +665,7 @@ Void *values ;
     case NC_SHORT :
         return( xdr_NCvshort(xdrs, (unsigned)rem/2, (short *)values) ) ;
     case NC_LONG :
-#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ 
+#if (_MIPS_SZLONG == 64) || defined __APPLE__ || (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__ 
         return( xdr_int(xdrs, (nclong *)values) ) ;
 #else
         return( xdr_long(xdrs, (nclong *)values) ) ;
@@ -1976,7 +1976,11 @@ Void *values ;
         } /* else */
         return(TRUE) ;
     case NC_LONG :
+#if (_MIPS_SZLONG == 64) || defined __APPLE__ || (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__ 
         xdr_NC_fnct = xdr_int ;
+#else
+        xdr_NC_fnct = xdr_long ;
+#endif
         szof = sizeof(nclong) ;
         break ;
     case NC_FLOAT :

--- a/mfhdf/ncdump/ncdump.h
+++ b/mfhdf/ncdump/ncdump.h
@@ -80,12 +80,9 @@ struct fspec {			/* specification for how to format dump */
 				 */
 };
 
-#ifdef OLD_WAY
 extern int getopt               PROTO((
                                        int argc,
                                        char **argv,
                                        char *opts
                                 ));
-
-#endif /* HP9000 */
 

--- a/mfhdf/ncgen/close.c
+++ b/mfhdf/ncgen/close.c
@@ -6,9 +6,7 @@
 
 #include <stdio.h>
 #include "ncgen.h"
-#ifdef EIP
 #include "genlib.h"
-#endif
 
 extern void fline(), cline();
 extern int netcdf_flag;

--- a/mfhdf/ncgen/genlib.h
+++ b/mfhdf/ncgen/genlib.h
@@ -55,13 +55,12 @@ extern int      yyparse         PROTO((
 extern void     put_variable    PROTO((
                                        void *
                                        ));
-#ifdef OLD_WAY
+
 extern int      getopt          PROTO((
                                        int  argc,
                                        char **argv,
                                        char *opts
-                                       ))
-#endif
+                                       ));
 
 /* generate.c */
 void cline(const char *stmnt);

--- a/mfhdf/ncgen/ncgen.h
+++ b/mfhdf/ncgen/ncgen.h
@@ -15,7 +15,8 @@
 
 /* Why is STREQ re-defined in multiple places? (hdf.h, then here, msoftyy.c,
    and vms_yy.c) -> compiler warnings. -BMR, Jul 17, 2012 */
-#define STREQ(a, b)     (*(a) == *(b) && strcmp((a), (b)) == 0)
+ /* #define STREQ(a, b)     (*(a) == *(b) && strcmp((a), (b)) == 0)
+ */ 
 
 extern struct dims {			/* dimensions */
     long size;

--- a/mfhdf/ncgen/ncgen.y
+++ b/mfhdf/ncgen/ncgen.y
@@ -682,7 +682,7 @@ const:         CHAR_CONST
 
 void derror();
 
-yyerror(s)	/* called for yacc syntax error */
+void yyerror(s)	/* called for yacc syntax error */
      char *s;
 {
 	derror(s);

--- a/mfhdf/ncgen/ncgentab.c
+++ b/mfhdf/ncgen/ncgentab.c
@@ -112,10 +112,10 @@
 
 
 /* Copy the first part of user declarations.  */
-#line 9 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 9 "ncgen.y"
 
 #ifndef lint
-static char SccsId[] = "$Id: ncgen.y 4928 2007-09-06 21:48:49Z epourmal $";
+static char SccsId[] = "$Id$";
 #endif
 #include        <string.h>
 #include	<stdlib.h>
@@ -257,7 +257,7 @@ typedef short int yytype_int16;
 #define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
 
 #ifndef YY_
-# if YYENABLE_NLS
+# if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
 #   define YY_(msgid) dgettext ("bison-runtime", msgid)
@@ -753,7 +753,7 @@ while (YYID (0))
    we won't break user code: when these are the locations we know.  */
 
 #ifndef YY_LOCATION_PRINT
-# if YYLTYPE_IS_TRIVIAL
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
 #  define YY_LOCATION_PRINT(File, Loc)			\
      fprintf (File, "%d.%d-%d.%d",			\
 	      (Loc).first_line, (Loc).first_column,	\
@@ -1494,12 +1494,12 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 103 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 103 "ncgen.y"
     { init_netcdf(); }
     break;
 
   case 3:
-#line 105 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 105 "ncgen.y"
     {
                        if (ndims > H4_MAX_NC_DIMS)
                          derror("Too many dimensions");
@@ -1507,7 +1507,7 @@ yyreduce:
     break;
 
   case 4:
-#line 110 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 110 "ncgen.y"
     {
 		       if (derror_count == 0)
 			 define_netcdf(netcdfname);
@@ -1515,7 +1515,7 @@ yyreduce:
     break;
 
   case 5:
-#line 116 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 116 "ncgen.y"
     {
 		       if (derror_count == 0)
 			 close_netcdf();
@@ -1523,7 +1523,7 @@ yyreduce:
     break;
 
   case 12:
-#line 131 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 131 "ncgen.y"
     { if (long_val <= 0)
 			 derror("negative dimension size");
 		     dims[ndims].size = long_val;
@@ -1532,7 +1532,7 @@ yyreduce:
     break;
 
   case 13:
-#line 137 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 137 "ncgen.y"
     {  if (rec_dim != -1)
 			 derror("only one NC_UNLIMITED dimension allowed");
 		     rec_dim = ndims; /* the unlimited (record) dimension */
@@ -1542,7 +1542,7 @@ yyreduce:
     break;
 
   case 14:
-#line 145 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 145 "ncgen.y"
     { if ((yyvsp[(1) - (1)])->is_dim == 1) {
 		        derror( "duplicate dimension declaration for %s",
 		                (yyvsp[(1) - (1)])->name);
@@ -1555,37 +1555,37 @@ yyreduce:
     break;
 
   case 23:
-#line 167 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 167 "ncgen.y"
     { type_code = NC_BYTE; }
     break;
 
   case 24:
-#line 168 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 168 "ncgen.y"
     { type_code = NC_CHAR; }
     break;
 
   case 25:
-#line 169 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 169 "ncgen.y"
     { type_code = NC_SHORT; }
     break;
 
   case 26:
-#line 170 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 170 "ncgen.y"
     { type_code = NC_LONG; }
     break;
 
   case 27:
-#line 171 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 171 "ncgen.y"
     { type_code = NC_FLOAT; }
     break;
 
   case 28:
-#line 172 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 172 "ncgen.y"
     { type_code = NC_DOUBLE; }
     break;
 
   case 31:
-#line 178 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 178 "ncgen.y"
     {
 		    if (nvars >= H4_MAX_NC_VARS)
 		       derror("too many variables");
@@ -1608,7 +1608,7 @@ yyreduce:
     break;
 
   case 32:
-#line 198 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 198 "ncgen.y"
     {
 		    vars[nvars].ndims = nvdims;
 		    nvars++;
@@ -1616,7 +1616,7 @@ yyreduce:
     break;
 
   case 38:
-#line 212 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 212 "ncgen.y"
     {
 		    if (nvdims >= H4_MAX_VAR_DIMS) {
 		       derror("%s has too many dimensions",vars[nvars].name);
@@ -1637,7 +1637,7 @@ yyreduce:
     break;
 
   case 39:
-#line 231 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 231 "ncgen.y"
     {
 		       valnum = 0;
 		       valtype = NC_UNSPECIFIED;
@@ -1654,7 +1654,7 @@ yyreduce:
     break;
 
   case 40:
-#line 245 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 245 "ncgen.y"
     {
 		       if (natts >= H4_MAX_NC_ATTRS)
 			 derror("too many attributes");
@@ -1674,14 +1674,14 @@ yyreduce:
     break;
 
   case 42:
-#line 264 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 264 "ncgen.y"
     {
 		    varnum = -1;  /* handle of "global" attribute */
 		   }
     break;
 
   case 43:
-#line 270 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 270 "ncgen.y"
     { if ((yyvsp[(1) - (1)])->is_var == 1)
 		       varnum = (yyvsp[(1) - (1)])->vnum;
 		    else {
@@ -1693,7 +1693,7 @@ yyreduce:
     break;
 
   case 44:
-#line 280 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 280 "ncgen.y"
     {
 		       atts[natts].name = (char *) emalloc(strlen((yyvsp[(1) - (1)])->name)+1);
 		       (void) strcpy(atts[natts].name,(yyvsp[(1) - (1)])->name);
@@ -1701,7 +1701,7 @@ yyreduce:
     break;
 
   case 47:
-#line 289 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 289 "ncgen.y"
     {
 		    if (valtype == NC_UNSPECIFIED)
 		      valtype = atype_code;
@@ -1711,7 +1711,7 @@ yyreduce:
     break;
 
   case 48:
-#line 298 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 298 "ncgen.y"
     {
 		       atype_code = NC_CHAR;
 		       *char_valp++ = char_val;
@@ -1720,7 +1720,7 @@ yyreduce:
     break;
 
   case 49:
-#line 304 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 304 "ncgen.y"
     {
 		       atype_code = NC_CHAR;
 		       {
@@ -1734,7 +1734,7 @@ yyreduce:
     break;
 
   case 50:
-#line 315 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 315 "ncgen.y"
     {
 		       atype_code = NC_BYTE;
 		       *byte_valp++ = byte_val;
@@ -1743,7 +1743,7 @@ yyreduce:
     break;
 
   case 51:
-#line 321 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 321 "ncgen.y"
     {
 		       atype_code = NC_SHORT;
 		       *short_valp++ = short_val;
@@ -1752,7 +1752,7 @@ yyreduce:
     break;
 
   case 52:
-#line 327 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 327 "ncgen.y"
     {
 		       atype_code = NC_LONG;
 		       *long_valp++ = long_val;
@@ -1761,7 +1761,7 @@ yyreduce:
     break;
 
   case 53:
-#line 333 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 333 "ncgen.y"
     {
 		       atype_code = NC_FLOAT;
 		       *float_valp++ = float_val;
@@ -1770,7 +1770,7 @@ yyreduce:
     break;
 
   case 54:
-#line 339 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 339 "ncgen.y"
     {
 		       atype_code = NC_DOUBLE;
 		       *double_valp++ = double_val;
@@ -1779,7 +1779,7 @@ yyreduce:
     break;
 
   case 59:
-#line 354 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 354 "ncgen.y"
     {
 		       valtype = vars[varnum].type; /* variable type */
 		       valnum = 0;	/* values accumulated for variable */
@@ -1831,7 +1831,7 @@ yyreduce:
     break;
 
   case 60:
-#line 403 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 403 "ncgen.y"
     {
 		       if (valnum > 0 && valnum < var_len) { /* leftovers */
 			   nc_fill(valtype,
@@ -1847,7 +1847,7 @@ yyreduce:
     break;
 
   case 63:
-#line 420 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 420 "ncgen.y"
     {
 		       if(valnum >= var_len) {
 			   derror("too many values for this variable");
@@ -1858,7 +1858,7 @@ yyreduce:
     break;
 
   case 64:
-#line 428 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 428 "ncgen.y"
     {
 		       if (not_a_string) {
 			   switch (valtype) {
@@ -1918,7 +1918,7 @@ yyreduce:
     break;
 
   case 65:
-#line 487 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 487 "ncgen.y"
     {
 		       atype_code = NC_CHAR;
 		       switch (valtype) {
@@ -1946,7 +1946,7 @@ yyreduce:
     break;
 
   case 66:
-#line 512 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 512 "ncgen.y"
     {
 		       not_a_string = 0;
 		       atype_code = NC_CHAR;
@@ -1982,7 +1982,7 @@ yyreduce:
     break;
 
   case 67:
-#line 545 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 545 "ncgen.y"
     {
 		       atype_code = NC_BYTE;
 		       switch (valtype) {
@@ -2010,7 +2010,7 @@ yyreduce:
     break;
 
   case 68:
-#line 570 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 570 "ncgen.y"
     {
 		       atype_code = NC_SHORT;
 		       switch (valtype) {
@@ -2038,7 +2038,7 @@ yyreduce:
     break;
 
   case 69:
-#line 595 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 595 "ncgen.y"
     {
 		       atype_code = NC_LONG;
 		       switch (valtype) {
@@ -2066,7 +2066,7 @@ yyreduce:
     break;
 
   case 70:
-#line 620 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 620 "ncgen.y"
     {
 		       atype_code = NC_FLOAT;
 		       switch (valtype) {
@@ -2094,7 +2094,7 @@ yyreduce:
     break;
 
   case 71:
-#line 645 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 645 "ncgen.y"
     {
 		       atype_code = NC_DOUBLE;
 		       switch (valtype) {
@@ -2340,7 +2340,7 @@ yyreturn:
 }
 
 
-#line 676 "../../../hdf4/mfhdf/ncgen/ncgen.y"
+#line 676 "ncgen.y"
 
 
 /* PROGRAMS */
@@ -2350,7 +2350,7 @@ yyreturn:
 
 void derror();
 
-yyerror(s)	/* called for yacc syntax error */
+void yyerror(s)	/* called for yacc syntax error */
      char *s;
 {
 	derror(s);

--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -52,14 +52,14 @@ extern int test_netcdf_reading();
 extern int test_szip_compression();
 extern int test_checkempty();
 extern int test_idtest();
-/* extern int test_sd(); - removed temporarily, see note in main(...) */
+extern int test_sd();
 extern int test_mixed_apis();
 extern int test_files();
 extern int test_SDSprops();
 extern int test_coordvar();
 extern int test_chunk();
 extern int test_compression();
-extern int test_dimension();
+extern int test_dimensions();
 extern int test_attributes();
 extern int test_datasizes();
 extern int test_datainfo();

--- a/mfhdf/test/hdftest.h
+++ b/mfhdf/test/hdftest.h
@@ -52,6 +52,9 @@
 
 /*************************** Utility Functions ***************************/
 
+/* Generates the correct name for the test file */
+intn make_datafilename(char* basename, char* testfile, unsigned int size);
+
 /* Calls SDcreate, SDwritedata, and SDendaccess */
 int32 make_SDS(int32 sd_id, char* sds_name, int32 type, int32 rank,
 			  int32* dim_sizes, int32 unlim_dim, VOIDP written_data);
@@ -73,6 +76,9 @@ int32 append_Data2SDS(int32 sd_id, char* sds_name, int32* start, int32* edges, v
 
 /* Calls SDgetdatasize then verify the size against data_size */
 void verify_datasize(int32 sds_id, int32 data_size, char* sds_name);
+
+/* Verifies the unlimited dimension's size and the variable's data. */
+int verify_info_data(int32 sds_id, int32 expected_dimsize, int16 *result);
 
 /* Find and open an SDS by name */
 int32 get_SDSbyName(int32 sd_id, char* sds_name);

--- a/mfhdf/test/tdatainfo.c
+++ b/mfhdf/test/tdatainfo.c
@@ -44,10 +44,6 @@
 #define ssize_t int32
 #endif
 
-#ifndef DATAINFO_TESTER
-#define DATAINFO_TESTER /* to include mfdatainfo.h */
-#endif
-
 #ifdef H4_HAVE_LIBSZ
 #include "szlib.h"
 #endif

--- a/mfhdf/test/tdim.c
+++ b/mfhdf/test/tdim.c
@@ -248,7 +248,7 @@ static intn test_basic_dim()
 
     /* Close the file */
     status = SDend(fid);
-    CHECK(status, FAIL, "test_dimensions: SDend");
+    CHECK(status, FAIL, "test_dim_basics: SDend");
 
     /* Return the number of errors that's been kept track of so far */
     return num_errs;
@@ -493,7 +493,7 @@ static intn test_dim_scales()
 
     /* Close the file */
     status = SDend(fid);
-    CHECK(status, FAIL, "test_dimensions: SDend");
+    CHECK(status, FAIL, "test_dim_scales: SDend");
 
     /* Return the number of errors that's been kept track of so far */
     return num_errs;
@@ -760,7 +760,7 @@ static intn test_dim_strs()
 
     /* Close the file */
     status = SDend(fid);
-    CHECK(status, FAIL, "test_dimensions: SDend");
+    CHECK(status, FAIL, "test_dim_strs: SDend");
 
     /* Return the number of errors that's been kept track of so far */
     return num_errs;

--- a/mfhdf/test/tnetcdf.c
+++ b/mfhdf/test/tnetcdf.c
@@ -110,7 +110,7 @@ static intn test_read_dim()
 
     /* Close the file */
     status = SDend(fid);
-    CHECK(status, FAIL, "test_dimensions: SDend");
+    CHECK(status, FAIL, "test_read_dim: SDend");
 
     } /* SDstart failed */
 

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -15,6 +15,8 @@
  * tsd.c - tests SDstart for file with no write permission
 ****************************************************************************/
 
+ /* #include <unistd.h>
+ */ 
 #include "mfhdf.h"
 
 #ifdef HDF


### PR DESCRIPTION
Description:
    - Removed some outdated machines from #ifdef lines as a temporary approach
      until autoconf approach works.
    - Added __APPLE__ to some of those lines, also as temporary approach
    - Replaced "free()" calls by "HDfreenclear()" to reset pointers after freeing
    - Removed implicit declaration of function errors, some need attention
    - Corrected string comparison in several if statements
    - Fixed many typos
Platforms Tested:
    Darwin (m1)
    Linux/64 (jelly)
    Note that at this time, hdf and mfhdf tests passed.  ncgen test still failed
        dues to one data value being corrupted.  It is hopeful that the autoconf
        approach will address that issue.