### PR TITLE
Brings HDF5's Autotools maintainer mode scheme over

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -319,6 +319,15 @@ release_date=`date +%F`
 today=`date +%Y%m%d`
 pmode='no'
 tmpdir="../#release_tmp.$$"    # tmp work directory
+MAINT_MODE_ENABLED=""
+
+# If maintainer mode is enabled in configure, it should be disabled for release,
+# and enabled again after release files have been created.  If already disabled
+# there's no need to do either.
+MAINT_MODE_ENABLED=`grep ^AM_MAINTAINER_MODE ./configure.ac | grep enable`
+if [ "${MAINT_MODE_ENABLED}" != "" ]; then
+    bin/switch_maint_mode -disable ./configure.ac
+fi
 
 # Restore previous Version information
 RESTORE_VERSION()
@@ -456,6 +465,12 @@ for comp in $methods; do
             ;;
     esac
 done
+
+# If AM_MAINTAINER_MODE was enabled before running this script
+# restore it to "enabled".
+if [ "${MAINT_MODE_ENABLED}" != "" ]; then
+    bin/switch_maint_mode -enable ./configure.ac
+fi
 
 # Copy the RELEASE.txt to the release area.
 cp release_notes/RELEASE.txt $DEST/$HDF4_VERS-RELEASE.txt

--- a/bin/switch_maint_mode
+++ b/bin/switch_maint_mode
@@ -1,0 +1,77 @@
+#!/bin/sh
+#
+# Copyright by The HDF Group.
+# Copyright by the Board of Trustees of the University of Illinois.
+# All rights reserved.
+#
+# This file is part of HDF.  The full HDF copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the COPYING file, which can be found at the root of the source code
+# distribution tree, or in https://support.hdfgroup.org/ftp/HDF/releases/.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+#
+
+USAGE()
+{
+cat <<EOF
+
+switch_maint_mode reverses the status of AM_MAINTAINER_MODE in
+configure.ac from enable to disable or vice-versa. When enabled,
+this feature forces the autotools to run when the input files are
+older than the output files. This is the default for development
+branches. When disabled, the autotools will NOT be re-run regardless
+of their timestamps or any modifications. This is the default for
+tarballs and release branches since it avoids having end-users
+requiring the autotools.
+
+Command Syntax
+==============
+switch_maint_mode [-help] [-enable|disable] <path-to-configure.ac>
+
+EOF
+}
+
+MODE="notset"
+CONFIG_AC_PATH=
+
+# Display help/usage if any options were passed in
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -enable)
+        MODE="enable"
+        ;;
+    -disable)
+        MODE="disable"
+        ;;
+	-help)
+	    USAGE
+	    exit 0
+	    ;;
+    *)
+	    CONFIG_AC_PATH="$1"
+	    ;;
+    esac
+    shift
+done
+
+# Did we get a file path?
+if test -z $CONFIG_AC_PATH ; then
+    USAGE
+    exit 1
+fi
+
+# Did we get a mode?
+if test -z $MODE ; then
+    USAGE
+    exit 1
+fi
+
+# Run perl over configure.ac
+if test "X-$MODE" = "X-enable" ; then
+    perl -pi -e 's/^(AM_MAINTAINER_MODE\(\[)([a-z]+)(\]\))/$1enable$3/g' $CONFIG_AC_PATH
+fi
+if test "X-$MODE" = "X-disable" ; then
+    perl -pi -e 's/^(AM_MAINTAINER_MODE\(\[)([a-z]+)(\]\))/$1disable$3/g' $CONFIG_AC_PATH
+fi
+

--- a/configure.ac
+++ b/configure.ac
@@ -40,17 +40,46 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) # use silent rules where available - automake 1.11
 
-## AM_MAINTAINER_MODE turns off "rebuild rules" that contain dependencies
-## for Makefiles, configure, etc.  If AM_MAINTAINER_MODE
-## is *not* included here, these files will be rebuilt if out of date.
-## This is a problem because if users try to build on a machine with
-## the wrong versions of autoconf and automake, these files will be
-## rebuilt with the wrong versions and bad things can happen.
-## Also, CVS doesn't preserve dependencies between timestamps, so
-## Makefiles will often think rebuilding needs to occur when it doesn't.
-## Developers should './configure --enable-maintainer-mode' to turn on
-## rebuild rules.
-AM_MAINTAINER_MODE
+## AM_MAINTAINER_MODE determines the behavior of "rebuild rules" that contain
+## dependencies for Makefile.in files, configure, src/H5config.h, etc. If
+## AM_MAINTAINER_MODE is enabled, these files will be rebuilt if out of date.
+## When disabled, the autotools build files can get out of sync and the build
+## system will not complain or try to regenerate downstream files.
+##
+## The AM_MAINTAINER_MODE macro also determines whether the
+## --(enable|disable)-maintainer-mode configure option is available. When the
+## macro is present, with or without a parameter, the option will be added
+## to the generated configure script.
+##
+## In summary:
+##
+##  AM_MAINTAINER_MODE([enable])
+##      - Build dependencies ON by default
+##      - Configure option exists
+##
+##  AM_MAINTAINER_MODE([disable])
+##      - Build dependencies OFF by default
+##      - Configure option exists
+##
+##  AM_MAINTAINER_MODE
+##      - Build dependencies OFF by default
+##      - Configure option exists
+##
+##  No AM_MAINTAINER_MODE macro
+##      - Build dependencies ON by default
+##      - No configure option to control build dependencies
+##
+## The biggest concern for us is that version control systems like git
+## usually don't preserve dependencies between timestamps, so the build
+## system will often think that upstream build files like Makefile.am are
+## dirty and that rebuilding needs to occur when it doesn't. This is a problem
+## in release branches where we provide the autotools-generated files. Users
+## who don't have autoconf, automake, etc. will then have difficulty building
+## release branches checked out from git.
+##
+## By default, maintainer mode is enabled in development branches and disabled
+## in release branches.
+AM_MAINTAINER_MODE([enable])
 
 ## ----------------------------------------------------------------------
 ## Set prefix default (install directory) to a directory in the build area.

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -38,6 +38,28 @@ New features and changes
 ========================
     Configuration:
     -------------
+    - Changed how maintainer mode works in the Autotools
+
+    The macro has changed from AM_MAINTAINER_MODE to
+    AM_MAINTAINER_MODE([enable]) in master and AM_MAINTAINER_MODE([disable])
+    at release time. The main change is that build dependencies will be ON
+    by default in master so out-of-date configure, Makefile.in will be
+    regenerated when their input files (configure.ac, Makefile.am, etc.)
+    change.
+
+    We previously used the macro with no parameter since we checked in the
+    Autotools-generated files. This allowed switching on maintainer mode
+    with a command-line option, but left maintainer mode off to avoid
+    regenerating the build files when checking out from git did not
+    preserve timestamps, making the files look out-of-date. Now that we no
+    longer check in Autotools-geneated files, we can turn the
+    dependencies on.
+
+    Detailed comments about the behavior of this macro have been added to
+    configure.ac where we define the macro.
+
+    (DER - 2023/01/13)
+
     - Removed the hdf/util/MacProjects directory
 
     It's unclear what build system these were for, but they have been


### PR DESCRIPTION
Now that we don't check in the Autotools-generated files we can bring over HDF5's scheme, which turns on maintainer mode by default. This will force a regeneration of configure, Makefile.in, etc. when their input files (configure.ac, Makefile.am) change.

We'll have to switch it at release time, so I brought over the script from HDF5 and updated bin/release to run it.