### PR TITLE
protoize most functions

### DIFF
--- a/mfhdf/libsrc/array.c
+++ b/mfhdf/libsrc/array.c
@@ -24,11 +24,8 @@
  * internal replacement for memset
  */
 char *
-NCmemset (s, c, n)
-     char *s;
-     int c, n;
+NCmemset (char *s, int c, int n)
 {
-
   char *cp ;
 
   for (cp = s ; cp < &s[n] ; *cp++ = c )
@@ -44,8 +41,7 @@ NCmemset (s, c, n)
  *  return the size of the on-disk representation
  */
 int
-NC_xtypelen(type)
-nc_type    type ;
+NC_xtypelen(nc_type type)
 {
     char *nada = NULL ;
 
@@ -82,8 +78,7 @@ nc_type    type ;
  *  private version of nctypelen
  */
 size_t
-NC_typelen(type)
-nc_type    type ;
+NC_typelen(nc_type type)
 {
     switch(type){
     case NC_BYTE :
@@ -120,8 +115,7 @@ nc_type    type ;
  *
  */
 int
-nctypelen(type)
-nc_type    type ;
+nctypelen(nc_type type)
 {
     switch(type){
     case NC_BYTE :
@@ -179,10 +173,9 @@ nclong xdr_d_infinity[2] = {0x00000000,0x7ff00000};
  *    Fill an array region with an appropriate special value
  */
 void
-NC_arrayfill(low, len, type)
-void *low ;    /* lower bound of area to be filled */
-size_t len ;    /* how many bytes */
-nc_type type ;
+NC_arrayfill(void *low, size_t len, nc_type type)
+/* low - lower bound of area to be filled */
+/* len how many bytes */
 {
     char *hi, *lo;    /* local low and hi ptr */
 
@@ -234,10 +227,7 @@ nc_type type ;
  * Else, just hook up the values passed in.
  */
 NC_array *
-NC_new_array(type, count, values)
-nc_type type ;
-unsigned count ;
-const void *values ;
+NC_new_array(nc_type type, unsigned count, const void *values)
 {
     NC_array *ret ;
     size_t memlen ;
@@ -292,11 +282,7 @@ alloc_err :
  * If values is non-NULL, copy them in.
  */
 NC_array *
-NC_re_array(old, type, count, values)
-NC_array *old ;
-nc_type type ;
-unsigned count ;
-const void *values ;
+NC_re_array(NC_array *old, nc_type type, unsigned count, const void *values)
 {
     size_t memlen ;
     size_t szof ;
@@ -330,8 +316,7 @@ const void *values ;
  *       If successful returns SUCCEED else FAIL -GV 9/19/97
  */
 int
-NC_free_array(array)
-NC_array *array ;
+NC_free_array(NC_array *array)
 {
     int ret_value = SUCCEED;
 
@@ -441,8 +426,7 @@ done:
 /*
  * How much space will the xdr'd array take.
  */
-int NC_xlen_array(array)
-NC_array *array ;
+int NC_xlen_array(NC_array *array)
 {
     int len = 8 ;
     int rem ;
@@ -501,9 +485,7 @@ NC_array *array ;
  * Add a new handle on the end of and array of handles
  */
 Void *
-NC_incr_array(array, tail)
-NC_array *array ;
-Void *tail ;
+NC_incr_array(NC_array *array, Void *tail)
 {
     char *ap ;
 
@@ -531,9 +513,7 @@ Void *tail ;
  * Definitely NOT Bomb proof.
  */
 void
-NC_copy_arrayvals( target, array )
-char *target ;
-NC_array *array ;
+NC_copy_arrayvals(char *target, NC_array *array)
 {
     size_t memlen ;
 
@@ -543,9 +523,7 @@ NC_array *array ;
 
 
 bool_t
-xdr_NC_array(xdrs, app)
-    XDR *xdrs;
-    NC_array **app;
+xdr_NC_array(XDR *xdrs, NC_array **app)
 {
     bool_t (*xdr_NC_fnct)() ;
     u_long count = 0, *countp=NULL ;

--- a/mfhdf/libsrc/attr.c
+++ b/mfhdf/libsrc/attr.c
@@ -21,11 +21,7 @@
 
 
 NC_attr *
-NC_new_attr(name,type,count,values)
-const char *name ;
-nc_type type ;
-unsigned count ;
-const void *values ;
+NC_new_attr(const char *name, nc_type type, unsigned count, const void *values)
 {
 	NC_attr *ret ;
 
@@ -57,8 +53,7 @@ alloc_err :
  *       If successful returns SUCCEED else FAIL -GV 9/19/97
  */
 int
-NC_free_attr(attr)
-NC_attr *attr ;
+NC_free_attr(NC_attr *attr)
 {
     int ret_value = SUCCEED;
 
@@ -94,8 +89,7 @@ done:
  *  Verify that this is a user nc_type
  */
 bool_t
-NCcktype(datatype)
-nc_type datatype ;
+NCcktype(nc_type datatype)
 {
 	switch(datatype){
 	case NC_BYTE :
@@ -118,9 +112,7 @@ nc_type datatype ;
  *  else NULL on error
  */
 static NC_array **
-NC_attrarray( cdfid, varid )
-int cdfid ;
-int varid ;
+NC_attrarray(int cdfid, int varid)
 {
 	NC *handle ;
 	NC_array **ap ;
@@ -150,9 +142,7 @@ int varid ;
  *  return match or NULL if Not Found.
  */
 NC_attr **
-NC_findattr(ap, name)
-NC_array **ap ;
-const char *name ;
+NC_findattr(NC_array **ap, const char *name)
 {
     NC_attr **attr ;
     unsigned attrid ;
@@ -181,11 +171,8 @@ const char *name ;
  * Look up by cdfid, varid and name, return NULL if not found
  */
 static NC_attr **
-NC_lookupattr( cdfid, varid, name, verbose)
-int cdfid ;
-int varid ;
-const char *name ; /* attribute name */
-bool_t verbose ;
+NC_lookupattr(int cdfid, int varid, const char *name, bool_t verbose)
+/* name - attribute name */
 {
 	NC_array **ap ;
 	NC_attr **attr ;
@@ -205,13 +192,8 @@ bool_t verbose ;
  * Common code for attput and attcopy
  */
 static int
-NC_aput(cdfid, ap, name, datatype, count, values)
-int cdfid ;
-NC_array **ap ;
-const char *name ;
-nc_type datatype ;
-unsigned count ;
-const void *values ;
+NC_aput(int cdfid, NC_array **ap, const char *name, nc_type datatype,
+        unsigned count, const void *values)
 {
 	NC *handle ;
 	NC_attr *attr[1] ;
@@ -293,13 +275,8 @@ const void *values ;
 }
 
 
-int ncattput(cdfid, varid, name, datatype, count, values)
-int cdfid ;
-int varid ;
-const char *name ;
-nc_type datatype ;
-int count ;
-const ncvoid *values ;
+int ncattput(int cdfid, int varid, const char *name, nc_type datatype,
+             int count, const ncvoid *values)
 {
 	NC_array **ap ;
 
@@ -323,11 +300,7 @@ const ncvoid *values ;
 }
 
 
-int ncattname( cdfid, varid, attnum, name)
-int cdfid ;
-int varid ;
-int attnum ;
-char *name ;
+int ncattname(int cdfid, int varid, int attnum, char *name)
 {
 	NC_array **ap ;
 	NC_attr **attr ;
@@ -357,12 +330,8 @@ char *name ;
 }
 
 
-int ncattinq( cdfid, varid, name, datatypep, countp)
-int cdfid ;
-int varid ;
-const char *name ; /* input, attribute name */
-nc_type *datatypep ;
-int *countp ;
+int ncattinq(int cdfid, int varid, const char *name, nc_type *datatypep, int *countp)
+/* name - input, attribute name */
 {
 	NC_attr **attr ;
 
@@ -380,13 +349,8 @@ int *countp ;
 }
 
 
-int ncattrename(cdfid, varid, name, newname)
-int cdfid ;
-int varid ;
-const char *name ;
-const char *newname ;
+int ncattrename(int cdfid, int varid, const char *name, const char *newname)
 {
-
 	NC *handle ;
 	NC_attr **attr ;
 	NC_string *new, *old ;
@@ -432,12 +396,7 @@ const char *newname ;
 }
 
 
-int ncattcopy( incdf, invar, name, outcdf, outname)
-int incdf ;
-int invar ;
-const char *name ;
-int outcdf ;
-int outname ;
+int ncattcopy(int incdf, int invar, const char *name, int outcdf, int outname)
 {
 	NC_attr **attr ;
 	NC_array **ap ;
@@ -458,12 +417,8 @@ int outname ;
 }
 
 
-int ncattdel(cdfid, varid, name)
-int cdfid ;
-int varid ;
-const char *name ;
+int ncattdel(int cdfid, int varid, const char *name)
 {
-
 	NC_array **ap ;
 	NC_attr **attr ;
 	NC_attr *old = NULL ;
@@ -511,13 +466,8 @@ const char *name ;
 }
 
 
-int ncattget(cdfid, varid, name, values)
-int cdfid ;
-int varid ;
-const char *name ;
-ncvoid *values ;
+int ncattget(int cdfid, int varid, const char *name, ncvoid *values)
 {
-
 	NC_attr **attr ;
 
 	cdf_routine_name = "ncattget" ;
@@ -533,9 +483,7 @@ ncvoid *values ;
 
 
 bool_t
-xdr_NC_attr(xdrs, app)
-	XDR *xdrs;
-	NC_attr **app;
+xdr_NC_attr(XDR *xdrs, NC_attr **app)
 {
     bool_t ret_value;
 
@@ -568,8 +516,7 @@ xdr_NC_attr(xdrs, app)
 /*
  * How much space will the xdr'd attr take.
  */
-int NC_xlen_attr(app)
-NC_attr **app ;
+int NC_xlen_attr(NC_attr **app)
 {
 	int len ;
 

--- a/mfhdf/libsrc/cdf.c
+++ b/mfhdf/libsrc/cdf.c
@@ -58,8 +58,7 @@ static int NC_free_xcdf(NC *);
  *       -GV 9/16/97
  */
 static int
-NC_free_xcdf(handle)
-NC *handle ;
+NC_free_xcdf(NC *handle)
 {
     int ret_value = SUCCEED;
 
@@ -88,8 +87,7 @@ done:
  *       -GV 9/16/97
  */
 int
-NC_free_cdf(handle)
-NC *handle ;
+NC_free_cdf(NC *handle)
 {
     int ret_value = SUCCEED;
 
@@ -139,8 +137,7 @@ done:
 
   Refactored out from existing functions. -BMR, Jun 7, 2016
 */
-int32 hdf_get_magicnum(filename)
-const char *filename;
+int32 hdf_get_magicnum(const char *filename)
 {
     CONSTR(FUNC, "hdf_get_magicnum");        /* for HERROR */
     hdf_file_t fp;
@@ -193,8 +190,7 @@ done:
 /*
   Return TRUE/FALSE depending on if the given file is a NASA CDF file
 */
-intn HDiscdf(filename)
-const char *filename;
+intn HDiscdf(const char *filename)
 {
     CONSTR(FUNC, "HDiscdf");    /* for HGOTO_ERROR */
     int32 magic_num = 0;
@@ -223,8 +219,7 @@ done:
 
   Return TRUE if the given file is a netCDF file, FALSE otherwise.
 */
-intn HDisnetcdf(filename)
-const char *filename;
+intn HDisnetcdf(const char *filename)
 {
     CONSTR(FUNC, "HDisnetcdf");    /* for HGOTO_ERROR */
     int32 magic_num = 0;
@@ -253,8 +248,7 @@ done:
 
   Return TRUE if the given file is a netCDF 64-bit file, FALSE otherwise.
 */
-intn HDisnetcdf64(filename)
-const char *filename;
+intn HDisnetcdf64(const char *filename)
 {
     CONSTR(FUNC, "HDisnetcdf64");    /* for HGOTO_ERROR */
     int32 magic_num = 0;
@@ -287,9 +281,7 @@ done:
  * NOTE: Cleaned up to catch errors - GV 9/19/97
  */
 NC *
-NC_new_cdf(name, mode)
-const char *name ;
-int mode ;
+NC_new_cdf(const char *name, int mode)
 {
 #ifdef HDF
     int32 hdf_mode =  DFACC_RDWR; /* default */
@@ -490,10 +482,7 @@ done:
  * NOTE:  Cleaned up to catch errors - GV 9/19/97
  */
 NC *
-NC_dup_cdf(name, mode, old)
-const char *name ;
-int mode ;
-NC *old ;
+NC_dup_cdf(const char *name, int mode, NC *old)
 {
     NC *cdf = NULL;
     NC *ret_value = NULL;
@@ -555,12 +544,7 @@ done:
 }
 
 
-int ncinquire(cdfid, ndimsp, nvarsp, nattrsp, xtendimp)
-int cdfid ;
-int *ndimsp ;
-int *nvarsp ;
-int *nattrsp ;
-int *xtendimp ;
+int ncinquire(int cdfid, int *ndimsp, int *nvarsp, int *nattrsp, int *xtendimp)
 {
     NC *handle ;
 
@@ -607,9 +591,7 @@ int *xtendimp ;
  *  NOTE: modified how errors were caught and reported - GV 9/19/97
  */
 bool_t
-xdr_cdf(xdrs, handlep)
-    XDR *xdrs;
-    NC **handlep;
+xdr_cdf(XDR *xdrs, NC **handlep)
 {
     bool_t ret_value = TRUE;
 
@@ -639,11 +621,8 @@ xdr_cdf(xdrs, handlep)
 
 
 static bool_t
-NC_xdr_cdf(xdrs, handlep)
-    XDR *xdrs;
-    NC **handlep;
+NC_xdr_cdf(XDR *xdrs, NC **handlep)
 {
-
     u_long    magic;
 
     if( xdrs->x_op == XDR_FREE)
@@ -743,8 +722,7 @@ NC_xdr_cdf(xdrs, handlep)
 ** Map an NC_<type> to an HDF type
 */
 int
-hdf_map_type(type)
-nc_type type;
+hdf_map_type(nc_type type)
 {
 
     switch(type)
@@ -775,8 +753,7 @@ nc_type type;
 **    bottom bits
 */
 nc_type
-hdf_unmap_type(type)
-int type;
+hdf_unmap_type(int type)
 {
     switch(type & 0xff)
       {
@@ -806,9 +783,7 @@ int type;
 ** Given a dimension id number return its hdf_ref number (Vgroup id)
 */
 int
-hdf_get_ref(handle, i)
-NC *handle;
-int i;
+hdf_get_ref(NC *handle, int i)
 {
   NC_array  *tmp = NULL;
   NC_dim   **d = NULL;
@@ -838,10 +813,7 @@ int i;
 **        seem valid -GV 9/19/97
 */
 int
-hdf_create_dim_vdata(xdrs, handle, dim)
-XDR *xdrs;
-NC *handle;
-NC_dim *dim;
+hdf_create_dim_vdata(XDR *xdrs, NC *handle, NC_dim *dim)
 {
 #ifdef LATER
     CONSTR(FUNC,"hdf_create_dim_vdata");
@@ -985,10 +957,7 @@ done:
 ** Write out a vdata representing an attribute
 */
 int
-hdf_write_attr(xdrs, handle, attr)
-XDR *xdrs;
-NC *handle;
-NC_attr **attr;
+hdf_write_attr(XDR *xdrs, NC *handle, NC_attr **attr)
 {
     char *name = NULL;
     Void *values = NULL;
@@ -1125,10 +1094,7 @@ done:
 **  return NULL
 */
 int32
-hdf_write_var(xdrs, handle, var)
-XDR *xdrs;
-NC *handle;
-NC_var **var;
+hdf_write_var(XDR *xdrs, NC *handle, NC_var **var)
 {
     NC_array  *  attrs = NULL;
     NC_iarray *  assoc = NULL;
@@ -1380,9 +1346,7 @@ done:
 ** Write out a cdf structure
 */
 intn
-hdf_write_xdr_cdf(xdrs, handlep)
-XDR *xdrs;
-NC **handlep;
+hdf_write_xdr_cdf(XDR *xdrs, NC **handlep)
 {
     int32 count;
     int status, done;
@@ -1584,8 +1548,7 @@ done:
 ** data out.
 */
 intn
-hdf_conv_scales(handlep)
-NC **handlep;
+hdf_conv_scales(NC **handlep)
 {
     int status, scaleref, scaletag, scalelen;
     unsigned i;
@@ -2542,9 +2505,7 @@ done:
 ** Read in a cdf structure
 */
 intn
-hdf_read_xdr_cdf(xdrs, handlep)
-XDR *xdrs;
-NC **handlep;
+hdf_read_xdr_cdf(XDR *xdrs, NC **handlep)
 {
 #if DEBUG
   char            vgname[H4_MAX_NC_NAME];
@@ -2559,7 +2520,6 @@ NC **handlep;
 #if DEBUG
  fprintf(stderr, "hdf_read_xdr_cdf i've been called %d\n", (*handlep)->hdf_file);
 #endif
-
 
     if((vgid = Vfindclass((*handlep)->hdf_file,_HDF_CDF))!=FAIL)
     {
@@ -2617,9 +2577,7 @@ done:
 **    them as netCDF information.
 */
 intn
-hdf_xdr_cdf(xdrs, handlep)
-XDR *xdrs;
-NC **handlep;
+hdf_xdr_cdf(XDR *xdrs, NC **handlep)
 {
     CONSTR(FUNC,"hdf_xdr_cdf"); /* for HERROR */
     intn status;
@@ -2689,9 +2647,7 @@ done:
   with class == DATA are saved
 */
 intn
-hdf_vg_clobber(handle, id)
-NC *handle;
-int id;
+hdf_vg_clobber(NC *handle, int id)
 {
     int   t, n;
     int32 vg, tag, ref;
@@ -2824,8 +2780,7 @@ done:
   Delete a netCDF structure that has been already written to disk
 */
 intn
-hdf_cdf_clobber(handle)
-NC *handle;
+hdf_cdf_clobber(NC *handle)
 {
     int32  vg, tag, ref;
     int    n, t, status;
@@ -3001,8 +2956,7 @@ BMR: handle->numrecs is used to write out the dim value for all unlimited
      file.  I believe this is what the "BUG:" comment above means.  6/24/2013
 */
 intn
-hdf_close(handle)
-    NC *handle;
+hdf_close(NC *handle)
 {
     NC_array  *tmp = NULL;
     NC_var   **vp = NULL;
@@ -3206,8 +3160,7 @@ done:
  * How much space will the xdr'd NC description take.
  *
  */
-int NC_xlen_cdf(cdf)
-NC *cdf ;
+int NC_xlen_cdf(NC *cdf)
 {
     int len = 8 ;
 
@@ -3224,9 +3177,7 @@ NC *cdf ;
 
 #define RECPOS    4L     /* seek index of numrecs value */
 bool_t
-xdr_numrecs(xdrs, handle)
-    XDR *xdrs;
-    NC *handle;
+xdr_numrecs(XDR *xdrs, NC *handle)
 {
 
 #ifdef HDF
@@ -3267,25 +3218,21 @@ xdr_numrecs(xdrs, handle)
 }
 
 static bool_t
-xdr_4bytes(xdrs, cp)
-XDR *xdrs ;
-char *cp ; /* at least 4 valid bytes */
+xdr_4bytes(XDR *xdrs, char *cp)
+/* cp - at least 4 valid bytes */
 {
       return xdr_opaque(xdrs, cp, 4) ;
 }
 
 static bool_t
-xdr_2shorts(xdrs, sp)
-XDR *xdrs ;
-short *sp ; /* at least 2 valid shorts */
+xdr_2shorts(XDR *xdrs, short *sp)
+/* sp - at least 2 valid shorts */
 {
       return xdr_shorts(xdrs, sp, 2) ;
 }
 
 bool_t
-xdr_NC_fill(xdrs, vp)
-XDR *xdrs ;
-NC_var *vp ;
+xdr_NC_fill(XDR *xdrs, NC_var *vp)
 {
     char fillp[2*sizeof(double)] ;
     bool_t stat ;

--- a/mfhdf/libsrc/dim.c
+++ b/mfhdf/libsrc/dim.c
@@ -21,9 +21,7 @@
 
 
 NC_dim *
-NC_new_dim(name,size)
-const char *name ;
-long size ;
+NC_new_dim(const char *name, long size)
 {
     NC_dim *ret ;
 
@@ -56,8 +54,7 @@ alloc_err :
  *       If successful returns SUCCEED else FAIL -GV 9/19/97
  */
 int
-NC_free_dim(dim)
-NC_dim *dim ;
+NC_free_dim(NC_dim *dim)
 {
     int ret_value = SUCCEED;
 
@@ -91,10 +88,7 @@ done:
 }
 
 
-int ncdimdef(cdfid, name, size)
-int cdfid ;
-const char *name ;
-long size ;
+int ncdimdef(int cdfid, const char *name, long size)
 {
     NC *handle ;
     NC_dim *dim[1] ;
@@ -161,9 +155,7 @@ long size ;
     return(handle->dims->count -1) ;
 }
 
-int NC_dimid( handle, name)
-NC *handle;
-char *name;
+int NC_dimid(NC *handle, char *name)
 {
   unsigned ii;
   size_t len;
@@ -181,9 +173,7 @@ char *name;
   return(-1) ;
 }
 
-int ncdimid( cdfid, name)
-int cdfid ;
-const char *name ;
+int ncdimid(int cdfid, const char *name)
 {
     NC *handle ;
     NC_dim **dp ;
@@ -210,11 +200,7 @@ const char *name ;
 }
 
 
-int ncdiminq( cdfid, dimid, name, sizep)
-int cdfid ;
-int dimid ;
-char *name ;
-long *sizep ;
+int ncdiminq(int cdfid, int dimid, char *name, long *sizep)
 {
     NC *handle ;
     NC_dim **dp ;
@@ -254,12 +240,8 @@ long *sizep ;
 }
 
 
-int ncdimrename(cdfid, dimid, newname)
-int cdfid ;
-int dimid ;
-const char *newname ;
+int ncdimrename(int cdfid, int dimid, const char *newname)
 {
-
     NC *handle ;
     NC_dim **dp ;
     NC_string *old, *new ;
@@ -321,9 +303,7 @@ const char *newname ;
 
 
 bool_t
-xdr_NC_dim(xdrs, dpp)
-    XDR *xdrs;
-    NC_dim **dpp;
+xdr_NC_dim(XDR *xdrs, NC_dim **dpp)
 {
     if( xdrs->x_op == XDR_FREE)
     {
@@ -356,8 +336,7 @@ xdr_NC_dim(xdrs, dpp)
 /*
  * How much space will the xdr'd dim take.
  */
-int NC_xlen_dim(dpp)
-NC_dim **dpp ;
+int NC_xlen_dim(NC_dim **dpp)
 {
     int len = 4 ;
     if(*dpp!=NULL)

--- a/mfhdf/libsrc/error.c
+++ b/mfhdf/libsrc/error.c
@@ -45,8 +45,7 @@ extern int errno;
 #else
 /* provide a strerror function for older unix systems */
 char *
-strerror(errnum)
-int errnum ;
+strerror(int errnum)
 {
 	extern int sys_nerr;
 	extern const char * const sys_errlist[];

--- a/mfhdf/libsrc/file.c
+++ b/mfhdf/libsrc/file.c
@@ -97,9 +97,9 @@ ncreset_cdflist()
  *  Allocates _cdfs and returns the allocated size if succeeds;
  *  otherwise return FAIL(-1).
  */
+/* req_max - requested max to allocate */
 intn
-NC_reset_maxopenfiles(req_max)
-intn req_max;    /* requested max to allocate */
+NC_reset_maxopenfiles(intn req_max)
 {
     intn sys_limit = MAX_AVAIL_OPENFILES;
     intn alloc_size;
@@ -224,8 +224,7 @@ NC_get_numopencdfs()
  * NULL on error.
  */
 NC *
-NC_check_id(cdfid)
-int cdfid ;
+NC_check_id(int cdfid)
 {
     NC *handle ;
 
@@ -244,9 +243,7 @@ int cdfid ;
  * If 'iserr' arg is true, advise.
  */
 bool_t
-NC_indefine(cdfid, iserr) /* Should be a Macro ? */
-int cdfid ;
-bool_t iserr ;
+NC_indefine(int cdfid, bool_t iserr) /* Should be a Macro ? */
 {
     bool_t ret  ;
     ret = (cdfid >= 0 && cdfid < _ncdf) ?
@@ -266,10 +263,9 @@ bool_t iserr ;
 /*
  *  Common code for ncopen and nccreate.
  */
+/* path - file name */
 static int
-NC_open(path, mode )
-const char    *path ;    /* file name */
-int mode ;
+NC_open(const char *path, int mode)
 {
     NC *handle ;
     int cdfid;
@@ -337,9 +333,8 @@ int mode ;
 }   /* NC_open */
 
 
-int nccreate(path, cmode)
-const char    *path ;    /* file name */
-int         cmode ;
+int nccreate(const char *path, int cmode)
+/* path - file name */
 {
     cdf_routine_name = "nccreate" ;
 
@@ -352,9 +347,8 @@ int         cmode ;
 }
 
 
-int ncopen(path,mode)
-const char    *path ;    /* file name */
-int         mode ;
+int ncopen(const char *path, int mode)
+/* path - file name */
 {
     cdf_routine_name = "ncopen" ;
     if(mode & NC_CREAT)
@@ -366,8 +360,7 @@ int         mode ;
 }
 
 
-int ncsync(cdfid)
-int cdfid ;
+int ncsync(int cdfid)
 {
     NC *handle ;
 
@@ -432,8 +425,7 @@ int cdfid ;
  * In define mode, restore previous definition ;
  * In create, remove the file ;
  */
-int ncabort(cdfid)
-int cdfid ;
+int ncabort(int cdfid)
 {
     NC *handle ;
     char path[FILENAME_MAX + 1] ;
@@ -534,8 +526,7 @@ int cdfid ;
 /*
  * Deprecated function ;
  */
-int ncnobuf(cdfid)
-int cdfid ;
+int ncnobuf(int cdfid)
 {
     NC *handle ;
 
@@ -559,8 +550,7 @@ int cdfid ;
  * and proto to dwell on the same filesystem.)
  */
 static char *
-NCtempname(proto)
-const char *proto ;
+NCtempname(const char *proto)
 {
 /* NO_ACCESS defined if the OS lacks the access() function */
 #ifndef NO_ACCESS
@@ -643,8 +633,7 @@ const char *proto ;
 }
 
 
-int ncredef(cdfid)
-int cdfid ;
+int ncredef(int cdfid)
 {
     NC *handle ;
     NC *new ;
@@ -732,8 +721,7 @@ int cdfid ;
  * Compute offsets and put into the header
  */
 static void
-NC_begins(handle)
-NC *handle ;
+NC_begins(NC *handle)
 {
     unsigned ii ;
     u_long index = 0 ;
@@ -801,10 +789,7 @@ NC *handle ;
  * to xdr_opaque may be used.
  */
 bool_t
-NC_dcpy( target, source, nbytes)
-XDR *target ;
-XDR *source ;
-long nbytes ;
+NC_dcpy(XDR *target, XDR *source, long nbytes)
 {
 /* you may wish to tune this: big on a cray, small on a PC? */
 #define NC_DCP_BUFSIZE 8192
@@ -834,10 +819,7 @@ err:
  * XDR the data of varid in old, target is the new xdr strm
  */
 static bool_t
-NC_vcpy( target, old, varid)
-XDR *target ;
-NC *old ;
-int varid ;
+NC_vcpy(XDR *target, NC *old, int varid)
 {
     NC_var **vpp ;
     vpp = (NC_var **)old->vars->values ;
@@ -857,11 +839,7 @@ int varid ;
  * XDR the data of (varid, recnum) in old, target is the new xdr strm
  */
 static bool_t
-NC_reccpy( target, old, varid, recnum)
-XDR *target ;
-NC *old ;
-int varid ;
-int recnum ;
+NC_reccpy(XDR *target, NC *old, int varid, int recnum)
 {
     NC_var **vpp ;
     vpp = (NC_var **)old->vars->values ;
@@ -881,9 +859,7 @@ int recnum ;
  *  Common code for ncendef, ncclose(endef)
  */
 static
-int NC_endef( cdfid, handle )
-int cdfid ;
-NC *handle ;
+int NC_endef(int cdfid, NC *handle )
 {
     XDR *xdrs ;
     unsigned ii ;
@@ -1031,8 +1007,7 @@ done:
 }
 
 
-int ncendef( cdfid )
-int cdfid ;
+int ncendef(int cdfid)
 {
     NC *handle ;
 
@@ -1049,8 +1024,7 @@ int cdfid ;
 /*
  * This routine is called by SDend()? -GV
  */
-int ncclose( cdfid )
-int cdfid ;
+int ncclose(int cdfid)
 {
     NC *handle ;
 
@@ -1102,9 +1076,7 @@ int cdfid ;
 }
 
 int
-ncsetfill(id, fillmode)
-int id ;
-int fillmode ;
+ncsetfill(int id, int fillmode)
 {
     NC *handle ;
     int ret = 0 ;

--- a/mfhdf/libsrc/iarray.c
+++ b/mfhdf/libsrc/iarray.c
@@ -18,11 +18,9 @@
 #include    "local_nc.h"
 #include    "alloc.h"
 
-
+/* values: VAX C doesn't like values[] */
 NC_iarray *
-NC_new_iarray(count, values)
-unsigned count ;
-const int *values ;           /* VAX C doesn't like values[] */
+NC_new_iarray(unsigned count, const int *values)
 {
     NC_iarray *ret ;
     int *ip ;
@@ -61,8 +59,7 @@ const int *values ;           /* VAX C doesn't like values[] */
  *       If successful returns SUCCEED else FAIL -GV 9/19/97
  */
 int
-NC_free_iarray(iarray)
-NC_iarray *iarray ;
+NC_free_iarray(NC_iarray *iarray)
 {
     int ret_value = SUCCEED;
 
@@ -78,9 +75,7 @@ NC_iarray *iarray ;
 
 
 bool_t
-xdr_NC_iarray(xdrs, ipp)
-    XDR *xdrs;
-    NC_iarray **ipp;
+xdr_NC_iarray(XDR *xdrs, NC_iarray **ipp)
 {
     int *ip ;
     u_long count = 0;
@@ -120,8 +115,7 @@ xdr_NC_iarray(xdrs, ipp)
 /*
  * How much space will the xdr'd iarray take.
  */
-int NC_xlen_iarray(iarray)
-NC_iarray *iarray ;
+int NC_xlen_iarray(NC_iarray *iarray)
 {
     int len = 4 ;
     if(iarray!=NULL)

--- a/mfhdf/libsrc/nssdc.c
+++ b/mfhdf/libsrc/nssdc.c
@@ -79,8 +79,7 @@
   UnMap a data type.  I.e. go from a CDF type to an NC_<type>
 */
 nc_type
-  cdf_unmap_type(type)
-int type;
+cdf_unmap_type(int type)
 {
 
     switch(type & 0xff) {
@@ -115,9 +114,7 @@ int type;
   Read a NC structure out of a CDF file
 */
 bool_t
-nssdc_read_cdf(xdrs, handlep)
-     XDR *  xdrs;
-     NC  ** handlep;
+nssdc_read_cdf(XDR *xdrs, NC **handlep)
 {
 
     NC     * handle;
@@ -844,9 +841,7 @@ nssdc_read_cdf(xdrs, handlep)
   Write a NC structure out to a CDF file
 */
 bool_t
-nssdc_write_cdf(xdrs, handlep)
-     XDR *  xdrs;
-     NC  ** handlep;
+nssdc_write_cdf(XDR *xdrs, NC **handlep)
 {
 #if DEBUG
     fprintf(stderr, "nssdc_write_cdf i've been called\n");
@@ -869,9 +864,7 @@ nssdc_write_cdf(xdrs, handlep)
   CDF analogue of hdf_xdr_cdf and NC_xdr_cdf
 */
 bool_t
-nssdc_xdr_cdf(xdrs, handlep)
-     XDR *  xdrs;
-     NC  ** handlep;
+nssdc_xdr_cdf(XDR *xdrs, NC **handlep)
 {
 
     int status;

--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -60,10 +60,7 @@ static const long *NCvcmaxcontig(NC *, NC_var *, const long *, const long *);
 /*
  * Print the values of an array of longs
  */
-int arrayp(label, count, array)
-const char *label ;
-unsigned count ;
-const long array[] ;
+int arrayp(const char *label, unsigned count, const long array[])
 {
     fprintf(stderr, "%s", label) ;
     fputc('\t',stderr) ;
@@ -78,8 +75,7 @@ const long array[] ;
 /*
  * Check if an ncxxx function has called the current function
  */
-static bool_t nc_API(caller)
-const char *caller;
+static bool_t nc_API(const char *caller)
 {
     char *nc_api=NULL;
     nc_api = strstr(caller, "nc");
@@ -91,10 +87,7 @@ const char *caller;
  * At the current position, add a record containing the fill values.
  */
 static bool_t
-NCfillrecord(xdrs, vpp, numvars)
-XDR *xdrs ;
-NC_var **vpp ;
-unsigned numvars ;
+NCfillrecord(XDR *xdrs, NC_var **vpp, unsigned numvars)
 {
     unsigned ii ;
 
@@ -127,10 +120,7 @@ unsigned numvars ;
  * -BMR, 12/09/2008
  */
 bool_t
-NCcoordck(handle, vp, coords)
-NC *handle ;
-NC_var *vp ;
-const long *coords ;
+NCcoordck(NC *handle, NC_var *vp, const long *coords)
 {
     const long *ip ;
     unsigned long *up ;
@@ -367,10 +357,7 @@ bad:
  * Translate the (variable, coords) pair into a seek index
  */
 static u_long
-NC_varoffset(handle, vp, coords)
-NC *handle ;
-NC_var *vp ;
-const long *coords ;
+NC_varoffset(NC *handle, NC_var *vp, const long *coords)
 {
     u_long offset ;
     const long *ip  ;
@@ -465,11 +452,7 @@ const long *coords ;
  * (minimum unit of io is 4 bytes)
  */
 static bool_t
-xdr_NCvbyte(xdrs, rem, count, values)
-XDR *xdrs ;
-unsigned rem ;
-unsigned count ;
-char *values ;
+xdr_NCvbyte(XDR *xdrs, unsigned rem, unsigned count, char *values)
 {
     char buf[4] ;
     u_long origin=0 ;
@@ -555,10 +538,7 @@ char *values ;
  * (minimum unit of io is 4 bytes)
  */
 bool_t
-xdr_NCvshort(xdrs, which, values)
-XDR *xdrs ;
-unsigned which ;
-short *values ;
+xdr_NCvshort(XDR *xdrs, unsigned which, short *values)
 {
     unsigned char buf[4] ; /* unsigned is important here */
     u_long origin=0;
@@ -632,11 +612,7 @@ short *values ;
  * xdr a single datum of type 'type' at 'where'
  */
 static bool_t
-xdr_NCv1data(xdrs, where, type, values)
-XDR *xdrs ;
-u_long where ;
-nc_type type ;
-Void *values ;
+xdr_NCv1data(XDR *xdrs, u_long where, nc_type type, Void *values)
 {
     u_long rem=0 ;
 
@@ -661,7 +637,7 @@ Void *values ;
     case NC_SHORT :
         return( xdr_NCvshort(xdrs, (unsigned)rem/2, (short *)values) ) ;
     case NC_LONG :
-#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ 
+#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__
         return( xdr_int(xdrs, (nclong *)values) ) ;
 #else
         return( xdr_long(xdrs, (nclong *)values) ) ;
@@ -788,9 +764,7 @@ done:
  *
  */
 intn
-hdf_get_data(handle, vp)
-NC *handle;
-NC_var *vp;
+hdf_get_data(NC *handle, NC_var *vp)
 {
     int32     vg = FAIL;
     int32     vsid = DFREF_NONE;
@@ -1008,9 +982,7 @@ done:
 
 */
 int32
-hdf_get_vp_aid(handle, vp)
-NC        * handle;
-NC_var    * vp;
+hdf_get_vp_aid(NC *handle, NC_var *vp)
 {
     int32 ret_value = SUCCEED;
 
@@ -1686,12 +1658,7 @@ done:
  * Return TRUE if everything worked, else FALSE
  */
 static intn
-hdf_xdr_NCv1data(handle, vp, where, type, values)
-NC      * handle;
-NC_var  * vp;
-u_long    where;
-nc_type   type;
-void *values;
+hdf_xdr_NCv1data(NC *handle, NC_var *vp, u_long where, nc_type type, void *values)
 {
 
     intn ret_value = SUCCEED;
@@ -1769,11 +1736,7 @@ nssdc_xdr_NCvdata(NC *handle,
 
 
 static
-int NCvar1io(handle, varid, coords, value)
-NC *handle ;
-int varid ;
-const long *coords ;
-Void *value ;
+int NCvar1io(NC *handle, int varid, const long *coords, Void *value)
 {
     NC_var *vp ;
     u_long offset ;
@@ -1841,11 +1804,7 @@ Void *value ;
 }
 
 
-int ncvarput1(cdfid, varid, coords, value)
-int cdfid ;
-int varid ;
-const long *coords ;
-const ncvoid *value ;
+int ncvarput1(int cdfid, int varid, const long *coords, const ncvoid *value)
 {
     NC *handle ;
 
@@ -1865,11 +1824,7 @@ const ncvoid *value ;
     return( NCvar1io(handle, varid, coords, value) ) ;
 }
 
-int ncvarget1(cdfid, varid, coords, value)
-int cdfid ;
-int varid ;
-const long *coords ;
-ncvoid *value ;
+int ncvarget1(int cdfid, int varid, const long *coords, ncvoid *value)
 {
     NC *handle ;
 
@@ -1889,12 +1844,7 @@ ncvoid *value ;
  * xdr 'count' items of contiguous data of type 'type' at 'where'
  */
 static bool_t
-xdr_NCvdata(xdrs, where, type, count, values)
-XDR *xdrs ;
-u_long where ;
-nc_type type ;
-unsigned count ;
-Void *values ;
+xdr_NCvdata(XDR *xdrs, u_long where, nc_type type, unsigned count, Void *values)
 {
     u_long rem = 0 ;
     bool_t (*xdr_NC_fnct)() ;
@@ -1987,11 +1937,7 @@ Void *values ;
  *  For a "hypercube" put/get, compute the largest contiguous block
  */
 static const long *
-NCvcmaxcontig(handle, vp, origin, edges)
-NC *handle ;
-NC_var *vp ;
-const long *origin ;
-const long *edges ;
+NCvcmaxcontig(NC *handle, NC_var *vp, const long *origin, const long *edges)
 {
     const long *edp, *orp ;
     unsigned long *boundary, *shp ;
@@ -2054,12 +2000,7 @@ const long *edges ;
 
 
 static
-int NCsimplerecio(handle, vp, start, edges, values)
-NC *handle ;
-NC_var *vp ;
-const long *start ;
-const long *edges ;
-Void *values ;
+int NCsimplerecio(NC *handle, NC_var *vp, const long *start, const long *edges, Void *values)
 {
     long offset ;
     long newrecs ;
@@ -2153,14 +2094,8 @@ Void *values ;
  * The following routine is not `static' because it is used by the `putgetg'
  * module for generalized hyperslab access.
  */
-int NCvario(handle, varid, start, edges, values)
-NC *handle ;
-int varid ;
-const long *start ;
-const long *edges ;
-void *values ;
+int NCvario(NC *handle, int varid, const long *start, const long *edges, void *values)
 {
-
     NC_var *vp ;
     const long *edp0, *edp ;
     unsigned long iocount ;
@@ -2384,12 +2319,7 @@ void *values ;
 }
 
 
-int ncvarput(cdfid, varid, start, edges, values)
-int cdfid ;
-int varid ;
-const long *start ;
-const long *edges ;
-ncvoid *values ;
+int ncvarput(int cdfid, int varid, const long *start, const long *edges, ncvoid *values)
 {
     NC *handle ;
 
@@ -2417,11 +2347,11 @@ ncvoid *values ;
  *  provided parameter 'edges'.
  *  -BMR, 2013/8/29
  */
-int NC_fill_buffer(handle, varid, edges, values)
-NC *handle;        /* file structure */
-int varid;        /* var number in handle->vars list */
-const long *edges;    /* size of the array's edges */
-void *values;        /* buffer to be filled */
+/* handle - file structure */
+/* varid - var number in handle->vars list */
+/* edges - size of the array's edges */
+/* values - buffer to be filled */
+int NC_fill_buffer(NC *handle, int varid, const long *edges, void *values)
 {
     NC_var *vp ;
     NC_attr **attr;
@@ -2466,12 +2396,7 @@ void *values;        /* buffer to be filled */
  *
  *  -BMR, 2013/8/29
  */
-int ncvarget(cdfid, varid, start, edges, values)
-int cdfid ;
-int varid ;
-const long *start ;
-const long *edges ;
-ncvoid *values ;
+int ncvarget(int cdfid, int varid, const long *start, const long *edges, ncvoid *values)
 {
     NC *handle;
     NC_var *vp;
@@ -2526,10 +2451,7 @@ ncvoid *values ;
  * Returns -1 on error.
  */
 static int
-NCnumrecvars(handle, vpp, recvarids)
-     NC *handle;
-     NC_var **vpp;
-    int *recvarids;
+NCnumrecvars(NC *handle, NC_var **vpp, int *recvarids)
 {
     NC_var **dp ;
     int ii ;
@@ -2555,8 +2477,7 @@ NCnumrecvars(handle, vpp, recvarids)
 
 
 static long
-NCelemsPerRec(vp)
-NC_var *vp ;
+NCelemsPerRec(NC_var *vp)
 {
     long nelems = 1 ;
     int jj ;
@@ -2572,11 +2493,7 @@ NC_var *vp ;
  * is null, the associated information is not returned.  Returns -1 on error.
  */
 int
-ncrecinq(cdfid, nrecvars, recvarids, recsizes)
-int cdfid ;
-int *nrecvars ;
-int *recvarids ;
-long *recsizes ;
+ncrecinq(int cdfid, int *nrecvars, int *recvarids, long *recsizes)
 {
     NC *handle ;
     int nrvars ;
@@ -2608,10 +2525,7 @@ long *recsizes ;
 
 
 static int
-NCrecio(handle, recnum, datap)
-NC *handle ;
-long recnum ;
-Void **datap ;
+NCrecio(NC *handle, long recnum, Void **datap)
 {
     int nrvars ;
     NC_var *rvp[H4_MAX_NC_VARS] ;
@@ -2675,10 +2589,7 @@ Void **datap ;
  * the address of the data to be written is null.  Return -1 on error.
  */
 int
-ncrecput(cdfid, recnum, datap)
-int cdfid ;
-long recnum ;
-ncvoid * *datap ;
+ncrecput(int cdfid, long recnum, ncvoid **datap)
 {
     NC *handle ;
     long unfilled ;
@@ -2737,10 +2648,7 @@ ncvoid * *datap ;
  * the address of the data to be read is null.  Return -1 on error;
  */
 int
-ncrecget(cdfid, recnum, datap)
-int cdfid ;
-long recnum ;
-ncvoid **datap ;
+ncrecget(int cdfid, long recnum, ncvoid **datap)
 {
     NC *handle ;
 

--- a/mfhdf/libsrc/putgetg.c
+++ b/mfhdf/libsrc/putgetg.c
@@ -30,18 +30,16 @@
  * Perform I/O on a generalized hyperslab.  The efficiency of this
  * implementation is dependent upon caching in the lower layers.
  */
+/* start  - NULL => first corner */
+/* count  - NULL => everything following start[] */
+/* stride - NULL => unity strides */
+/* imap   - NULL => same structure as netCDF variable */
 #ifndef HDF
     static
 #endif
 int
-NCgenio(handle, varid, start, count, stride, imap, values)
-    NC		*handle;
-    int		varid;
-    const long	*start;		/* NULL => first corner */
-    const long	*count;		/* NULL => everything following start[] */
-    const long	*stride;	/* NULL => unity strides */
-    const long	*imap;		/* NULL => same structure as netCDF variable */
-    void	*values ;
+NCgenio(NC *handle, int varid, const long *start, const long *count,
+        const long *stride, const long *imap, void *values)
 {
     int		maxidim;	/* maximum dimensional index */
     NC_var	*vp	= NC_hlookupvar( handle, varid );
@@ -154,15 +152,9 @@ NCgenio(handle, varid, start, count, stride, imap, values)
 /*
  * Generalized hyperslab output.
  */
-    int
-ncvarputg(cdfid, varid, start, count, stride, imap, values)
-int cdfid ;
-int varid ;
-const long *start ;
-const long *count ;
-const long *stride ;
-const long *imap ;
-ncvoid *values ;
+int
+ncvarputg(int cdfid, int varid, const long *start, const long *count,
+          const long *stride, const long *imap, ncvoid *values)
 {
 	NC *handle ;
 
@@ -187,14 +179,8 @@ ncvoid *values ;
  * Generalized hyperslab input.
  */
     int
-ncvargetg(cdfid, varid, start, count, stride, imap, values)
-int cdfid ;
-int varid ;
-const long *start ;
-const long *count ;
-const long *stride ;
-const long *imap ;
-ncvoid *values ;
+ncvargetg(int cdfid, int varid, const long *start, const long *count,
+          const long *stride, const long *imap, ncvoid* values)
 {
 	NC *handle ;
 
@@ -215,13 +201,7 @@ ncvoid *values ;
  * Stride-oriented hyperslab output.
  */
     int
-ncvarputs(cdfid, varid, start, count, stride, values)
-int cdfid ;
-int varid ;
-const long *start ;
-const long *count ;
-const long *stride ;
-ncvoid *values ;
+ncvarputs(int cdfid, int varid, const long *start, const long *count, const long *stride, ncvoid *values)
 {
 	NC *handle ;
 
@@ -246,13 +226,7 @@ ncvoid *values ;
  * Stride-oriented hyperslab input.
  */
     int
-ncvargets(cdfid, varid, start, count, stride, values)
-int cdfid ;
-int varid ;
-const long *start ;
-const long *count ;
-const long *stride ;
-ncvoid *values ;
+ncvargets(int cdfid, int varid, const long *start, const long *count, const long *stride, ncvoid *values)
 {
 	NC *handle ;
 

--- a/mfhdf/libsrc/sharray.c
+++ b/mfhdf/libsrc/sharray.c
@@ -27,10 +27,7 @@
  */
 static
 bool_t
-NCxdr_shortsb(xdrs, sp, nshorts)
-	XDR *xdrs;
-	short *sp;
-	u_int nshorts ;
+NCxdr_shortsb(XDR *xdrs, short *sp, u_int nshorts)
 {
 	unsigned char buf[NC_SHRT_BUFSIZ] ;
 	unsigned char *cp ;
@@ -72,10 +69,7 @@ NCxdr_shortsb(xdrs, sp, nshorts)
  * Translate an array of cnt short integers at sp.
  */
 bool_t
-xdr_shorts(xdrs, sp, cnt)
-	XDR *xdrs;
-	short *sp;
-	u_int cnt ;
+xdr_shorts(XDR *xdrs, short *sp, u_int cnt)
 {
 	int odd ; /* 1 if cnt is odd, 0 otherwise */
 

--- a/mfhdf/libsrc/string.c
+++ b/mfhdf/libsrc/string.c
@@ -50,9 +50,7 @@ compute_hash(unsigned count,
 #endif /* HDF */
 
 NC_string *
-NC_new_string(count, str)
-unsigned count ;
-const char *str ;
+NC_new_string(unsigned count, const char *str)
 {
     NC_string *ret ;
     size_t memlen ;
@@ -109,8 +107,7 @@ const char *str ;
  *       If successful returns SUCCEED else FAIL -GV 9/19/97
  */
 int
-NC_free_string(cdfstr)
-NC_string *cdfstr ;
+NC_free_string(NC_string *cdfstr)
 {
     int ret_value = SUCCEED;
 
@@ -135,10 +132,7 @@ done:
 
 
 NC_string *
-NC_re_string(old, count, str)
-NC_string *old ;
-unsigned count ;
-const char *str ;
+NC_re_string(NC_string *old, unsigned count, const char *str)
 {
     if(old->count < count) /* punt */
       {
@@ -164,9 +158,7 @@ const char *str ;
 }
 
 bool_t
-xdr_NC_string(xdrs, spp)
-    XDR *xdrs;
-    NC_string **spp;
+xdr_NC_string(XDR *xdrs, NC_string **spp)
 {
         u_long count = 0;
         int status ;
@@ -217,8 +209,7 @@ xdr_NC_string(xdrs, spp)
  * How much space will the xdr'd string take.
  *
  */
-int NC_xlen_string(cdfstr)
-NC_string *cdfstr ;
+int NC_xlen_string(NC_string *cdfstr)
 {
     int len = 4 ;
     int rem ;

--- a/mfhdf/libsrc/var.c
+++ b/mfhdf/libsrc/var.c
@@ -24,11 +24,7 @@ static int ncvarcpy(int, int, int);
 #endif /* NOT_USED */
 
 NC_var *
-NC_new_var(name,type,ndims,dims)
-const char *name ;
-nc_type type ;
-int ndims ;
-const int *dims ;
+NC_new_var(const char *name, nc_type type, int ndims, const int *dims)
 {
     NC_var *ret ;
 
@@ -83,8 +79,7 @@ alloc_err :
  *       If successful returns SUCCEED else FAIL -GV 9/19/97
  */
 intn
-NC_free_var(var)
-NC_var *var ;
+NC_free_var(NC_var *var)
 {
     intn ret_value = SUCCEED;
 
@@ -131,9 +126,7 @@ done:
 #ifndef HDF
 static
 #endif
-int NC_var_shape(var, dims)
-NC_var *var ;
-NC_array *dims;
+int NC_var_shape(NC_var *var, NC_array *dims)
 {
     unsigned long *shape, *dsizes ;
     int ii ;
@@ -254,12 +247,7 @@ out :
 }
 
 
-int ncvardef(cdfid, name, type, ndims, dims)
-int cdfid ;
-const char *name ;
-nc_type type ;
-int ndims ;
-const int dims[] ;
+int ncvardef(int cdfid, const char *name, nc_type type, int ndims, const int dims[])
 {
     NC *handle ;
     NC_var *var[1] ;
@@ -355,8 +343,7 @@ const int dims[] ;
  * Sets handle->begin_rec to start of first record variable
  * returns -1 on error
  */
-int NC_computeshapes( handle )
-NC *handle ;
+int NC_computeshapes(NC *handle)
 {
     NC_var **vbase, **vpp ;
     NC_var *first = NULL ;
@@ -397,9 +384,7 @@ NC *handle ;
 }
 
 
-int ncvarid( cdfid, name)
-int cdfid ;
-const char *name ;
+int ncvarid(int cdfid, const char *name)
 {
     NC *handle ;
     NC_var **dp ;
@@ -433,9 +418,7 @@ const char *name ;
  *  else NULL on error
  */
 NC_var *
-NC_hlookupvar( handle, varid )
-NC *handle ;
-int varid ;
+NC_hlookupvar(NC *handle, int varid)
 {
     NC_array **ap ;
 
@@ -459,9 +442,7 @@ int varid ;
  *  else NULL on error
  */
 static NC_var *
-NC_lookupvar( cdfid, varid )
-int cdfid ;
-int varid ;
+NC_lookupvar(int cdfid, int varid)
 {
     NC *handle ;
 
@@ -473,14 +454,7 @@ int varid ;
 }
 
 
-int ncvarinq( cdfid, varid, name, typep, ndimsp, dims, nattrsp)
-int cdfid ;
-int varid ;
-char *name ;
-nc_type *typep ;
-int *ndimsp ;
-int dims[] ;
-int *nattrsp ;
+int ncvarinq(int cdfid, int varid, char *name, nc_type *typep, int *ndimsp, int dims[], int *nattrsp)
 {
     NC_var *vp ;
     int ii ;
@@ -528,12 +502,8 @@ int *nattrsp ;
 }
 
 
-int ncvarrename(cdfid, varid, newname)
-int cdfid ;
-int varid ;
-const char *newname ;
+int ncvarrename(int cdfid, int varid, const char *newname)
 {
-
     NC *handle ;
     NC_var **vpp ;
     int ii ;
@@ -606,10 +576,7 @@ const char *newname ;
  *  else NULL on error
  */
 static NC_var *
-NC_hvarid(handle, name, namelen)
-NC *handle ;
-const char *name ;
-int namelen ;
+NC_hvarid(NC *handle, const char *name, int namelen)
 {
     NC_var **dp ;
     int ii ;
@@ -638,10 +605,7 @@ int namelen ;
  * general in a future release.
  */
 static int
-ncvarcpy(incdf, varid, outcdf)
-int             incdf;
-int             varid;
-int             outcdf;
+ncvarcpy(int incdf, int varid, int outcdf)
 {
     NC *inhandle, *outhandle ;
     NC_var *invp, *outvp ;
@@ -827,9 +791,7 @@ int             outcdf;
 
 
 bool_t
-xdr_NC_var(xdrs, vpp)
-    XDR *xdrs;
-    NC_var **vpp;
+xdr_NC_var(XDR *xdrs, NC_var **vpp)
 {
     u_long begin = 0;
 
@@ -914,8 +876,7 @@ xdr_NC_var(xdrs, vpp)
  * How much space will the xdr'd var take.
  *
  */
-int NC_xlen_var(vpp)
-NC_var **vpp ;
+int NC_xlen_var(NC_var **vpp)
 {
     int len ;
 

--- a/mfhdf/libsrc/xdrposix.c
+++ b/mfhdf/libsrc/xdrposix.c
@@ -78,8 +78,7 @@ typedef struct {
 
 
 static void
-free_biobuf(abuf)
-biobuf *abuf;
+free_biobuf(biobuf *abuf)
 {
     if(abuf != NULL)
     HDfree((VOIDP)abuf) ;
@@ -87,9 +86,7 @@ biobuf *abuf;
 
 
 static biobuf *
-new_biobuf(fd, fmode)
-int fd;
-int fmode;
+new_biobuf(int fd, int fmode)
 {
     biobuf *biop ;
 
@@ -113,8 +110,7 @@ int fmode;
 
 
 static int
-rdbuf(biop)
-biobuf *biop;
+rdbuf(biobuf *biop)
 {
     memset(biop->base, 0, ((size_t)(BIOBUFSIZ))) ;
 
@@ -138,8 +134,7 @@ biobuf *biop;
 
 
 static int
-wrbuf(biop)
-biobuf *biop;
+wrbuf(biobuf *biop)
 {
 
     if(!((biop->mode & O_WRONLY) || (biop->mode & O_RDWR))
@@ -163,8 +158,7 @@ biobuf *biop;
 }
 
 static int
-nextbuf(biop)
-biobuf *biop;
+nextbuf(biobuf *biop)
 {
     if(biop->isdirty)
     {
@@ -189,10 +183,7 @@ biobuf *biop;
 #define BREM(p) (BIOBUFSIZ - CNT(p))
 
 static int
-bioread(biop, ptr, nbytes)
-biobuf *biop;
-unsigned char *ptr;
-int nbytes;
+bioread(biobuf *biop, unsigned char *ptr, int nbytes)
 {
     int ngot = 0 ;
     size_t rem ;
@@ -221,10 +212,7 @@ int nbytes;
 
 
 static int
-biowrite(biop, ptr, nbytes)
-biobuf *biop;
-unsigned char *ptr;
-int nbytes;
+biowrite(biobuf *biop, unsigned char *ptr, int nbytes)
 {
     size_t rem ;
     int nwrote = 0 ;
@@ -328,9 +316,7 @@ static struct xdr_ops   xdrposix_ops = {
  * Fake an XDR initialization for HDF files
  */
 void
-hdf_xdrfile_create(xdrs, ncop)
-     XDR *xdrs;
-     int ncop;
+hdf_xdrfile_create(XDR *xdrs, int ncop)
 {
     biobuf *biop = new_biobuf(-1, 0) ;
 
@@ -351,13 +337,8 @@ hdf_xdrfile_create(xdrs, ncop)
  * Operation flag is set to op.
  */
 static int
-xdrposix_create(xdrs, fd, fmode, op)
-    XDR *xdrs;
-    int fd;
-    int fmode;
-    enum xdr_op op;
+xdrposix_create(XDR *xdrs, int fd, int fmode, enum xdr_op op)
 {
-
     biobuf *biop = new_biobuf(fd, fmode) ;
    /* fprintf(stderr, "xdrposix_create: biop = %p\n", biop);
  */
@@ -390,8 +371,7 @@ fprintf(stderr,"xdrposix_create(): before rdbuf()\n");
  * "sync" a posix xdr stream.
  */
 static int
-xdrposix_sync(xdrs)
-    XDR *xdrs;
+xdrposix_sync(XDR *xdrs)
 {
     biobuf *biop = (biobuf *)xdrs->x_private ;
     if(biop->isdirty)
@@ -416,8 +396,7 @@ xdrposix_sync(xdrs)
  * Cleans up the xdr stream handle xdrs previously set up by xdrposix_create.
  */
 static void
-xdrposix_destroy(xdrs)
-    XDR *xdrs;
+xdrposix_destroy(XDR *xdrs)
 {
     /* flush */
     biobuf *biop = (biobuf *)xdrs->x_private ;
@@ -436,9 +415,7 @@ xdrposix_destroy(xdrs)
 }
 
 static bool_t
-xdrposix_getlong(xdrs, lp)
-    XDR *xdrs;
-    long *lp;
+xdrposix_getlong(XDR *xdrs, long *lp)
 {
     unsigned char *up = (unsigned char *)lp ;
 #if (defined AIX5L64 || defined __powerpc64__ || (defined __hpux && __LP64__))
@@ -454,9 +431,7 @@ xdrposix_getlong(xdrs, lp)
 }
 
 static bool_t
-xdrposix_putlong(xdrs, lp)
-    XDR *xdrs;
-    long *lp;
+xdrposix_putlong(XDR *xdrs, long *lp)
 {
 
     unsigned char *up = (unsigned char *)lp ;
@@ -473,34 +448,24 @@ xdrposix_putlong(xdrs, lp)
     return (TRUE);
 }
 
-static bool_t
-xdrposix_getbytes(xdrs, addr, len)
-    XDR *xdrs;
-    caddr_t addr;
 #if (defined __hpux)
-    int len;
+static bool_t xdrposix_getbytes(XDR *xdrs, caddr_t addr, int len)
 #else
-    u_int len;
+static bool_t xdrposix_getbytes(XDR *xdrs, caddr_t addr, u_int len)
 #endif
 {
-
     if ((len != 0)
             && (bioread((biobuf *)xdrs->x_private, (unsigned char *)addr, (int)len) != len))
         return (FALSE);
     return (TRUE);
 }
 
-static bool_t
-xdrposix_putbytes(xdrs, addr, len)
-    XDR *xdrs;
-    caddr_t addr;
 #if (defined __hpux)
-    int len;
+static bool_t xdrposix_putbytes(XDR *xdrs, caddr_t addr, int len)
 #else
-    u_int len;
+static bool_t xdrposix_putbytes(XDR *xdrs, caddr_t addr, u_int len)
 #endif
 {
-
     if ((len != 0)
             && (biowrite((biobuf *)xdrs->x_private, (unsigned char *)addr, (int)len) != len))
         return (FALSE);
@@ -508,18 +473,14 @@ xdrposix_putbytes(xdrs, addr, len)
 }
 
 static ncpos_t
-xdrposix_getpos(xdrs)
-    XDR *xdrs;
+xdrposix_getpos(XDR *xdrs)
 {
-
     biobuf *biop = (biobuf *)xdrs->x_private ;
     return (BIOBUFSIZ * biop->page + CNT(biop));
 }
 
 static bool_t
-xdrposix_setpos(xdrs, pos)
-    XDR *xdrs;
-    ncpos_t pos;
+xdrposix_setpos(XDR *xdrs, ncpos_t pos)
 {
     biobuf *biop = (biobuf *)xdrs->x_private ;
     if(biop != NULL)
@@ -566,11 +527,8 @@ static netlong *
 #endif
 #endif
 #endif
-xdrposix_inline(xdrs, len)
-    XDR *xdrs;
-    u_int len;
+xdrposix_inline(XDR *xdrs, u_int len)
 {
-
     /*
      * Must do some work to implement this: must insure
      * enough data in the underlying posix buffer,
@@ -583,9 +541,7 @@ xdrposix_inline(xdrs, len)
 #if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64  || defined __x86_64__ || defined __powerpc64__
 
 static bool_t
-xdrposix_getint(xdrs, lp)
-    XDR *xdrs;
-    int *lp;
+xdrposix_getint(XDR *xdrs, int *lp)
 {
     unsigned char *up = (unsigned char *)lp ;
     if(bioread((biobuf *)xdrs->x_private, up, 4) < 4)
@@ -597,11 +553,8 @@ xdrposix_getint(xdrs, lp)
 }
 
 static bool_t
-xdrposix_putint(xdrs, lp)
-    XDR *xdrs;
-    int *lp;
+xdrposix_putint(XDR *xdrs, int *lp)
 {
-
     unsigned char *up = (unsigned char *)lp ;
 #ifndef H4_WORDS_BIGENDIAN
     netlong mycopy = htonl(*lp);
@@ -614,17 +567,13 @@ xdrposix_putint(xdrs, lp)
 #endif /* end of xdrposix_put(get)int */
 
 int
-NCxdrfile_sync(xdrs)
-XDR *xdrs ;
+NCxdrfile_sync(XDR *xdrs)
 {
     return xdrposix_sync(xdrs) ;
 }
 
 int
-NCxdrfile_create(xdrs, path, ncmode)
-XDR *xdrs ;
-const char *path ;
-int ncmode ;
+NCxdrfile_create(XDR *xdrs, const char *path, int ncmode)
 {
     int fmode ;
     int  fd ;

--- a/mfhdf/libsrc/xdrstdio.c
+++ b/mfhdf/libsrc/xdrstdio.c
@@ -69,10 +69,7 @@ static struct xdr_ops    xdrNCstdio_ops = {
  * Operation flag is set to op.
  */
 void
-xdrNCstdio_create(xdrs, file, op)
-    register XDR *xdrs;
-    FILE *file;
-    enum xdr_op op;
+xdrNCstdio_create(register XDR *xdrs, FILE *file, enum xdr_op op)
 {
     xdrs->x_op = op;
     xdrs->x_ops = &xdrNCstdio_ops;
@@ -89,16 +86,13 @@ xdrNCstdio_create(xdrs, file, op)
  * This function closes the stream.
  */
 static void
-xdrNCstdio_destroy(xdrs)
-    register XDR *xdrs;
+xdrNCstdio_destroy(register XDR *xdrs)
 {
     (void)fclose((FILE *)xdrs->x_private);
 }
 
 static bool_t
-xdrNCstdio_getlong(xdrs, lp)
-    XDR *xdrs;
-    register long *lp;
+xdrNCstdio_getlong(XDR *xdrs, register long *lp)
 {
     if (fread((caddr_t)lp, sizeof(long), 1, (FILE *)xdrs->x_private) != 1)
     {
@@ -113,9 +107,7 @@ xdrNCstdio_getlong(xdrs, lp)
 }
 
 static bool_t
-xdrNCstdio_putlong(xdrs, lp)
-    XDR *xdrs;
-    long *lp;
+xdrNCstdio_putlong(XDR *xdrs, long *lp)
 {
 #ifndef H4_WORDS_BIGENDIAN
     long mycopy = htonl(*lp);
@@ -132,10 +124,7 @@ xdrNCstdio_putlong(xdrs, lp)
 }
 
 static bool_t
-xdrNCstdio_getbytes(xdrs, addr, len)
-    XDR *xdrs;
-    caddr_t addr;
-    u_int len;
+xdrNCstdio_getbytes(XDR *xdrs, caddr_t addr, u_int len)
 {
     if ((len != 0) && (fread(addr, (int)len, 1, (FILE *)xdrs->x_private) != 1))
     {
@@ -147,10 +136,7 @@ xdrNCstdio_getbytes(xdrs, addr, len)
 }
 
 static bool_t
-xdrNCstdio_putbytes(xdrs, addr, len)
-    XDR *xdrs;
-    caddr_t addr;
-    u_int len;
+xdrNCstdio_putbytes(XDR *xdrs, caddr_t addr, u_int len)
 {
 
     if ((len != 0) && (fwrite(addr, (int)len, 1, (FILE *)xdrs->x_private) != 1))
@@ -163,17 +149,14 @@ xdrNCstdio_putbytes(xdrs, addr, len)
 }
 
 static u_long
-xdrNCstdio_getpos(xdrs)
-    XDR *xdrs;
+xdrNCstdio_getpos(XDR *xdrs)
 {
     XDRNC_POS(xdrs) = ftell((FILE *)xdrs->x_private);
     return ((u_long)XDRNC_POS(xdrs));
 }
 
 static bool_t
-xdrNCstdio_setpos(xdrs, pos)
-    XDR *xdrs;
-    u_int pos;
+xdrNCstdio_setpos(XDR *xdrs, u_int pos)
 {
     if(xdrs->x_op == XDRNC_LASTOP(xdrs) && pos == XDRNC_POS(xdrs))
         return TRUE ;
@@ -191,9 +174,7 @@ xdrNCstdio_setpos(xdrs, pos)
 
 /*ARGSUSED*/
 static int32_t *
-xdrNCstdio_inline(xdrs, len)
-    XDR *xdrs;
-    u_int len;
+xdrNCstdio_inline(XDR *xdrs, u_int len)
 {
 
     /*
@@ -216,18 +197,14 @@ xdrNCstdio_inline(xdrs, len)
  * library function, xdrstdio_destroy() which merely flushes it.
  */
 static void
-xdrNCstdio_destroy(xdrs)
-    XDR *xdrs;
+xdrNCstdio_destroy(XDR *xdrs)
 {
     (void)fclose((FILE *)xdrs->x_private);
 }
 
 static bool_t
-xdrNCstdio_setpos(xdrs, pos)
-    XDR *xdrs;
-    u_int pos;
+xdrNCstdio_setpos(XDR *xdrs, u_int pos)
 {
-
     static XDR *last = NULL ;
     static enum xdr_op lastop = XDR_FREE ;
 
@@ -275,8 +252,7 @@ xdrNCstdio_setpos(xdrs, pos)
  * "sync" (flush) xdr stream.
  */
 int
-NCxdrfile_sync(xdrs)
-    XDR *xdrs;
+NCxdrfile_sync(XDR *xdrs)
 {
     /* assumes xdrstdio, violates layering */
     FILE *fp = (FILE *)xdrs->x_private ;
@@ -288,10 +264,7 @@ NCxdrfile_sync(xdrs)
 
 
 int
-NCxdrfile_create(xdrs, path, ncmode)
-XDR *xdrs ;
-const char *path ;
-int ncmode ;
+NCxdrfile_create(XDR *xdrs, const char *path, int ncmode)
 {
     char *fmode ;
     FILE *fp ;

--- a/mfhdf/ncdump/dumplib.c
+++ b/mfhdf/ncdump/dumplib.c
@@ -58,24 +58,21 @@ static int linep;
 static int max_line_len;
 
 void
-set_indent(in)
-     int in;
+set_indent(int in)
 {
     linep = in;
 }
 
 
 void
-set_max_len(len)
-     int len;
+set_max_len(int len)
 {
     max_line_len = len-2;
 }
 
 
 void
-lput(cp)
-     const char *cp;
+lput(const char *cp)
 {
     int nn = strlen(cp);
 
@@ -101,19 +98,17 @@ static char *formats[] =
 
 /* In case different formats specified with -d option, set them here. */
 void
-set_formats(flt, dbl)
-     char *flt;
-     char *dbl;
+set_formats(char *flt, char *dbl)
 {
     strcpy(formats[3], flt);
     strcpy(formats[4], dbl);
 }
 
 
+/* ncid - netcdf id */
+/* varid - variable id */
 static char *
-has_c_format_att(ncid, varid)
-    int ncid;			/* netcdf id */
-    int varid;			/* variable id */
+has_c_format_att(int ncid, int varid)
 {
     nc_type cfmt_type;
     int cfmt_len;
@@ -144,11 +139,11 @@ has_c_format_att(ncid, varid)
  * Determine print format to use for each value for this variable.  Use value
  * of attribute C_format if it exists, otherwise a sensible default.
  */
+/* ncid  - netcdf id */
+/* varid - variable id */
+/* type  - netCDF data type */
 const char *
-get_fmt(ncid, varid, type)
-     int ncid;			/* netcdf id */
-     int varid;			/* variable id */
-     nc_type type;		/* netCDF data type */
+get_fmt(int ncid, int varid, nc_type type)
 {
     char *c_format_att = has_c_format_att(ncid, varid);
 
@@ -203,9 +198,7 @@ newvlist()
 
 
 void
-varadd(vlist, varid)
-     vnode* vlist;
-     int varid;
+varadd(vnode *vlist, int varid)
 {
     vnode *newvp = newvnode();
 
@@ -216,9 +209,7 @@ varadd(vlist, varid)
 
 
 int
-varmember(vlist, varid)
-     vnode* vlist;
-     int varid;
+varmember(vnode *vlist, int varid)
 {
     vnode *vp = vlist -> next;
 

--- a/mfhdf/ncdump/ncdump.c
+++ b/mfhdf/ncdump/ncdump.c
@@ -45,8 +45,7 @@ usage()
  * last component of path and stripping off any extension.
  */
 static char *
-name_path(path)
-     char *path;
+name_path(char *path)
 {
     char *cp, *new;
 
@@ -73,8 +72,7 @@ name_path(path)
 }
 
 static const char *
-type_name(type)
-     nc_type type;
+type_name(nc_type type)
 {
     switch (type) {
       case NC_BYTE:
@@ -100,9 +98,9 @@ type_name(type)
  * point from ss, a string representation of a floating-point number that
  * might include an exponent part.
  */
+/* ss - returned string representing dd */
 static void
-tztrim(ss)
-     char *ss;			/* returned string representing dd */
+tztrim(char *ss)
 {
     char *cp, *ep;
 
@@ -130,10 +128,7 @@ tztrim(ss)
  * explicit type tags, because their types are not declared.
  */
 static void
-pr_att_vals(type, len, vals)
-     nc_type type;
-     int len;
-     void *vals;
+pr_att_vals(nc_type type, int len, void *vals)
 {
     int iel;
     union {
@@ -558,9 +553,7 @@ do_ncdump(char *path, struct fspec* specp)
 }
 
 static void
-make_lvars(optarg, fspecp)
-     char *optarg;
-     struct fspec* fspecp;
+make_lvars(char *optarg, struct fspec *fspecp)
 {
     char *cp = optarg;
     int nvars = 1;
@@ -601,8 +594,7 @@ make_lvars(optarg, fspecp)
  * command-line and update the default data formats appropriately.
  */
 static void
-set_sigdigs(optarg)
-     char *optarg;
+set_sigdigs(char *optarg)
 {
     char *ptr = optarg;
     char *ptr2 = 0;
@@ -633,9 +625,7 @@ set_sigdigs(optarg)
 
 
 int
-main(argc, argv)
-int argc;
-char *argv[];
+main(int argc, char *argv[])
 {
     extern int optind;
     extern int opterr;

--- a/mfhdf/ncdump/vardata.c
+++ b/mfhdf/ncdump/vardata.c
@@ -34,26 +34,26 @@ static void annotate
  * Print a row of variable values.  Makes sure output lines aren't too long
  * by judiciously inserting newlines.
  */
+/* vp - variable */
+/* len - number of values to print */
+/* fmt
+ * printf format used for each value.  If
+ * nc_type is NC_CHAR and this is NULL,
+ * character arrays will be printed as strings
+ * enclosed in quotes.
+ */
+/* more
+ * true if more data will follow, so add
+ * trailing comma
+ */
+/* lastrow
+ * true if this is the last row for this
+ * variable, so terminate with ";" instead of
+ * ","
+ */
+/* vals pointer to block of values */
 static void
-pr_vals(vp, len, fmt, more, lastrow, vals)
-     struct ncvar *vp;		/* variable */
-     long len;			/* number of values to print */
-     char *fmt;			/*
-				 * printf format used for each value.  If
-				 * nc_type is NC_CHAR and this is NULL,
-				 * character arrays will be printed as strings
-				 * enclosed in quotes.
-				 */
-     bool more;			/*
-				 * true if more data will follow, so add
-				 * trailing comma
-				 */
-     bool lastrow;		/*
-				 * true if this is the last row for this
-				 * variable, so terminate with ";" instead of
-				 * ","
-				 */
-     void *vals;		/* pointer to block of values */
+pr_vals(struct ncvar *vp, long len, char *fmt, bool more, bool lastrow, void *vals)
 {
     long iel;
     union {
@@ -216,9 +216,7 @@ pr_vals(vp, len, fmt, more, lastrow, vals)
  * print last delimiter in each line before annotation (, or ;)
  */
 static void
-lastdelim (more, lastrow)
-     bool more;
-     bool lastrow;
+lastdelim (bool more, bool lastrow)
 {
     if (more) {
 	Printf(", ");
@@ -235,12 +233,12 @@ lastdelim (more, lastrow)
 /*
  * Annotates a value in data section with var name and indices in comment
  */
+/* vp  - variable */
+/* fsp - formatting specs */
+/* cor - corner coordinates */
+/* iel - which element in current row */
 static void
-annotate(vp, fsp, cor, iel)
-     struct ncvar *vp;		/* variable */
-     struct fspec* fsp;		/* formatting specs */
-     long cor[];		/* corner coordinates */
-     long iel;			/* which element in current row */
+annotate(struct ncvar *vp, struct fspec *fsp, long cor[], long iel)
 {
     int vrank = vp->ndims;
     int id;
@@ -270,28 +268,28 @@ annotate(vp, fsp, cor, iel)
  * Print a number of commented variable values, where the comments for each
  * value identify the variable, and each dimension index.
  */
+/* vp - variable */
+/* len - number of values to print */
+/* fmt
+ * printf format used for each value.  If
+ * nc_type is NC_CHAR and this is NULL,
+ * character arrays will be printed as strings
+ * enclosed in quotes.
+ */
+/* more
+ * true if more data for this row will follow,
+ * so add trailing comma
+ */
+/* lastrow
+ * true if this is the last row for this
+ * variable, so terminate with ";" instead of
+ * ","
+ */
+/* vals - pointer to block of values */
+/* fsp  - formatting specs */
+/* cor  - corner coordinates */
 static void
-pr_cvals(vp, len, fmt, more, lastrow, vals, fsp, cor)
-     struct ncvar *vp;		/* variable */
-     long len;			/* number of values to print */
-     char *fmt;			/*
-				 * printf format used for each value.  If
-				 * nc_type is NC_CHAR and this is NULL,
-				 * character arrays will be printed as strings
-				 * enclosed in quotes.
-				 */
-     bool more;			/*
-				 * true if more data for this row will follow,
-				 * so add trailing comma
-				 */
-     bool lastrow;		/*
-				 * true if this is the last row for this
-				 * variable, so terminate with ";" instead of
-				 * ","
-				 */
-     void *vals;		/* pointer to block of values */
-     struct fspec* fsp;		/* formatting specs */
-     long cor[];		/* corner coordinates */
+pr_cvals(struct ncvar *vp, long len, char *fmt, bool more, bool lastrow, void *vals, struct fspec *fsp, long cor[])
 {
     long iel;
     union {
@@ -448,12 +446,12 @@ pr_cvals(vp, len, fmt, more, lastrow, vals, fsp, cor)
  * Updates a vector of ints, odometer style.  Returns 0 if odometer
  * overflowed, else 1.
  */
+/* dims  - The "odometer" limits for each dimension  */
+/* ndims - Number of dimensions */
+/* odom  - The "odometer" vector to be updated */
+/* add   - A vector to "add" to odom on each update */
 static int
-upcorner(dims,ndims,odom,add)
-     long *dims;		/* The "odometer" limits for each dimension  */
-     int ndims;			/* Number of dimensions */
-     long* odom;		/* The "odometer" vector to be updated */
-     long* add;			/* A vector to "add" to odom on each update */
+upcorner(long *dims, int ndims, long *odom, long  *add)
 {
     int id;
     int ret = 1;
@@ -472,13 +470,13 @@ upcorner(dims,ndims,odom,add)
 }
 
 
+/* vp    - variable */
+/* vdims - variable dimension sizes */
+/* ncid  - netcdf id */
+/* varid - variable id */
+/* fsp   - formatting specs */
 int
-vardata(vp, vdims, ncid, varid, fsp)
-     struct ncvar *vp;		/* variable */
-     long vdims[];		/* variable dimension sizes */
-     int ncid;			/* netcdf id */
-     int varid;			/* variable id */
-     struct fspec* fsp;		/* formatting specs */
+vardata(struct ncvar *vp, long vdims[], int ncid, int varid, struct fspec *fsp)
 {
     long cor[H4_MAX_VAR_DIMS];	/* corner coordinates */
     long edg[H4_MAX_VAR_DIMS];	/* edges of hypercube */

--- a/mfhdf/ncgen/escapes.c
+++ b/mfhdf/ncgen/escapes.c
@@ -11,12 +11,9 @@
  * sequence "\t" in yystring would be converted into a single tab character
  * in termstring.  On return, termstring is properly terminated.
  */
-
+/* termstring - returned, with escapes expanded */
 void
-expand_escapes(termstring, yytext, yyleng)
-     char *termstring;		/* returned, with escapes expanded */
-     char *yytext;
-     int yyleng;
+expand_escapes(char *termstring, char *yytext, int yyleng)
 {
     char *s, *t, *endp;
 

--- a/mfhdf/ncgen/generate.c
+++ b/mfhdf/ncgen/generate.c
@@ -21,9 +21,9 @@ extern int c_flag;
 extern int fortran_flag;
 
 /* create netCDF from in-memory structure */
+/* filename - name for output netcdf file */
 static void
-gen_netcdf(filename)
-     char *filename;		/* name for output netcdf file */
+gen_netcdf(char *filename)
 {
     int idim, ivar, iatt;
     int istat;
@@ -75,8 +75,7 @@ gen_netcdf(filename)
  * Output a C statement.
  */
 void
-cline(stmnt)
-     const char *stmnt;
+cline(const char *stmnt)
 {
     FILE *cout = stdout;
 
@@ -87,8 +86,7 @@ cline(stmnt)
 
 /* generate C code for creating netCDF from in-memory structure */
 static void
-gen_c(filename)
-     char *filename;
+gen_c(char *filename)
 {
     int idim, ivar, iatt, jatt, itype, maxdims;
     int scalar_atts, vector_atts;
@@ -351,8 +349,7 @@ gen_c(filename)
  * but since we don't generate any labels, we don't care.
  */
 void
-fline(stmnt)
-     const char *stmnt;
+fline(const char *stmnt)
 {
     FILE *fout = stdout;
     int len = strlen(stmnt);
@@ -381,8 +378,7 @@ fline(stmnt)
 
 /* generate FORTRAN code for creating netCDF from in-memory structure */
 static void
-gen_fortran(filename)
-     char *filename;
+gen_fortran(char *filename)
 {
     int idim, ivar, iatt, jatt, itype, maxdims;
     int vector_atts;
@@ -636,9 +632,9 @@ gen_fortran(filename)
 
 
 /* return C name for netCDF type, given type code */
+/* type  - netCDF type code */
 const char *
-nctype(type)
-     nc_type type;			/* netCDF type code */
+nctype(nc_type type)
 {
     switch (type) {
       case NC_BYTE:
@@ -661,9 +657,9 @@ nctype(type)
 
 
 /* return FORTRAN name for netCDF type, given type code */
+/* type  - netCDF type code */
 static const char *
-ftypename(type)
-     nc_type type;			/* netCDF type code */
+ftypename(nc_type type)
 {
     switch (type) {
       case NC_BYTE:
@@ -686,10 +682,9 @@ ftypename(type)
 
 
 /* return C type name for netCDF type, given type code */
-
+/* type  - netCDF type code */
 const char *
-ncctype(type)
-     nc_type type;			/* netCDF type code */
+ncctype(nc_type type)
 {
     switch (type) {
       case NC_BYTE:
@@ -712,10 +707,9 @@ ncctype(type)
 
 
 /* return Fortran type name for netCDF type, given type code */
-
+/* type - netCDF type code */
 static const char *
-ncftype(type)
-     nc_type type;		/* netCDF type code */
+ncftype(nc_type type)
 {
     switch (type) {
       case NC_BYTE:
@@ -747,12 +741,11 @@ ncftype(type)
  * and the index of the vector element desired, returns a pointer to a
  * malloced string representing the value in C.
  */
-
+/* type - netCDF type code */
+/* valp - pointer to vector of values */
+/* num  - element of vector desired */
 static char *
-cstring(type,valp, num)
-     nc_type type;			/* netCDF type code */
-     void *valp;		/* pointer to vector of values */
-     int num;			/* element of vector desired */
+cstring(nc_type type, void *valp, int num)
 {
     static char *cp, *sp, ch;
     char *bytep;
@@ -836,11 +829,11 @@ cstring(type,valp, num)
  * and the index of the vector element desired, returns a pointer to a
  * malloced string representing the value in FORTRAN.
  */
+/* type - netCDF type code */
+/* valp - pointer to vector of values */
+/* num  - element of vector desired */
 char *
-fstring(type,valp, num)
-     nc_type type;			/* netCDF type code */
-     void *valp;		/* pointer to vector of values */
-     int num;			/* element of vector desired */
+fstring(nc_type type, void *valp, int num)
 {
     static char *cp, *sp;
     char ch;
@@ -899,10 +892,10 @@ fstring(type,valp, num)
  * Given a pointer to a counted string, returns a pointer to a malloced string
  * representing the string as a C constant.
  */
+/* valp - pointer to vector of characters*/
+/* len  - number of characters in valp */
 char *
-cstrstr(valp, len)
-     char *valp;		/* pointer to vector of characters*/
-     long len;			/* number of characters in valp */
+cstrstr(char *valp, long len)
 {
     static char *sp;
     char *cp;
@@ -960,10 +953,10 @@ cstrstr(valp, len)
  * the FORTRAN string "'don''t'", and the string "ab\ncd" would yield
  * "'ab'//char(10)//'cd'".
  */
+/* str  - pointer to vector of characters */
+/* ilen - number of characters in istr */
 char *
-fstrstr(str, ilen)
-     char *str;			/* pointer to vector of characters */
-     long ilen;			/* number of characters in istr */
+fstrstr(char *str, long ilen)
 {
     static char *ostr;
     char *cp, tstr[12];
@@ -1041,8 +1034,7 @@ fstrstr(str, ilen)
 /* invoke netcdf calls (or generate C or Fortran code) to create netcdf
  * from in-memory structure. */
 void
-define_netcdf(netcdfname)
-     char *netcdfname;
+define_netcdf(char *netcdfname)
 {
     char *filename;		/* output file name */
 

--- a/mfhdf/ncgen/genlib.c
+++ b/mfhdf/ncgen/genlib.c
@@ -57,8 +57,7 @@ derror(fmt, va_alist)
 
 
 void *
-emalloc (size)			/* check return from malloc */
-int size;
+emalloc (int size)			/* check return from malloc */
 {
     void   *p;
 
@@ -75,9 +74,7 @@ int size;
 }
 
 void *
-erealloc (ptr,size)		/* check return from realloc */
-     void *ptr;
-     int size;
+erealloc (void *ptr, int size)		/* check return from realloc */
 {
     void *p;
 

--- a/mfhdf/ncgen/getfill.c
+++ b/mfhdf/ncgen/getfill.c
@@ -12,9 +12,7 @@
  * that type.
  */
 void
-nc_getfill(type, gval)
-     nc_type type;
-     union generic *gval;
+nc_getfill(nc_type type, union generic *gval)
 {
     switch(type) {
       case NC_CHAR:
@@ -40,12 +38,12 @@ nc_getfill(type, gval)
     }
 }
 
+/* type     - netcdf type code  */
+/* num      - number of values to fill */
+/* datap    - where to start filling */
+/* fill_val - value to use */
 void
-nc_fill(type, num, datp, fill_val)
-     nc_type type;			/* netcdf type code  */
-     long num;			/* number of values to fill */
-     void *datp;		/* where to start filling */
-     union generic fill_val;	/* value to use */
+nc_fill(nc_type type, long num, void *datp, union generic fill_val)
 {
     char *char_valp=NULL;		/* pointers used to accumulate data values */
     short *short_valp=NULL;
@@ -101,11 +99,10 @@ nc_fill(type, num, datp, fill_val)
 /*
  * Given netCDF type, put a value of that type into a fill_value
  */
+/* val  - value of type to be put */
+/* gval - where the value is to be put */
 void
-nc_putfill(type, val, gval)
-     nc_type type;
-     void *val;			/* value of type to be put */
-     union generic *gval;	/* where the value is to be put */
+nc_putfill(nc_type type, void *val, union generic *gval)
 {
     switch(type) {
       case NC_CHAR:

--- a/mfhdf/ncgen/load.c
+++ b/mfhdf/ncgen/load.c
@@ -15,8 +15,7 @@ extern int c_flag;
 extern int fortran_flag;
 
 void
-load_netcdf(rec_start)	/* write out record from in-memory structure */
-     void *rec_start;
+load_netcdf(void *rec_start)	/* write out record from in-memory structure */
 {
     int idim;
     int istat=0;
@@ -97,9 +96,9 @@ load_netcdf(rec_start)	/* write out record from in-memory structure */
  * point from ss, a string representation of a floating-point number that
  * might include an exponent part.
  */
-    static void
-    tztrim(ss)
-char *ss;			/* returned string representing dd */
+/* ss - returned string representing dd */
+static void
+tztrim(char *ss)
 {
     char *cp, *ep;
 
@@ -125,8 +124,7 @@ char *ss;			/* returned string representing dd */
 
 /* generate C to put netCDF record from in-memory data */
 static void
-gen_load_c(rec_start)
-     void *rec_start;
+gen_load_c(void *rec_start)
 {
     int idim, ival;
     char *val_string;
@@ -348,11 +346,11 @@ gen_load_c(rec_start)
  * This will cause a Fortran compiler error, but at least all the information
  * will be available.
  */
+/* s     - source string of stement being built */
+/* t     - string to be appended to source */
+/* slenp - pointer to length of source string */
 static void
-fstrcat(s, t, slenp)
-     char *s;			/* source string of stement being built */
-     char *t;			/* string to be appended to source */
-     long *slenp;		/* pointer to length of source string */
+fstrcat(char *s, char *t, long *slenp)
 {
     *slenp += strlen(t);
     if (*slenp >= FORT_MAX_STMNT) {
@@ -367,8 +365,7 @@ fstrcat(s, t, slenp)
 
 
 static void
-gen_load_fortran(rec_start)  /* make Fortran to put record */
-     void *rec_start;
+gen_load_fortran(void *rec_start)  /* make Fortran to put record */
 {
     int idim, ival;
     char *val_string;
@@ -510,9 +507,9 @@ gen_load_fortran(rec_start)  /* make Fortran to put record */
  * struct dims[]     - structure containing name and size of dimensions.
  * int netcdf_record_number - number of current record for this variable.
  */
+/* rec_start - points to data to be loaded  */
 void
-put_variable(rec_start)
-     void *rec_start;		/* points to data to be loaded  */
+put_variable(void *rec_start)
 {
     if (netcdf_flag)
       load_netcdf(rec_start);	/* put variable values (one record's worth) */

--- a/mfhdf/ncgen/main.c
+++ b/mfhdf/ncgen/main.c
@@ -41,9 +41,7 @@ void usage()
 }
 
 int
-main(argc, argv)
-int argc;
-char *argv[];
+main(int argc, char *argv[])
 {
     extern int optind;
     extern int opterr;

--- a/mfhdf/nctest/add.c
+++ b/mfhdf/nctest/add.c
@@ -30,10 +30,9 @@ struct netcdf test;		/*
 				 * with disk netcdf
 				 */
 
+/* add the dimension idim to the netcdf test */
 void
-add_dim (test, idim)		/* add the dimension idim to the netcdf test */
-     struct netcdf *test;
-     struct cdfdim *idim;
+add_dim(struct netcdf *test, struct cdfdim *idim)
 {
     static char pname[] = "add_dim";
 
@@ -50,10 +49,9 @@ add_dim (test, idim)		/* add the dimension idim to the netcdf test */
     test->ndims++;
 }
 
+/* add the variable ivar to the netcdf test */
 void
-add_var (test, ivar)		/* add the variable ivar to the netcdf test */
-     struct netcdf *test;
-     struct cdfvar *ivar;
+add_var (struct netcdf *test, struct cdfvar *ivar)
 {
     static char pname[] = "add_var";
     int i;
@@ -75,11 +73,9 @@ add_var (test, ivar)		/* add the variable ivar to the netcdf test */
     test->nvars++;
 }
 
+/* add attribute iatt to the netcdf test */
 void
-add_att (test, varid, iatt)	/* add attribute iatt to the netcdf test */
-     struct netcdf *test;
-     int varid;			/* variable id */
-     struct cdfatt *iatt;
+add_att (struct netcdf *test, int varid, struct cdfatt *iatt)
 {
     static char pname[] = "add_att";
     int ia;			/* attribute number */
@@ -115,9 +111,9 @@ add_att (test, varid, iatt)	/* add attribute iatt to the netcdf test */
 }
 
 
+/* reset in-memory netcdf test to empty */
 void
-add_reset(test)			/* reset in-memory netcdf test to empty */
-     struct netcdf *test;
+add_reset(struct netcdf *test)
 {
     test->ndims = 0;
     test->nvars = 0;
@@ -126,12 +122,9 @@ add_reset(test)			/* reset in-memory netcdf test to empty */
     test->xdimid = -1;		/* no unlimited dimension */
 }
 
-
+/* delete attribute iatt in the netcdf test */
 void
-del_att (test, varid, iatt)	/* delete attribute iatt in the netcdf test */
-     struct netcdf *test;
-     int varid;			/* variable id */
-     struct cdfatt *iatt;
+del_att (struct netcdf *test, int varid, iatt)
 {
     static char pname[] = "del_att";
     int ia, ib;			/* attribute number */
@@ -160,12 +153,9 @@ del_att (test, varid, iatt)	/* delete attribute iatt in the netcdf test */
 		   test->vars[varid].name, iatt->name);
 }
 
+/* keep max record written updated */
 void
-add_data(test, varid, start, edges) /* keep max record written updated */
-     struct netcdf *test;
-     int varid;
-     long start[];
-     long edges[];
+add_data(struct netcdf *test, int varid, long start[], long edges[])
 {
     if (varid != test->xdimid)	/* not a record variable */
       return;
@@ -175,9 +165,7 @@ add_data(test, varid, start, edges) /* keep max record written updated */
 
 
 void
-errvar(cdfp, varp)
-     struct netcdf *cdfp;
-     struct cdfvar *varp;
+errvar(struct netcdf *cdfp, struct cdfvar *varp)
 {
     const char *types;
     int id;

--- a/mfhdf/nctest/add.c
+++ b/mfhdf/nctest/add.c
@@ -124,7 +124,7 @@ add_reset(struct netcdf *test)
 
 /* delete attribute iatt in the netcdf test */
 void
-del_att (struct netcdf *test, int varid, iatt)
+del_att (struct netcdf *test, int varid, struct cdfatt *iatt)
 {
     static char pname[] = "del_att";
     int ia, ib;			/* attribute number */

--- a/mfhdf/nctest/atttests.c
+++ b/mfhdf/nctest/atttests.c
@@ -44,9 +44,9 @@
  *    try with bad variable handle, should fail
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncattput(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncattput(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattput";
@@ -341,9 +341,9 @@ test_ncattput(path)
  *    try with bad variable handle, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncattinq(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncattinq(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattinq";
@@ -454,9 +454,9 @@ test_ncattinq(path)
  *    try with nonexisting attribute, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncattget(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncattget(char *path)
 {
     int nerrs = 0;
     int cdfid;			/* netcdf id */
@@ -623,10 +623,10 @@ test_ncattget(path)
  *    try with bad source or target netCDF handles, check error
  *    try with bad source or target variable handle, check error
  */
+/* path1 - name of input netcdf file to open */
+/* path2 - name of output netcdf file to create */
 void
-test_ncattcopy(path1, path2)
-     char *path1;		/* name of input netcdf file to open */
-     char *path2;		/* name of output netcdf file to create */
+test_ncattcopy(char *path1, char *path2)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattcopy";
@@ -895,9 +895,9 @@ test_ncattcopy(path1, path2)
  *    try with bad variable handle, check error
  *    try with bad attribute number, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncattname(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncattname(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattname";
@@ -1079,9 +1079,9 @@ test_ncattname(path)
  *    try in data mode, check error
  *    try with bad netCDF handle, check error
  */
+/* name of writable netcdf file to open */
 void
-test_ncattrename(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncattrename(chat *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattrename";
@@ -1218,9 +1218,9 @@ test_ncattrename(path)
  *    try with nonexisting attribute, check error
  *    try in data mode, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncattdel(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncattdel(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattdel";

--- a/mfhdf/nctest/atttests.c
+++ b/mfhdf/nctest/atttests.c
@@ -1081,7 +1081,7 @@ test_ncattname(char *path)
  */
 /* name of writable netcdf file to open */
 void
-test_ncattrename(chat *path)
+test_ncattrename(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncattrename";

--- a/mfhdf/nctest/cdftests.c
+++ b/mfhdf/nctest/cdftests.c
@@ -34,9 +34,9 @@
  * On exit, netcdf files are closed.
  * Uses: nccreate, ncendef, ncclose, ncopen.
  */
+/* path - name of cdf file to create */
 void
-test_nccreate(path)
-     char *path;		/* name of cdf file to create */
+test_nccreate(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_nccreate";
@@ -90,9 +90,9 @@ test_nccreate(path)
  * On exit, netcdf files are closed.
  * Uses: ncopen, ncredef, ncattput, ncendef, ncclose.
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncopen(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncopen(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncopen";
@@ -188,9 +188,9 @@ test_ncopen(path)
  * On exit netcdf files are closed.
  * Uses: ncopen, ncredef, ncdimdef, ncvardef, ncattput, ncclose
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncredef(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncredef(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncredef";
@@ -274,9 +274,9 @@ test_ncredef(path)
  *  On exit netcdf files are closed.
  * Uses: ncopen, ncredef, ncdimdef, ncvardef, ncattput, ncendef, ncclose
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncendef(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncendef(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncendef";
@@ -364,9 +364,9 @@ test_ncendef(path)
  *    try with bad handle, check error
  *  On exit netcdf files are closed.
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncclose(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncclose(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncclose";
@@ -416,9 +416,9 @@ test_ncclose(path)
  *    try with bad handle, check error
  *  On exit netcdf files are closed.
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncinquire(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncinquire(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncinquire";
@@ -577,9 +577,9 @@ test_ncinquire(path)
  *    try with bad handle, check error
  *  On exit netcdf files are closed.
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncsync(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncsync(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncsync";
@@ -710,9 +710,9 @@ test_ncsync(path)
  *    try with bad handle, check error
  *  On exit netcdf files are closed.
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncabort(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncabort(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncabort";

--- a/mfhdf/nctest/dimtests.c
+++ b/mfhdf/nctest/dimtests.c
@@ -32,9 +32,9 @@
  *    make sure unlimited size works, shows up in ncinquire(...,*xtendim)
  *    try to define a second unlimited dimension, check error
  */
+/* path - name of writable netcdf to open */
 void
-test_ncdimdef(path)
-     char *path;		/* name of writable netcdf to open */
+test_ncdimdef(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncdimdef";
@@ -134,9 +134,9 @@ test_ncdimdef(path)
  *    check return with unlimited size dimension
  *    try with bad handle, check error
  */
+/* path - name of writable netcdf to open */
 void
-test_ncdimid(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncdimid(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncdimid";
@@ -209,9 +209,9 @@ test_ncdimid(path)
  *    try with bad dimension handle, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf to open */
 void
-test_ncdiminq(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncdiminq(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncdiminq";
@@ -304,9 +304,9 @@ test_ncdiminq(path)
  *    try with bad dimension handle, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf to open */
 void
-test_ncdimrename(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncdimrename(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncdimrename";

--- a/mfhdf/nctest/driver.c
+++ b/mfhdf/nctest/driver.c
@@ -30,13 +30,7 @@ FILE *dbg_file;
 #include <stdlib.h>
 #include <string.h> /* to remove warnings, HDFFR-1434 */
 
-#ifdef PROTOTYPE
 int main(int argc, char *argv[])
-#else
-int main(argc, argv)
-int argc;
-char *argv[];
-#endif
 {
     static char testfile[] = "test.nc";
     static char unlim_testfile_name[] = "test_unlim.nc";

--- a/mfhdf/nctest/emalloc.c
+++ b/mfhdf/nctest/emalloc.c
@@ -11,9 +11,9 @@
 #include "hdf.h"
 #endif
 
+/* check return from malloc */
 void *
-emalloc (size)			/* check return from malloc */
-int size;
+emalloc (int size)
 {
     void   *p;
 
@@ -35,10 +35,9 @@ int size;
     return p;
 }
 
+/* check return from realloc */
 void *
-erealloc (ptr,size)		/* check return from realloc */
-     void *ptr;
-     int size;
+erealloc (void *ptr, int size)
 {
     void *p;
 

--- a/mfhdf/nctest/error.c
+++ b/mfhdf/nctest/error.c
@@ -25,26 +25,14 @@ int	error_count = 0;
 /*
  * Use for logging error conditions.
  */
-#ifndef NO_STDARG
 void
 error(const char *fmt, ...)
-#else
-/*VARARGS1*/
-void
-error(fmt, va_alist)
-     const char *fmt ;
-     va_dcl
-#endif
 {
     va_list args ;
 
     (void) fprintf(stderr,"*** ");
 
-#ifndef NO_STDARG
     va_start(args, fmt) ;
-#else
-    va_start(args) ;
-#endif
     (void) vfprintf(stderr,fmt,args) ;
     va_end(args) ;
 

--- a/mfhdf/nctest/rec.c
+++ b/mfhdf/nctest/rec.c
@@ -250,9 +250,6 @@ dimsizes(int ncid, int varid, long *sizes)
  */
 static int
 recput(int ncid, long recnum, void **datap)
-     int ncid;
-     long recnum;
-     void **datap;
 {
     int iv;
     int rvids[VARS];

--- a/mfhdf/nctest/rec.c
+++ b/mfhdf/nctest/rec.c
@@ -30,9 +30,7 @@
  * error.
  */
 static int
-numrecvars(ncid, recvarids)
-     int ncid;
-     int *recvarids;
+numrecvars(int ncid, int *recvarids)
 {
     int ndims, iv, nvars;
     int nrecvars;
@@ -62,9 +60,7 @@ numrecvars(ncid, recvarids)
  * variable id.  Returns 0 if not a record variable.  Returns -1 on error.
  */
 static long
-ncrecsize(ncid,vid)
-     int ncid;
-     int vid;
+ncrecsize(int ncid, int vid)
 {
     int recdimid;
     nc_type type;
@@ -97,11 +93,7 @@ ncrecsize(ncid,vid)
  * errors better.
  */
 static int
-recinq(ncid, nrecvars, recvarids, recsizes)
-     int ncid;
-     int *nrecvars;
-     int *recvarids;
-     long *recsizes;
+recinq(int ncid, int *nrecvars, int *recvarids, long *recsizes)
 {
     int iv;
     int rvarids[VARS];
@@ -128,9 +120,9 @@ recinq(ncid, nrecvars, recvarids, recsizes)
  *    check returned values against independently computed values
  *    try with bad netCDF handle, check error
  */
+/* path - name of netcdf file to open */
 void
-test_ncrecinq(path)
-     char *path;		/* name of netcdf file to open */
+test_ncrecinq(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncrecinq";
@@ -234,10 +226,7 @@ test_ncrecinq(path)
  * an open netCDF file.  Returns -1 on error.
  */
 static int
-dimsizes(ncid, varid, sizes)
-     int ncid;
-     int varid;
-     long *sizes;
+dimsizes(int ncid, int varid, long *sizes)
 {
     int ndims;
     int id;
@@ -260,7 +249,7 @@ dimsizes(ncid, varid, sizes)
  * better.
  */
 static int
-recput(ncid, recnum, datap)
+recput(int ncid, long recnum, void **datap)
      int ncid;
      long recnum;
      void **datap;
@@ -297,10 +286,7 @@ recput(ncid, recnum, datap)
  * better.
  */
 static int
-recget(ncid, recnum, datap)
-     int ncid;
-     long recnum;
-     void **datap;
+recget(int ncid, int recnum, void **datap)
 {
     int iv;
     int rvids[VARS];
@@ -335,9 +321,9 @@ recget(ncid, recnum, datap)
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncrecput(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncrecput(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncrecput";
@@ -491,9 +477,9 @@ test_ncrecput(path)
  *    try getting the empty subset of variables
  *    try with bad netCDF handle, check error
  */
+/* path - name of netcdf file to open */
 void
-test_ncrecget(path)
-     char *path;		/* name of netcdf file to open */
+test_ncrecget(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncrecget";

--- a/mfhdf/nctest/slabs.c
+++ b/mfhdf/nctest/slabs.c
@@ -176,7 +176,7 @@ val_diff(nc_type type, void *v, int ii, long val)	/* v[ii] != val */
 /* cdfid - handle of netcdf open and in data mode */
 int
 test_slabs(int cdfid)
-s{
+{
     int nerrs = 0;
     static char pname[] = "test_slabs";
     static struct cdfdim dims[NDIMS] = {

--- a/mfhdf/nctest/slabs.c
+++ b/mfhdf/nctest/slabs.c
@@ -40,12 +40,12 @@
  *
  * 	v[ii] = val;
  */
+/* type - netcdf type of v, NC_BYTE, ..., NC_DOUBLE */
+/* v    - array of specified type */
+/* ii   - it's v[ii] we want to store into */
+/* val  - value to store */
 static void
-val_stuff(type, v, ii, val)	/* v[ii] = val */
-     nc_type type;		/* netcdf type of v, NC_BYTE, ..., NC_DOUBLE */
-     void *v;			/* array of specified type */
-     int ii;			/* it's v[ii] we want to store into */
-     long val;			/* value to store */
+val_stuff(nc_type type, void *v, int ii, long val)	/* v[ii] = val */
 {
     static char pname[] = "val_stuff";
 #ifdef WRONG_for_PGCC /* This way caused a lot of problems for PGI CC compiler
@@ -110,12 +110,12 @@ val_stuff(type, v, ii, val)	/* v[ii] = val */
  * returns 0 if equal, 1 if not equal
  */
 
+/* type - netcdf type of v, NC_BYTE, ..., NC_DOUBLE */
+/* v    - array of specified type */
+/* ii   - it's v[ii] we want to compare */
+/* val  - value to compare with */
 static int
-val_diff(type, v, ii, val)	/* v[ii] != val */
-     nc_type type;		/* netcdf type of v, NC_BYTE, ..., NC_DOUBLE */
-     void *v;			/* array of specified type */
-     int ii;			/* it's v[ii] we want to compare */
-     long val;			/* value to compare with */
+val_diff(nc_type type, void *v, int ii, long val)	/* v[ii] != val */
 {
     static char pname[] = "val_diff";
 #ifdef WRONG_for_PGCC /* This way caused a lot of problems for PGI CC compiler
@@ -173,11 +173,10 @@ val_diff(type, v, ii, val)	/* v[ii] != val */
  * triples of dimensions.  In each case, compare the retrieved values with
  * the written values.
  */
-
+/* cdfid - handle of netcdf open and in data mode */
 int
-test_slabs(cdfid)
-     int cdfid;			/* handle of netcdf open and in data mode */
-{
+test_slabs(int cdfid)
+s{
     int nerrs = 0;
     static char pname[] = "test_slabs";
     static struct cdfdim dims[NDIMS] = {

--- a/mfhdf/nctest/val.c
+++ b/mfhdf/nctest/val.c
@@ -18,11 +18,11 @@
 
 
 /* fill typed value block with values of specified type */
+/* type - netcdf type, NC_BYTE, ..., NC_DOUBLE */
+/* len  - number of elements to fill with */
+/* vals - start of first block of values */
 void
-val_fill(type, len, vals)
-     nc_type type;		/* netcdf type, NC_BYTE, ..., NC_DOUBLE */
-     long len;			/* number of elements to fill with */
-     void *vals;		/* start of first block of values */
+val_fill(nc_type type, long len, void *vals)
 {
     static char pname[] = "val_fill";
     int iel;
@@ -68,11 +68,11 @@ val_fill(type, len, vals)
 
 
 /* fill typed value block with zeros of specified type */
+/* type - netcdf type, NC_BYTE, ..., NC_DOUBLE */
+/* len  - number of elements to fill with */
+/* vals - start of first block of values */
 void
-val_fill_zero(type, len, vals)
-     nc_type type;		/* netcdf type, NC_BYTE, ..., NC_DOUBLE */
-     long len;			/* number of elements to fill with */
-     void *vals;		/* start of first block of values */
+val_fill_zero(nc_type type, long len, void *vals)
 {
     static char pname[] = "val_fill_zero";
     int iel;
@@ -122,12 +122,12 @@ val_fill_zero(type, len, vals)
  * compare two typed value blocks, return 0 if equal, 1+n otherwise,
  * where n is the index of the first differing element.
  */
+/* type - netcdf type, NC_BYTE, ..., NC_DOUBLE */
+/* len  - number of elements of type to compare */
+/* v1   - start of first block of values */
+/* v2   - start of second block of values */
 int
-val_cmp (type, len, v1, v2)
-     nc_type type;		/* netcdf type, NC_BYTE, ..., NC_DOUBLE */
-     long len;			/* number of elements of type to compare */
-     void *v1;			/* start of first block of values */
-     void *v2;			/* start of second block of values */
+val_cmp(nc_type type, long len, void *v1, void *v2)
 {
     static char pname[] = "val_cmp";
     int iel;
@@ -199,11 +199,11 @@ val_cmp (type, len, v1, v2)
 
 
 /* print typed value block with values of specified type */
+/* type - netcdf type, NC_BYTE, ..., NC_DOUBLE */
+/* len  - number of elements to fill with */
+/* vals - start of first block of values */
 void
-val_out(type, len, vals)
-     nc_type type;		/* netcdf type, NC_BYTE, ..., NC_DOUBLE */
-     long len;			/* number of elements to fill with */
-     void *vals;		/* start of first block of values */
+val_out(nc_type type, long len, void *vals)
 {
     static char pname[] = "val_oout";
     int iel;

--- a/mfhdf/nctest/vardef.c
+++ b/mfhdf/nctest/vardef.c
@@ -41,9 +41,9 @@
  *    try with bad dimension ids, check error
  *    try in data mode, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvardef(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvardef(char *path)
 {
     int nerrs = 0;
     int cdfid;			/* netcdf id */

--- a/mfhdf/nctest/varget.c
+++ b/mfhdf/nctest/varget.c
@@ -32,9 +32,9 @@
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarget(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarget(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarget";

--- a/mfhdf/nctest/varget_unlim.c
+++ b/mfhdf/nctest/varget_unlim.c
@@ -2,7 +2,7 @@
  * This tests uses HDF NetCDF APIs to read the NetCDF file test_unlim.nc
  * generated with the NetCDF Library v3.5 from test_unlim.cdl
  */
-    
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -18,12 +18,12 @@
 #include "tests.h"
 #include "alloc.h"
 #include "emalloc.h"
-#ifdef HDF  
-#include "hdf.h" 
-#endif  
+#ifdef HDF
+#include "hdf.h"
+#endif
 
 float a_val[2][3] = {
-                      {1.0, 2.0, 3.0}, 
+                      {1.0, 2.0, 3.0},
                       {4.0, 5.0, 6.0}
                     };
 int   date_val[12] = {840116, 840214, 840316, 840415, 840516, 840615, 840716, 840816,
@@ -46,9 +46,9 @@ short b_val[][3][2] = {
 /*
  * Test ncvarget for variables with unlimited dimensions (bug #897)
  */
+/* basefile - name of writable netcdf file to open */
 void
-test_ncvarget_unlim(basefile)
-     char *basefile;               /* name of writable netcdf file to open */
+test_ncvarget_unlim(char *basefile)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarget_unlim";
@@ -114,7 +114,7 @@ test_ncvarget_unlim(basefile)
         start[1] = 0;
         count[0] = 2;
         count[1] = 3;
-	
+
          if((status = ncvarget (ncid, var_id, start, count, a)) == -1) {
            error("%s: ncvarget failed for variable a in ", pname);
            ncclose(ncid);
@@ -129,14 +129,14 @@ test_ncvarget_unlim(basefile)
              }
           }
          }
-        
+
 
 /* Reading 1D array with unlimited dimension */
 
 	var_id = ncvarid( ncid, "date");
         start[0] = 0;
         count[0] = 12;
-	
+
          if((status = ncvarget (ncid, var_id, start, count, date)) == -1) {
            error("%s: ncvarget failed for variable date in ", pname);
            ncclose(ncid);
@@ -155,7 +155,7 @@ test_ncvarget_unlim(basefile)
 	var_id = ncvarid( ncid, "time");
         start[0] = 0;
         count[0] = 12;
-	
+
          if((status = ncvarget (ncid, var_id, start, count, time)) == -1) {
            error("%s: ncvarget failed varaible time in ", pname);
            ncclose(ncid);

--- a/mfhdf/nctest/vargetg.c
+++ b/mfhdf/nctest/vargetg.c
@@ -33,9 +33,9 @@
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvargetg(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvargetg(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvargetg";

--- a/mfhdf/nctest/varput.c
+++ b/mfhdf/nctest/varput.c
@@ -33,9 +33,9 @@
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarput(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarput(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarput";

--- a/mfhdf/nctest/varputg.c
+++ b/mfhdf/nctest/varputg.c
@@ -33,9 +33,9 @@
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarputg(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarputg(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarputg";

--- a/mfhdf/nctest/vartests.c
+++ b/mfhdf/nctest/vartests.c
@@ -34,9 +34,9 @@
  *    try with undefined name, check error
  *    try with bad handle, check error
  */
+/* pathname of writable netcdf file to open */
 void
-test_ncvarid(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarid(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarid";
@@ -110,9 +110,9 @@ test_ncvarid(path)
  *    try with bad variable handle, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarinq(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarinq(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarinq";
@@ -253,9 +253,9 @@ struct cdfelm {			/* coordinates and generic value */
  *    for each existing variable, put values of its type at each point
  *    get values and compare with put values
  */
+/* cdfid - handle of netcdf open and in data mode */
 static int
-test_varputget1(cdfid)
-     int cdfid;			/* handle of netcdf open and in data mode */
+test_varputget1(int cdfid)
 {
     int nerrs = 0;
     static char pname[] = "test_varputget1";
@@ -383,9 +383,9 @@ test_varputget1(cdfid)
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarput1(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarput1(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarput1";
@@ -469,9 +469,9 @@ test_ncvarput1(path)
  *    try in define mode, check error
  *    try with bad netCDF handle, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarget1(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarget1(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarget1";
@@ -555,9 +555,9 @@ test_ncvarget1(path)
  *    try with bad variable handle, check error
  *    try renaming to existing variable name, check error
  */
+/* path - name of writable netcdf file to open */
 void
-test_ncvarrename(path)
-     char *path;		/* name of writable netcdf file to open */
+test_ncvarrename(char *path)
 {
     int nerrs = 0;
     static char pname[] = "test_ncvarrename";

--- a/mfhdf/nctest/vputget.c
+++ b/mfhdf/nctest/vputget.c
@@ -41,9 +41,9 @@
  *      toward the far corner.
  */
 
+/* cdfid - handle of netcdf open and in data mode */
 int
-test_varputget(cdfid)
-     int cdfid;			/* handle of netcdf open and in data mode */
+test_varputget(int cdfid)
 {
     int nerrs = 0;
     static char pname[] = "test_varputget";

--- a/mfhdf/nctest/vputgetg.c
+++ b/mfhdf/nctest/vputgetg.c
@@ -40,9 +40,9 @@
  *      toward the far corner.
  */
 
+/* cdfid - handle of netcdf open and in data mode */
 int
-test_varputgetg(cdfid)
-     int cdfid;			/* handle of netcdf open and in data mode */
+test_varputgetg(int cdfid)
 {
     int nerrs = 0;
     static char pname[] = "test_varputgetg";

--- a/mfhdf/test/cdftest.c
+++ b/mfhdf/test/cdftest.c
@@ -93,10 +93,7 @@ union getret
 } ;
 
 static void
-chkgot(type, got, check)
-nc_type type ;
-union getret got ;
-double check ;
+chkgot(nc_type type, union getret got, double check)
 {
 	switch(type){
 	case NC_BYTE :
@@ -125,11 +122,7 @@ long sizes[] = { NC_UNLIMITED, SIZE_1 , SIZE_2 } ;
 const char *dim_names[] = { "record", "ixx", "iyy"} ;
 
 static void
-createtestdims(cdfid, num_dims, sizes, dim_names)
-int cdfid ;
-int num_dims ;
-long *sizes ;
-const char *dim_names[] ;
+createtestdims(int cdfid, int num_dims, long *sizes, const char *dim_names[])
 {
 	while(num_dims--)
 	{
@@ -140,11 +133,7 @@ const char *dim_names[] ;
 }
 
 static void
-testdims(cdfid, num_dims, sizes, dim_names)
-int cdfid ;
-int num_dims ;
-long *sizes ;
-const char *dim_names[] ;
+testdims(int cdfid, int num_dims, long *sizes, const char *dim_names[])
 {
 	int ii ;
 	long size ;
@@ -210,58 +199,51 @@ struct tcdfvar {
 #define	NUM_TESTVARS	5
 
 static void
-createtestvars(id, testvars, count )
-int id ;
-struct tcdfvar *testvars ;
-int count ;
+createtestvars(int id, struct tcdfvar *testvars, int count)
 {
 	int ii ;
 	struct tcdfvar *vp = testvars ;
 
 	for(ii = 0 ; ii < count ; ii++, vp++ )
 	{
-		assert(ncvardef(id, vp->mnem, vp->type, vp->ndims, vp->dims) == ii ) ; 
+		assert(ncvardef(id, vp->mnem, vp->type, vp->ndims, vp->dims) == ii ) ;
 
 	 	assert(
 			ncattput(id,ii,reqattr[0],NC_CHAR,strlen(vp->units), vp->units)
-			== 0) ; 
+			== 0) ;
 	 	assert(
 			ncattput(id,ii,reqattr[1],NC_DOUBLE,1,
 				(ncvoid*)&(vp->validmin))
-			== 1) ; 
+			== 1) ;
 	 	assert(
 			ncattput(id,ii,reqattr[2],NC_DOUBLE,1,
 				(ncvoid*)&(vp->validmax))
-			== 2) ; 
+			== 2) ;
 	 	assert(
 			ncattput(id,ii,reqattr[3],NC_DOUBLE,1,
 				(ncvoid*)&(vp->scalemin))
-			== 3) ; 
+			== 3) ;
 	 	assert(
 			ncattput(id,ii,reqattr[4],NC_DOUBLE,1,
 				(ncvoid*)&(vp->scalemax))
-			== 4) ; 
+			== 4) ;
 	 	assert(
 			ncattput(id,ii,reqattr[5],NC_CHAR,strlen(vp->fieldnam), vp->fieldnam)
-			== 5) ; 
+			== 5) ;
 	}
 }
 
 static void
-parray(label, count, array)
-char *label ;
-unsigned count ;
-long array[] ;
+parray(char *label, unsigned count, long array[])
 {
 	fprintf(stdout, "%s", label) ;
-	fputc('\t',stdout) ;	
+	fputc('\t',stdout) ;
 	for(; count > 0 ; count--, array++)
 		fprintf(stdout," %d", (int)*array) ;
 }
 
 static void
-fill_seq(id)
-int id ;
+fill_seq(int id)
 {
     long vindices[NUM_DIMS];
 	long *cc, *mm ;
@@ -273,7 +255,7 @@ int id ;
 
 	cc = vindices;
 	while (cc <= &vindices[num_dims-1])
-		*cc++ = 0; 
+		*cc++ = 0;
 
 	/* ripple counter */
 	cc = vindices;
@@ -306,8 +288,7 @@ int id ;
 }
 
 static void
-check_fill_seq(id)
-int id ;
+check_fill_seq(int id)
 {
     long vindices[NUM_DIMS];
 	long *cc, *mm ;
@@ -318,7 +299,7 @@ int id ;
 	sizes[0] = NUM_RECS ;
 	cc = vindices;
 	while (cc <= &vindices[num_dims-1])
-		*cc++ = 0; 
+		*cc++ = 0;
 
 	/* ripple counter */
 	cc = vindices;
@@ -329,7 +310,7 @@ int id ;
 	    {
 		if (mm == &sizes[num_dims - 1])
 		{
-	if(ncvarget1(id, Float_id, vindices, (ncvoid*)&got) == -1) 
+	if(ncvarget1(id, Float_id, vindices, (ncvoid*)&got) == -1)
 		goto bad_ret ;
 	val = ii ;
 	if(val != got.fl[0])
@@ -384,13 +365,7 @@ double zed = 0.0 ;
 FILE *dbg_file;
 #endif
 
-#ifdef PROTOTYPE
 int main(int argc, char *argv[])
-#else
-int main(argc, argv)
-int argc;
-char *argv[];
-#endif
 {
 	int ret ;
 	int	 id ;
@@ -418,13 +393,13 @@ char *argv[];
 		fprintf(stderr, "trying again\n") ;
 		id = nccreate(fname,NC_CLOBBER) ;
 	}
-	if( id == -1 ) 
+	if( id == -1 )
 		exit(errno) ;
 
 #ifdef NOBUF
 	assert( ncnobuf(id) != 1 ) ;
 #endif /* NOBUF */
-	
+
 	assert( ncattput(id, NC_GLOBAL,
 		"TITLE", NC_CHAR, 12, "another name") != -1) ;
 	assert( ncattget(id, NC_GLOBAL,
@@ -443,7 +418,7 @@ char *argv[];
 	createtestdims(id, NUM_DIMS, sizes, dim_names) ;
 	testdims(id, NUM_DIMS, sizes, dim_names) ;
 
-	createtestvars(id, testvars, NUM_TESTVARS) ; 
+	createtestvars(id, testvars, NUM_TESTVARS) ;
 
  	{
  	long lfill = -1 ; double dfill = -9999 ;
@@ -455,7 +430,7 @@ char *argv[];
 
 #ifdef REDEF
 	assert( ncendef(id) != -1 ) ;
-	assert( ncvarput1(id, Long_id, indices[3], (ncvoid *)&birthday) 
+	assert( ncvarput1(id, Long_id, indices[3], (ncvoid *)&birthday)
 		!= -1 ) ;
 	fill_seq(id) ;
 	assert( ncredef(id) != -1 ) ;
@@ -519,18 +494,18 @@ char *argv[];
 	assert( ncnobuf(id) != 1 ) ;
 #endif /* NOBUF */
 
-	/*	NC	*/ 
+	/*	NC	*/
 	printf("NC ") ;
 	assert( ncinquire(id, &(cdesc->num_dims), &(cdesc->num_vars),
 		&(cdesc->num_attrs), &(cdesc->xtendim) ) == id) ;
 	if(cdesc->num_dims != num_dims )
 	{
-		printf(" num_dims  : %d != %d\n", (int)cdesc->num_dims, (int)num_dims ) ; 
+		printf(" num_dims  : %d != %d\n", (int)cdesc->num_dims, (int)num_dims ) ;
 		exit(1) ;
 	}
 	assert(cdesc->num_vars == NUM_TESTVARS) ;
 	printf("done\n") ;
-	
+
 	/*	GATTR	*/
 	printf("GATTR ") ;
 	assert(cdesc->num_attrs == 2) ;
@@ -559,7 +534,7 @@ char *argv[];
 	printf("VAR ") ;
 	assert( cdesc->num_vars == NUM_TESTVARS ) ;
 
-	for(ii = 0 ; ii < cdesc->num_vars ; ii++, tvp++ ) 
+	for(ii = 0 ; ii < cdesc->num_vars ; ii++, tvp++ )
 	{
 		int jj ;
 		assert( ncvarinq(id, ii,
@@ -593,7 +568,7 @@ char *argv[];
 
 		/* VATTR */
 		printf("VATTR\n") ;
-		for(jj=0 ; jj<vdesc->num_attrs ; jj++ ) 
+		for(jj=0 ; jj<vdesc->num_attrs ; jj++ )
 		{
 			assert( ncattname(id, ii, jj, adesc->mnem) == jj) ;
 			if( strcmp(adesc->mnem, reqattr[jj]) != 0 )
@@ -608,7 +583,7 @@ char *argv[];
 			!= -1) {
 		assert( adesc->type == NC_CHAR ) ;
 		assert( adesc->len == strlen(tvp->units) ) ;
-	 	assert( ncattget(id,ii,reqattr[0],(ncvoid *)new) != -1) ; 
+	 	assert( ncattget(id,ii,reqattr[0],(ncvoid *)new) != -1) ;
 		new[adesc->len] = 0 ;
 		assert( strcmp(tvp->units, new) == 0) ;
 		}
@@ -619,7 +594,7 @@ char *argv[];
 		{
 		assert( adesc->type == NC_DOUBLE ) ;
 		assert( adesc->len == 1 ) ;
-	 	assert( ncattget(id,ii,reqattr[1],(ncvoid *)&got) != -1) ; 
+	 	assert( ncattget(id,ii,reqattr[1],(ncvoid *)&got) != -1) ;
 		chkgot(adesc->type, got, tvp->validmin) ;
 		}
 
@@ -629,7 +604,7 @@ char *argv[];
 		{
 		assert( adesc->type == NC_DOUBLE ) ;
 		assert( adesc->len == 1 ) ;
-	 	assert( ncattget(id,ii,reqattr[2],(ncvoid *)&got) != -1) ; 
+	 	assert( ncattget(id,ii,reqattr[2],(ncvoid *)&got) != -1) ;
 		chkgot(adesc->type, got, tvp->validmax) ;
 		}
 
@@ -639,7 +614,7 @@ char *argv[];
 		{
 		assert( adesc->type == NC_DOUBLE ) ;
 		assert( adesc->len ==1 ) ;
-	 	assert( ncattget(id,ii,reqattr[3],(ncvoid *)&got) != -1) ; 
+	 	assert( ncattget(id,ii,reqattr[3],(ncvoid *)&got) != -1) ;
 		chkgot(adesc->type, got, tvp->scalemin) ;
 		}
 
@@ -649,7 +624,7 @@ char *argv[];
 		{
 		assert( adesc->type == NC_DOUBLE ) ;
 		assert( adesc->len == 1 ) ;
-	 	assert( ncattget(id,ii,reqattr[4],(ncvoid *)&got) != -1) ; 
+	 	assert( ncattget(id,ii,reqattr[4],(ncvoid *)&got) != -1) ;
 		chkgot(adesc->type, got, tvp->scalemax) ;
 		}
 
@@ -657,7 +632,7 @@ char *argv[];
 		{
 		assert( adesc->type == NC_CHAR ) ;
 		assert( adesc->len == strlen(tvp->fieldnam) ) ;
-	 	assert( ncattget(id,ii,reqattr[5],(ncvoid *)new) != -1) ; 
+	 	assert( ncattget(id,ii,reqattr[5],(ncvoid *)new) != -1) ;
 		new[adesc->len] = 0 ;
 		assert( strcmp(tvp->fieldnam, new) == 0) ;
 		}

--- a/mfhdf/util/getopt.c
+++ b/mfhdf/util/getopt.c
@@ -29,9 +29,7 @@ int             optopt;
 char           *optarg;
 
 int
-getopt(argc, argv, opts)
-    int             argc;
-    char          **argv, *opts;
+getopt(int argc, char **argv, char *opts)
 {
     static int      sp = 1;
     register int    c;

--- a/mfhdf/xdr/byteordr.c
+++ b/mfhdf/xdr/byteordr.c
@@ -3,8 +3,7 @@
  */
 
 /* switch the order of the bytes in a long integer */
-long ntohl(i_in)
-long i_in;
+long ntohl(long i_in)
 {
 	long i_out;
 	register unsigned char *inptr, *outptr;
@@ -21,8 +20,7 @@ long i_in;
 }
 
 /* switch the order of the bytes in a long integer */
-long htonl(i_in)
-long i_in;
+long htonl(long i_in)
 {
 	long i_out;
 	register unsigned char *inptr, *outptr;
@@ -40,8 +38,7 @@ long i_in;
 
 
 /* switch the order of the bytes in a short integer */
-short ntohs(i_in)
-short i_in;
+short ntohs(short i_in)
 {
 	short i_out;
 	register unsigned char *inptr, *outptr;
@@ -56,8 +53,7 @@ short i_in;
 }
 
 /* switch the order of the bytes in a short integer */
-short htons(i_in)
-short i_in;
+short htons(short i_in)
 {
 	short i_out;
 	register unsigned char *inptr, *outptr;

--- a/mfhdf/xdr/xdr.c
+++ b/mfhdf/xdr/xdr.c
@@ -68,9 +68,7 @@ static const char xdr_zero[BYTES_PER_XDR_UNIT] = { 0, 0, 0, 0 };
  * Not a filter, but a convenient utility nonetheless
  */
 void
-xdr_free(proc, objp)
-    xdrproc_t proc;
-    void *objp;
+xdr_free(xdrproc_t proc, void *objp)
 {
     XDR x;
 
@@ -94,9 +92,7 @@ xdr_void(void /* xdrs, addr */)
  * XDR integers
  */
 bool_t
-xdr_int(xdrs, ip)
-    XDR *xdrs;
-    int *ip;
+xdr_int(XDR *xdrs, int *ip)
 {
     long l;
 
@@ -124,9 +120,7 @@ xdr_int(xdrs, ip)
  * XDR unsigned integers
  */
 bool_t
-xdr_u_int(xdrs, up)
-    XDR *xdrs;
-    u_int *up;
+xdr_u_int(XDR *xdrs, u_int *up)
 {
     u_long l;
 
@@ -154,9 +148,7 @@ xdr_u_int(xdrs, up)
  * XDR long integers
  */
 bool_t
-xdr_long(xdrs, lp)
-    XDR *xdrs;
-    long *lp;
+xdr_long(XDR *xdrs, long *lp)
 {
     switch (xdrs->x_op) {
     case XDR_ENCODE:
@@ -174,9 +166,7 @@ xdr_long(xdrs, lp)
  * XDR unsigned long integers
  */
 bool_t
-xdr_u_long(xdrs, ulp)
-    XDR *xdrs;
-    u_long *ulp;
+xdr_u_long(XDR *xdrs, u_long *ulp)
 {
     switch (xdrs->x_op) {
     case XDR_ENCODE:
@@ -194,9 +184,7 @@ xdr_u_long(xdrs, ulp)
  * XDR 32-bit integers
  */
 bool_t
-xdr_int32_t(xdrs, int32_p)
-    XDR *xdrs;
-    int32_t *int32_p;
+xdr_int32_t(XDR *xdrs, int32_t *int32_p)
 {
     long l;
 
@@ -224,9 +212,7 @@ xdr_int32_t(xdrs, int32_p)
  * XDR unsigned 32-bit integers
  */
 bool_t
-xdr_uint32_t(xdrs, uint32_p)
-    XDR *xdrs;
-    uint32_t *uint32_p;
+xdr_uint32_t(XDR *xdrs, uint32_t *uint32_p)
 {
     u_long l;
 
@@ -255,9 +241,7 @@ xdr_uint32_t(xdrs, uint32_p)
  * XDR short integers
  */
 bool_t
-xdr_short(xdrs, sp)
-    XDR *xdrs;
-    short *sp;
+xdr_short(XDR *xdrs, short *sp)
 {
     long l;
 
@@ -285,9 +269,7 @@ xdr_short(xdrs, sp)
  * XDR unsigned short integers
  */
 bool_t
-xdr_u_short(xdrs, usp)
-    XDR *xdrs;
-    u_short *usp;
+xdr_u_short(XDR *xdrs, u_short *usp)
 {
     u_long l;
 
@@ -316,9 +298,7 @@ xdr_u_short(xdrs, usp)
  * XDR 16-bit integers
  */
 bool_t
-xdr_int16_t(xdrs, int16_p)
-    XDR *xdrs;
-    int16_t *int16_p;
+xdr_int16_t(XDR *xdrs, int16_t *int16_p)
 {
     long l;
 
@@ -346,9 +326,7 @@ xdr_int16_t(xdrs, int16_p)
  * XDR unsigned 16-bit integers
  */
 bool_t
-xdr_uint16_t(xdrs, uint16_p)
-    XDR *xdrs;
-    uint16_t *uint16_p;
+xdr_uint16_t(XDR *xdrs, uint16_t *uint16_p)
 {
     u_long l;
 
@@ -378,9 +356,7 @@ xdr_uint16_t(xdrs, uint16_p)
  * XDR 8-bit integers
  */
 bool_t
-xdr_int8_t(xdrs, int8_p)
-    XDR *xdrs;
-    int8_t *int8_p;
+xdr_int8_t(XDR *xdrs, int8_t *int8_p)
 {
     long l;
 
@@ -409,9 +385,7 @@ xdr_int8_t(xdrs, int8_p)
  * XDR unsigned 8-bit integers
  */
 bool_t
-xdr_uint8_t(xdrs, uint8_p)
-    XDR *xdrs;
-    uint8_t *uint8_p;
+xdr_uint8_t(XDR *xdrs, uint8_t *uint8_p)
 {
     u_long l;
 
@@ -440,9 +414,7 @@ xdr_uint8_t(xdrs, uint8_p)
  * XDR a char
  */
 bool_t
-xdr_char(xdrs, cp)
-    XDR *xdrs;
-    char *cp;
+xdr_char(XDR *xdrs, char *cp)
 {
     int i;
 
@@ -458,9 +430,7 @@ xdr_char(xdrs, cp)
  * XDR an unsigned char
  */
 bool_t
-xdr_u_char(xdrs, cp)
-    XDR *xdrs;
-    u_char *cp;
+xdr_u_char(XDR *xdrs, u_char *cp)
 {
     u_int u;
 
@@ -476,9 +446,7 @@ xdr_u_char(xdrs, cp)
  * XDR booleans
  */
 bool_t
-xdr_bool(xdrs, bp)
-    XDR *xdrs;
-    bool_t *bp;
+xdr_bool(XDR *xdrs, bool_t *bp)
 {
     long lb;
 
@@ -506,9 +474,7 @@ xdr_bool(xdrs, bp)
  * XDR enumerations
  */
 bool_t
-xdr_enum(xdrs, ep)
-    XDR *xdrs;
-    enum_t *ep;
+xdr_enum(XDR *xdrs, enum_t *ep)
 {
     enum sizecheck { SIZEVAL };    /* used to find the size of an enum */
 
@@ -532,10 +498,7 @@ xdr_enum(xdrs, ep)
  * cp points to the opaque object and cnt gives the byte length.
  */
 bool_t
-xdr_opaque(xdrs, cp, cnt)
-    XDR *xdrs;
-    caddr_t cp;
-    u_int cnt;
+xdr_opaque(XDR *xdrs, caddr_t cp, u_int cnt)
 {
     u_int rndup;
     static int crud[BYTES_PER_XDR_UNIT];
@@ -584,11 +547,7 @@ xdr_opaque(xdrs, cp, cnt)
  * If *cpp is NULL maxsize bytes are allocated
  */
 bool_t
-xdr_bytes(xdrs, cpp, sizep, maxsize)
-    XDR *xdrs;
-    char **cpp;
-    u_int *sizep;
-    u_int maxsize;
+xdr_bytes(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize)
 {
     char *sp = *cpp;  /* sp is the actual string pointer */
     u_int nodesize;
@@ -649,9 +608,7 @@ xdr_bytes(xdrs, cpp, sizep, maxsize)
  * Implemented here due to commonality of the object.
  */
 bool_t
-xdr_netobj(xdrs, np)
-    XDR *xdrs;
-    struct netobj *np;
+xdr_netobj(XDR *xdrs, struct netobj *np)
 {
 
     return (xdr_bytes(xdrs, &np->n_bytes, &np->n_len, MAX_NETOBJ_SZ));
@@ -668,13 +625,13 @@ xdr_netobj(xdrs, np)
  * routine may be called.
  * If there is no specific or default routine an error is returned.
  */
+/* dscmp - enum to decide which arm to work on */
+/* unp - the union itself */
+/* choices - [value, xdr proc] for each arm */
+/* dfault - default xdr routine */
 bool_t
-xdr_union(xdrs, dscmp, unp, choices, dfault)
-    XDR *xdrs;
-    enum_t *dscmp;        /* enum to decide which arm to work on */
-    char *unp;        /* the union itself */
-    const struct xdr_discrim *choices;    /* [value, xdr proc] for each arm */
-    xdrproc_t dfault;    /* default xdr routine */
+xdr_union(XDR *xdrs, enum_t *dscmp, char *unp,
+          const struct xdr_discrim *choices, xdrproc_t dfault)
 {
     enum_t dscm;
 
@@ -718,10 +675,7 @@ xdr_union(xdrs, dscmp, unp, choices, dfault)
  * of the string as specified by a protocol.
  */
 bool_t
-xdr_string(xdrs, cpp, maxsize)
-    XDR *xdrs;
-    char **cpp;
-    u_int maxsize;
+xdr_string(XDR *xdrs, char **cpp, u_int maxsize)
 {
     char *sp = *cpp;  /* sp is the actual string pointer */
     u_int size;
@@ -802,9 +756,7 @@ xdr_string(xdrs, cpp, maxsize)
  * routines like clnt_call
  */
 bool_t
-xdr_wrapstring(xdrs, cpp)
-    XDR *xdrs;
-    char **cpp;
+xdr_wrapstring(XDR *xdrs, char **cpp)
 {
     return xdr_string(xdrs, cpp, RPC_MAXDATASIZE);
 }
@@ -821,9 +773,7 @@ xdr_wrapstring(xdrs, cpp)
  * XDR 64-bit integers
  */
 bool_t
-xdr_int64_t(xdrs, llp)
-    XDR *xdrs;
-    int64_t *llp;
+xdr_int64_t(XDR *xdrs, int64_t *llp)
 {
     u_long ul[2];
 
@@ -855,9 +805,7 @@ xdr_int64_t(xdrs, llp)
  * XDR unsigned 64-bit integers
  */
 bool_t
-xdr_uint64_t(xdrs, ullp)
-    XDR *xdrs;
-    uint64_t *ullp;
+xdr_uint64_t(XDR *xdrs, uint64_t *ullp)
 {
     u_long ul[2];
 
@@ -889,11 +837,8 @@ xdr_uint64_t(xdrs, ullp)
  * XDR hypers
  */
 bool_t
-xdr_hyper(xdrs, llp)
-    XDR *xdrs;
-    longlong_t *llp;
+xdr_hyper(XDR *xdrs, longlong_t *llp)
 {
-
     /*
     * Don't bother open-coding this; it's a fair amount of code.  Just
     * call xdr_int64_t().
@@ -906,11 +851,8 @@ xdr_hyper(xdrs, llp)
  * XDR unsigned hypers
  */
 bool_t
-xdr_u_hyper(xdrs, ullp)
-    XDR *xdrs;
-    u_longlong_t *ullp;
+xdr_u_hyper(XDR *xdrs, u_longlong_t *ullp)
 {
-
     /*
     * Don't bother open-coding this; it's a fair amount of code.  Just
     * call xdr_uint64_t().
@@ -923,9 +865,7 @@ xdr_u_hyper(xdrs, ullp)
  * XDR longlong_t's
  */
 bool_t
-xdr_longlong_t(xdrs, llp)
-    XDR *xdrs;
-    longlong_t *llp;
+xdr_longlong_t(XDR *xdrs, longlong_t *llp)
 {
 
     /*
@@ -940,9 +880,7 @@ xdr_longlong_t(xdrs, llp)
  * XDR u_longlong_t's
  */
 bool_t
-xdr_u_longlong_t(xdrs, ullp)
-    XDR *xdrs;
-    u_longlong_t *ullp;
+xdr_u_longlong_t(XDR *xdrs, u_longlong_t *ullp)
 {
 
     /*
@@ -956,9 +894,7 @@ xdr_u_longlong_t(xdrs, ullp)
  * XDR quad_t
  */
 bool_t
-xdr_quad_t(xdrs, llp)
-    XDR *xdrs;
-    int64_t *llp;
+xdr_quad_t(XDR *xdrs, int64_t *llp)
 {
     return (xdr_int64_t(xdrs, (int64_t *)llp));
 }
@@ -968,9 +904,7 @@ xdr_quad_t(xdrs, llp)
  * XDR u_quad_t
  */
 bool_t
-xdr_u_quad_t(xdrs, ullp)
-    XDR *xdrs;
-    uint64_t *ullp;
+xdr_u_quad_t(XDR *xdrs, uint64_t *ullp)
 {
     return (xdr_uint64_t(xdrs, (uint64_t *)ullp));
 }

--- a/mfhdf/xdr/xdrarray.c
+++ b/mfhdf/xdr/xdrarray.c
@@ -59,14 +59,13 @@ static char sccsid[] = "@(#)xdr_array.c 1.10 87/08/11 Copyr 1984 Sun Micro";
  * elsize is the size (in bytes) of each element, and elproc is the
  * xdr procedure to call to handle each element of the array.
  */
+/* addrp - array pointer */
+/* sizep - number of elements */
+/* maxsize - max numberof elements */
+/* elsize - size in bytes of each element */
+/* elproc - xdr routine to handle each element */
 bool_t
-xdr_array(xdrs, addrp, sizep, maxsize, elsize, elproc)
-    XDR *xdrs;
-    caddr_t *addrp;        /* array pointer */
-    u_int *sizep;        /* number of elements */
-    u_int maxsize;        /* max numberof elements */
-    u_int elsize;        /* size in bytes of each element */
-    xdrproc_t elproc;    /* xdr routine to handle each element */
+xdr_array(XDR *xdrs, caddr_t *addrp, u_int *sizep, u_int maxsize, u_int elsize, xdrproc_t elproc)
 {
     u_int i;
     caddr_t target = *addrp;
@@ -136,12 +135,7 @@ xdr_array(xdrs, addrp, sizep, maxsize, elsize, elproc)
  * > xdr_elem: routine to XDR each element
  */
 bool_t
-xdr_vector(xdrs, basep, nelem, elemsize, xdr_elem)
-    XDR *xdrs;
-    char *basep;
-    u_int nelem;
-    u_int elemsize;
-    xdrproc_t xdr_elem;
+xdr_vector(XDR *xdrs, char *basep, u_int nelem, u_int elemsize, xdrproc_t xdr_elem)
 {
     u_int i;
     char *elptr;

--- a/mfhdf/xdr/xdrfloat.c
+++ b/mfhdf/xdr/xdrfloat.c
@@ -46,9 +46,7 @@
 #include "xdr.h"
 
 bool_t
-xdr_float(xdrs, fp)
-    XDR *xdrs;
-    float *fp;
+xdr_float(XDR *xdrs, float *fp)
 {
     switch (xdrs->x_op) {
 
@@ -65,9 +63,7 @@ xdr_float(xdrs, fp)
 }
 
 bool_t
-xdr_double(xdrs, dp)
-    XDR *xdrs;
-    double *dp;
+xdr_double(XDR *xdrs, double *dp)
 {
     int32_t *i32p;
     bool_t rv;

--- a/mfhdf/xdr/xdrstdio.c
+++ b/mfhdf/xdr/xdrstdio.c
@@ -92,10 +92,7 @@ static const struct xdr_ops   xdrstdio_ops = {
  * Operation flag is set to op.
  */
 void
-xdrstdio_create(xdrs, file, op)
-    XDR *xdrs;
-    FILE *file;
-    enum xdr_op op;
+xdrstdio_create(XDR *xdrs, FILE *file, enum xdr_op op)
 {
     xdrs->x_op = op;
     xdrs->x_ops = &xdrstdio_ops;
@@ -109,17 +106,14 @@ xdrstdio_create(xdrs, file, op)
  * Cleans up the xdr stream handle xdrs previously set up by xdrstdio_create.
  */
 static void
-xdrstdio_destroy(xdrs)
-    XDR *xdrs;
+xdrstdio_destroy(XDR *xdrs)
 {
     (void)fflush((FILE *)xdrs->x_private);
     /* xx should we close the file ?? */
 }
 
 static bool_t
-xdrstdio_getlong(xdrs, lp)
-    XDR *xdrs;
-    long *lp;
+xdrstdio_getlong(XDR *xdrs, long *lp)
 {
     int32_t mycopy;
 
@@ -131,9 +125,7 @@ xdrstdio_getlong(xdrs, lp)
 }
 
 static bool_t
-xdrstdio_putlong(xdrs, lp)
-    XDR *xdrs;
-    const long *lp;
+xdrstdio_putlong(XDR *xdrs, const long *lp)
 {
     int32_t mycopy;
 
@@ -149,10 +141,7 @@ xdrstdio_putlong(xdrs, lp)
 }
 
 static bool_t
-xdrstdio_getbytes(xdrs, addr, len)
-    XDR *xdrs;
-    char *addr;
-    u_int len;
+xdrstdio_getbytes(XDR *xdrs, char *addr, u_int len)
 {
 
     if ((len != 0) && (fread(addr, (size_t)len, 1, (FILE *)xdrs->x_private) != 1))
@@ -161,10 +150,7 @@ xdrstdio_getbytes(xdrs, addr, len)
 }
 
 static bool_t
-xdrstdio_putbytes(xdrs, addr, len)
-    XDR *xdrs;
-    const char *addr;
-    u_int len;
+xdrstdio_putbytes(XDR *xdrs, const char *addr, u_int len)
 {
 
     if ((len != 0) && (fwrite(addr, (size_t)len, 1,
@@ -174,17 +160,14 @@ xdrstdio_putbytes(xdrs, addr, len)
 }
 
 static u_int
-xdrstdio_getpos(xdrs)
-    XDR *xdrs;
+xdrstdio_getpos(XDR *xdrs)
 {
 
     return ((u_int)ftell((FILE *)xdrs->x_private));
 }
 
 static bool_t
-xdrstdio_setpos(xdrs, pos)
-    XDR *xdrs;
-    u_int pos;
+xdrstdio_setpos(XDR *xdrs, u_int pos)
 {
 
     return ((fseek((FILE *)xdrs->x_private, (long)pos, 0) < 0) ?
@@ -193,9 +176,7 @@ xdrstdio_setpos(xdrs, pos)
 
 /* ARGSUSED */
 static int32_t *
-xdrstdio_inline(xdrs, len)
-    XDR *xdrs;
-    u_int len;
+xdrstdio_inline(XDR *xdrs, u_int len)
 {
 
     /*

--- a/mfhdf/xdr/xdrtest.c
+++ b/mfhdf/xdr/xdrtest.c
@@ -38,9 +38,7 @@
 #define EPSILON .0005
 #endif /* __FreeBSD__ */
 
-int main(ac,av)
-int ac ;
-char *av[] ;
+int main(int ac, char *av[])
 {
     int ii ;
     const char *fname ;


### PR DESCRIPTION
Converts old style K & R function definitions to ANSI style.

- Converts old style K & R function definitions to ANSI style.
- Does not change any of the headers or local file prototypes.
- Does not fix some varargs
 
The changes are generally of this form:

```diff
-xdrposix_putint(xdrs, lp)
-    XDR *xdrs;
-    int *lp;
+xdrposix_putint(XDR *xdrs, int *lp)
```