### PR TITLE
putget.c: nc_API: Be explicit about returning FALSE if caller is null

### DIFF
--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -81,6 +81,7 @@ static bool_t nc_API(const char *caller)
     nc_api = strstr(caller, "nc");
     if (nc_api == caller)
         return TRUE;
+    return FALSE;
 }
 
 /*


### PR DESCRIPTION
I originally hit this when I updated hdf4 to 4.2.13 back in 2018