### PR TITLE
Disables the Fortran interface by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,12 +566,15 @@ endif ()
 # Option to build Fortran bindings/tests/examples
 # Make sure this appears before the CONFIGURE_FILE step
 # so that fortran name mangling is detected before writing H4config.h
+#
+# This interface is UNSAFE on 64-bit systems as the interface attempts to
+# store pointers in 32-bit integers.
 #-----------------------------------------------------------------------------
 # Set default name mangling : overridden by Fortran detection in fortran dir
 set (H4_F77_FUNC "H4_F77_FUNC(name,NAME) name ## _")
 set (H4_F77_FUNC_ "H4_F77_FUNC_(name,NAME) name ## __")
 if (EXISTS "${HDF4_SOURCE_DIR}/mfhdf/fortran" AND IS_DIRECTORY "${HDF4_SOURCE_DIR}/mfhdf/fortran")
-  option (HDF4_BUILD_FORTRAN "Build FORTRAN support" ON)
+  option (HDF4_BUILD_FORTRAN "Build FORTRAN support" OFF)
   if (HDF4_BUILD_FORTRAN)
     if (WIN32)
       set (H4_F77_FUNC "H4_F77_FUNC(name,NAME) NAME")

--- a/configure.ac
+++ b/configure.ac
@@ -209,10 +209,17 @@ AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_CXX
 
+## ----------------------------------------------------------------------
+## Check if they would like the Fortran interface compiled
+##
+## This interface is UNSAFE on 64-bit systems as the interface will
+## attempt to store pointers in 32-bit integers.
+##
 AC_ARG_ENABLE([fortran],
               [AS_HELP_STRING([--enable-fortran],
-                              [Build Fortran into library [default=yes]])],,
-              [enableval="yes"])
+                              [Build Fortran into library. This interface
+                               is unsafe on 64-bit systems. [default=no]])],,
+              [enableval="no"])
 
 case "$enableval" in
   yes)

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -38,6 +38,14 @@ New features and changes
 ========================
     Configuration:
     -------------
+    - The Fortran interface is disabled by default
+
+      The Fortran interface is unsafe on 32-bit systems as it stores pointers
+      in 32-bit integers. It will be removed in a future release, but for now
+      it will be disabled by default in both CMake and the Autotools.
+
+      (ADB - 2023/01/12)
+
     - Corrected path searched by CMake find_package command
 
       The install path for cmake find_package files had been changed to use


### PR DESCRIPTION
The Fortran interface stores pointers in 32-bit integers and is thus unsafe on 64-bit systems.