### PR TITLE
Remove DATAINFO macros

### DIFF
--- a/mfhdf/libsrc/mfdatainfo.h
+++ b/mfhdf/libsrc/mfdatainfo.h
@@ -16,9 +16,6 @@
 
 #include "H4api_adpt.h"
 
-/* Activate raw datainfo interface - added for hmap project in 2010 */
-#if defined DATAINFO_MASTER || defined DATAINFO_TESTER
-
 #if defined c_plusplus || defined __cplusplus
 extern      "C"
 {
@@ -43,5 +40,4 @@ HDFLIBAPI intn SDgetanndatainfo
 #if defined c_plusplus || defined __cplusplus
 }
 #endif /* c_plusplus || __cplusplus */
-#endif /* DATAINFO_MASTER || DATAINFO_TESTER */
 #endif /* _MF_DATAINFO */

--- a/mfhdf/test/hdftest.h
+++ b/mfhdf/test/hdftest.h
@@ -52,6 +52,9 @@
 
 /*************************** Utility Functions ***************************/
 
+/* Generates the correct name for the test file */
+intn make_datafilename(char* basename, char* testfile, unsigned int size);
+
 /* Calls SDcreate, SDwritedata, and SDendaccess */
 int32 make_SDS(int32 sd_id, char* sds_name, int32 type, int32 rank,
 			  int32* dim_sizes, int32 unlim_dim, VOIDP written_data);
@@ -73,6 +76,9 @@ int32 append_Data2SDS(int32 sd_id, char* sds_name, int32* start, int32* edges, v
 
 /* Calls SDgetdatasize then verify the size against data_size */
 void verify_datasize(int32 sds_id, int32 data_size, char* sds_name);
+
+/* Verifies the unlimited dimension's size and the variable's data. */
+int verify_info_data(int32 sds_id, int32 expected_dimsize, int16 *result);
 
 /* Find and open an SDS by name */
 int32 get_SDSbyName(int32 sd_id, char* sds_name);

--- a/mfhdf/test/tattdatainfo.c
+++ b/mfhdf/test/tattdatainfo.c
@@ -22,10 +22,6 @@
  * -BMR, Jul 2010
 ****************************************************************************/
 
-#ifndef DATAINFO_TESTER
-#define DATAINFO_TESTER /* to include mfdatainfo.h */
-#endif
-
 #include "mfhdf.h"
 #include "hdftest.h"
 

--- a/mfhdf/test/tdatainfo.c
+++ b/mfhdf/test/tdatainfo.c
@@ -44,10 +44,6 @@
 #define ssize_t int32
 #endif
 
-#ifndef DATAINFO_TESTER
-#define DATAINFO_TESTER /* to include mfdatainfo.h */
-#endif
-
 #ifdef H4_HAVE_LIBSZ
 #include "szlib.h"
 #endif


### PR DESCRIPTION
They were added to not include functions for hmap project at the beginning (2010).  This is not longer necessary.