### PR TITLE
Porting to m1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -788,6 +788,19 @@ if test "X$BUILD_FORTRAN" = "Xyes"; then
   AC_PROG_F77_C_O
 fi
 
+## ======================================================================
+## Data types and their sizes.
+## ======================================================================
+AC_CHECK_SIZEOF([char])
+AC_CHECK_SIZEOF([short])
+AC_CHECK_SIZEOF([int])
+AC_CHECK_SIZEOF([unsigned])
+AC_CHECK_SIZEOF([long])
+AC_CHECK_SIZEOF([long long])
+AC_CHECK_SIZEOF([float])
+AC_CHECK_SIZEOF([double])
+AC_CHECK_SIZEOF([long double])
+
 ## This is a bit of a hack. The AC_CHECK_SIZEOF macro is supposed to
 ## #define a value in a header file. However, we don't use a generated
 ## header file. So I check the value left over from autoconf's test  is

--- a/hdf/src/hconv.h
+++ b/hdf/src/hconv.h
@@ -57,8 +57,8 @@
 /*****************************************************************************/
 /* CONSTANT DEFINITIONS                                                      */
 /*****************************************************************************/
-/* Generally Big-Endian machines */
-#if !defined(INTEL86) && !defined(MIPSEL) && !defined(DEC_ALPHA) && !defined(I860) && !defined(SUN386) && !(defined(__ia64) && !(defined(hpux) || defined(__hpux))) && !defined(__x86_64__)
+/* Big-Endian machines */
+#ifdef __BIG_ENDIAN__
 #       define UI8_IN     DFKnb1b   /* Unsigned Integer, 8 bits */
 #       define UI8_OUT    DFKnb1b
 #       define SI16_IN    DFKnb2b   /* S = Signed */
@@ -89,7 +89,7 @@
 #       define LF64_IN    DFKsb8b
 #       define LF64_OUT   DFKsb8b
 
-#else  /* must be INTEL86 || MIPSEL || DEC_ALPHA || I860 || SUN386 || IA64 || Linux64 (Generally, little-endian machines */
+#else
 #   define UI8_IN     DFKnb1b   /* Big-Endian IEEE support */
 #   define UI8_OUT    DFKnb1b   /* The s in DFKsb2b is for swap */
 #   define SI16_IN    DFKsb2b

--- a/mfhdf/libsrc/netcdf.h.in
+++ b/mfhdf/libsrc/netcdf.h.in
@@ -292,16 +292,11 @@ typedef double        ncdouble;
 /*
  * Variables/attributes of type NC_LONG should use the C type 'nclong'
  */
-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__
-/*
- * LP64 (also known as 4/8/8) denotes long and pointer as 64 bit types.
- * http://www.unix.org/version2/whatsnew/lp64_wp.html
- */
+#if (H4_SIZEOF_LONG == 8)
 typedef int     nclong;
 #else
 typedef long    nclong;         /* default, compatible type */
 #endif
-
 
 /*
  * Global netcdf error status variable


### PR DESCRIPTION
Description:
    - added definition for type sizes
    - replaced some of the #ifdef machines by features
Platforms Tested:
    Darwin (m1) both hdf and mfhdf tests passed