### PR TITLE
Removed implicit declaration warning of HDiscdf/HDisnetcdf/HDisnetcdf64

### DIFF
--- a/mfhdf/libsrc/local_nc.h
+++ b/mfhdf/libsrc/local_nc.h
@@ -825,15 +825,6 @@ HDFLIBAPI bool_t nssdc_write_cdf
 HDFLIBAPI bool_t nssdc_xdr_cdf
     PROTO((XDR *xdrs, NC **handlep));
 
-HDFLIBAPI intn HDiscdf
-    (const char *filename);
-
-HDFLIBAPI intn HDisnetcdf
-    (const char *filename);
-
-HDFLIBAPI intn HDisnetcdf64
-    (const char *filename);
-
 #endif /* HDF */
 
 #ifdef __cplusplus

--- a/mfhdf/libsrc/mfhdf.h
+++ b/mfhdf/libsrc/mfhdf.h
@@ -241,6 +241,15 @@ HDFLIBAPI intn SDgetfilename
 HDFLIBAPI intn SDgetnamelen
     (int32 sdsid, uint16 *name_len);
 
+HDFLIBAPI intn HDiscdf
+    (const char *filename);
+
+HDFLIBAPI intn HDisnetcdf
+    (const char *filename);
+
+HDFLIBAPI intn HDisnetcdf64
+    (const char *filename);
+
 /*====================== Chunking Routines ================================*/
 
 /* For definition of HDF_CHUNK_DEF union see hproto.h since


### PR DESCRIPTION
Description:
    Moved the declaration of HDiscdf, HDisnetcdf, HDisnetcdf64 from
    a private header to a public one.  They are used in tests and
    can be used by user applications.