### PR TITLE
Remove error_top from public API, revert HEClear back to a function

### DIFF
--- a/hdf/src/herr.c
+++ b/hdf/src/herr.c
@@ -35,6 +35,9 @@ EXPORTED ROUTINES
  */
 #include <stdarg.h>
 
+/* always points to the next available slot; the last error record is in slot (top-1) */
+   static int32 error_top = 0;
+
 /* We use a stack to hold the errors plus we keep track of the function,
    file and line where the error occurs. */
 
@@ -100,7 +103,7 @@ DESCRIPTION
 
 ---------------------------------------------------------------------------*/
 VOID
-HEPclear(void)
+HEclear(void)
 {
     if (!error_top)
         goto done;
@@ -116,7 +119,7 @@ HEPclear(void)
 
 done:
     return;
-} /* HEPclear */
+} /* HEclear */
 
 /*-------------------------------------------------------------------------
 NAME

--- a/hdf/src/herr.c
+++ b/hdf/src/herr.c
@@ -36,7 +36,7 @@ EXPORTED ROUTINES
 #include <stdarg.h>
 
 /* always points to the next available slot; the last error record is in slot (top-1) */
-   static int32 error_top = 0;
+static int32 error_top = 0;
 
 /* We use a stack to hold the errors plus we keep track of the function,
    file and line where the error occurs. */

--- a/hdf/src/herr.h
+++ b/hdf/src/herr.h
@@ -133,38 +133,6 @@
         goto done;                                                                                           \
     }
 
-/* always points to the next available slot; the last error record is in slot (top-1) */
-#if defined(H4_BUILT_AS_DYNAMIC_LIB)
-#ifdef _H_ERR_MASTER_
-#if defined H4_HAVE_WIN32_API && defined hdf_shared_EXPORTS
-__declspec(dllexport)
-#endif
-#else
-HDFERRPUBLIC
-#endif /* _H_ERR_MASTER_ */
-    int32 error_top
-#ifdef _H_ERR_MASTER_
-    = 0
-#endif /* _H_ERR_MASTER_ */
-    ;
-#else /* defined(H4_BUILT_AS_DYNAMIC_LIB) */
-#ifndef _H_ERR_MASTER_
-HDFERRPUBLIC
-#endif /* _H_ERR_MASTER_ */
-int32 error_top
-#ifdef _H_ERR_MASTER_
-    = 0
-#endif /* _H_ERR_MASTER_ */
-    ;
-#endif /* defined(H4_BUILT_AS_DYNAMIC_LIB) */
-
-/* Macro to wrap around calls to HEPclear, so it doesn't get called zillions of times */
-#define HEclear()                                                                                            \
-    {                                                                                                        \
-        if (error_top != 0)                                                                                  \
-            HEPclear();                                                                                      \
-    }
-
 /*
    ======================================================================
    Error codes

--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -419,7 +419,7 @@ HDFLIBAPI void HEprint(FILE *stream, int32 print_level);
 
 HDFLIBAPI int16 HEvalue(int32 level);
 
-HDFLIBAPI void HEPclear(void);
+HDFLIBAPI void HEclear(void);
 
 HDFLIBAPI intn HEshutdown(void);
 


### PR DESCRIPTION
HEClear was a function until error_top was exposed (and build complexity increased) for a macro that wrapped the function. The function checks the state of error_top first thing anyway. Complexity and unneeded public variable is not worth saving a function call.