### PR TITLE
Update warnings filter for new extlib builds from fetchcontent

### DIFF
--- a/config/cmake/CTestCustom.cmake
+++ b/config/cmake/CTestCustom.cmake
@@ -5,9 +5,12 @@ set (CTEST_CUSTOM_WARNING_EXCEPTION
     ${CTEST_CUSTOM_WARNING_EXCEPTION}
     ".*note.*expected.*void.*but argument is of type.*volatile.*"
     "src.ZLIB.*:[ \t]*warning"
+    "zlib-src.*:[ \t]*warning"
     "warning LNK4197:.*ZLIB-prefix"
+    "szip-src.*:[ \t]*warning"
     "src.SZIP.*:[ \t]*warning"
     "warning LNK4197:.*SZIP-prefix"
+    "jpeg-src.*:[ \t]*warning"
     "src.JPEG.*:[ \t]*warning"
     "warning LNK4197:.*JPEG-prefix"
     ".*POSIX name for this item is deprecated.*"

--- a/config/cmake/CTestCustom.cmake
+++ b/config/cmake/CTestCustom.cmake
@@ -1,22 +1,28 @@
 # CTestCustom.cmake
-set (CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1500)
+set (CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 3000)
 
 set (CTEST_CUSTOM_WARNING_EXCEPTION
     ${CTEST_CUSTOM_WARNING_EXCEPTION}
     ".*note.*expected.*void.*but argument is of type.*volatile.*"
-    "src.ZLIB.*:[ \t]*warning"
-    "zlib-src.*:[ \t]*warning"
-    "warning LNK4197:.*ZLIB-prefix"
-    "szip-src.*:[ \t]*warning"
-    "src.SZIP.*:[ \t]*warning"
-    "warning LNK4197:.*SZIP-prefix"
-    "jpeg-src.*:[ \t]*warning"
-    "src.JPEG.*:[ \t]*warning"
-    "warning LNK4197:.*JPEG-prefix"
+    ".*src.SZIP.*"
+    ".*src.ZLIB.*"
+    ".*src.JPEG.*"
+    ".*szip.src.*"
+    ".*zlib.src.*"
+    ".*jpeg.src.*"
     ".*POSIX name for this item is deprecated.*"
     ".*disabling jobserver mode.*"
     ".*warning.*implicit declaration of function.*"
     ".*note: expanded from macro.*"
+    "note.*expected.*void.*but argument is of type.*volatile.*"
+    "stamp.verify"
+    "CMake Warning*stamp"
+    "warning LNK4197:.*ZLIB-prefix"
+    "warning LNK4197:.*SZIP-prefix"
+    "warning LNK4197:.*JPEG-prefix"
+    "POSIX name for this item is deprecated.*"
+    "disabling jobserver mode.*"
+#    "note: expanded from macro.*"
 )
 
 set (CTEST_CUSTOM_MEMCHECK_IGNORE
@@ -106,22 +112,4 @@ set (CTEST_CUSTOM_MEMCHECK_IGNORE
     NC_TEST-clearall-objects
     HEDIT-hdfed.input1
     HEDIT-ristosds.input1
-)
-
-set (CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 3000)
-
-set (CTEST_CUSTOM_WARNING_EXCEPTION
-    ${CTEST_CUSTOM_WARNING_EXCEPTION}
-    ".*note.*expected.*void.*but argument is of type.*volatile.*"
-    ".*src.SZIP.*:[ \t]*warning.*"
-    ".*src.ZLIB.*:[ \t]*warning.*"
-    ".*src.JPEG.*:[ \t]*warning.*"
-    ".*POSIX name for this item is deprecated.*"
-    ".*disabling jobserver mode.*"
-    ".*warning.*implicit declaration of function.*"
-    ".*note: expanded from macro.*"
-)
-
-set (CTEST_CUSTOM_MEMCHECK_IGNORE
-    ${CTEST_CUSTOM_MEMCHECK_IGNORE}
 )

--- a/hdf/src/bitvect.c
+++ b/hdf/src/bitvect.c
@@ -446,7 +446,6 @@ bv_find(bv_ptr b, int32 last_find, bv_bool value)
     if (value == BV_TRUE) {   /* looking for first '1' in the bit-vector */
         if (last_find >= 0) { /* if the last bit found option is used, look for more bits in that same byte */
             intn bit_off;
-            int  unused;
 
             first_byte = (uint32)last_find / BV_BASE_BITS;
             bit_off    = (intn)(((uint32)last_find - (first_byte * BV_BASE_BITS)) + 1);

--- a/hdf/src/cdeflate.c
+++ b/hdf/src/cdeflate.c
@@ -558,16 +558,12 @@ HCPcdeflate_read(accrec_t *access_rec, int32 length, void *data)
     CONSTR(FUNC, "HCPcdeflate_read");
     compinfo_t                *info;         /* special element information */
     comp_coder_deflate_info_t *deflate_info; /* ptr to gzip 'deflate' info */
-    uintn                      uninit;       /* Whether the interface was initialized */
 
     info         = (compinfo_t *)access_rec->special_info;
     deflate_info = &(info->cinfo.coder_info.deflate_info);
 
     /* Check if second stage of initialization has been performed */
     if (deflate_info->acc_init != DFACC_READ) {
-        /* preserve the initialized state for later */
-        uninit = (deflate_info->acc_init != 0);
-
         /* Terminate the previous method of access */
         if (HCIcdeflate_term(info, deflate_info->acc_mode) == FAIL)
             HRETURN_ERROR(DFE_CTERM, FAIL);

--- a/hdf/src/cszip.c
+++ b/hdf/src/cszip.c
@@ -319,9 +319,11 @@ HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
     return (SUCCEED);
 
 #else /* ifdef H4_HAVE_LIBSZ */
+    (void)info;
+    (void)length;
+    (void)buf;
 
     HRETURN_ERROR(DFE_CANTCOMP, FAIL);
-
 #endif /* H4_HAVE_LIBSZ */
 
 } /* end HCIcszip_decode() */
@@ -385,9 +387,11 @@ HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf)
     return (SUCCEED);
 
 #else /* ifdef H4_HAVE_SZIP_ENCODER */
+    (void)info;
+    (void)length;
+    (void)buf;
 
     HRETURN_ERROR(DFE_CANTDECOMP, FAIL);
-
 #endif /* H4_HAVE_SZIP_ENCODER */
 
 } /* end HCIcszip_encode() */
@@ -603,9 +607,9 @@ HCIcszip_term(compinfo_t *info)
     return (SUCCEED);
 
 #else /* H4_HAVE_SZIP_ENCODER */
+    (void)info;
 
     HRETURN_ERROR(DFE_CANTCOMP, FAIL);
-
 #endif /* H4_HAVE_SZIP_ENCODER */
 
 } /* end HCIcszip_term() */
@@ -868,6 +872,9 @@ HCPcszip_write(accrec_t *access_rec, int32 length, const void *data)
 
     return (length);
 #else /* ifdef H4_HAVE_SZIP_ENCODER */
+    (void)access_rec;
+    (void)length;
+    (void)data;
 
     HRETURN_ERROR(DFE_CANTDECOMP, FAIL);
 
@@ -1066,6 +1073,13 @@ done:
     return (ret_value);
 #else
     /* szip not enabled */
+    (void)c_info;
+    (void)nt;
+    (void)ncomp;
+    (void)ndims;
+    (void)dims;
+    (void)cdims;
+
     return (FAIL);
 #endif
 }

--- a/hdf/src/cszip.c
+++ b/hdf/src/cszip.c
@@ -318,7 +318,7 @@ HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
 
     return (SUCCEED);
 
-#else /* ifdef H4_HAVE_LIBSZ */
+#else  /* ifdef H4_HAVE_LIBSZ */
     (void)info;
     (void)length;
     (void)buf;
@@ -386,7 +386,7 @@ HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf)
 
     return (SUCCEED);
 
-#else /* ifdef H4_HAVE_SZIP_ENCODER */
+#else  /* ifdef H4_HAVE_SZIP_ENCODER */
     (void)info;
     (void)length;
     (void)buf;
@@ -606,7 +606,7 @@ HCIcszip_term(compinfo_t *info)
 
     return (SUCCEED);
 
-#else /* H4_HAVE_SZIP_ENCODER */
+#else  /* H4_HAVE_SZIP_ENCODER */
     (void)info;
 
     HRETURN_ERROR(DFE_CANTCOMP, FAIL);

--- a/hdf/src/hblocks.c
+++ b/hdf/src/hblocks.c
@@ -792,6 +792,7 @@ HLgetdatainfo(int32 file_id, uint8 *buf, /* IN: special header info */
     int  ii;
     intn ret_value = SUCCEED;
 
+    (void)start_block; /*not used */
     /* Clear error stack */
     HEclear();
 

--- a/hdf/src/hdatainfo.c
+++ b/hdf/src/hdatainfo.c
@@ -927,10 +927,8 @@ GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array)
     CONSTR(FUNC, "GRgetpalinfo");
     gr_info_t *gr_ptr;
     int32      file_id;
-    int32      nbytes = 0;
     int32      aid    = FAIL;
     intn       idx;
-    uintn      count;
     intn       ret_value = SUCCEED;
 
     /* Clear error stack */
@@ -946,8 +944,8 @@ GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array)
 
     file_id = gr_ptr->hdf_file_id; /* alias of the file id */
 
-    /* Validate array size.  Fail when count is a pos number but the array is
-       NULL, or when count is a neg number */
+    /* Validate array size.  Fail when pal_count is a pos number but the array is
+       NULL, or when pal_count is a neg number */
     if ((pal_count > 0 && palinfo_array == NULL) || pal_count < 0)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 

--- a/hdf/src/hdatainfo.c
+++ b/hdf/src/hdatainfo.c
@@ -927,7 +927,7 @@ GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array)
     CONSTR(FUNC, "GRgetpalinfo");
     gr_info_t *gr_ptr;
     int32      file_id;
-    int32      aid    = FAIL;
+    int32      aid = FAIL;
     intn       idx;
     intn       ret_value = SUCCEED;
 

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -946,7 +946,6 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                 case DFTAG_ID: /* Image description info */
                                 {
                                     uint8     *p = GRtbuf;
-                                    at_info_t *new_attr; /* attr to add to the local attr set */
                                     if (Hgetelement(file_id, (uint16)img_tag, (uint16)img_ref, GRtbuf) !=
                                         FAIL)
                                         Decode_diminfo(p, &(new_image->img_dim));
@@ -978,6 +977,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                         else /* little endian */
                                             new_image->img_dim.nt |= DFNT_LITEND;
                                     } /* end if */
+                                    break;
                                 }     /* end case DFTAG_ID */
 
                                 case DFTAG_VH: /* Attribute information */
@@ -2649,7 +2649,6 @@ intn
 GRwriteimage(int32 riid, int32 start[2], int32 in_stride[2], int32 count[2], void *data)
 {
     CONSTR(FUNC, "GRwriteimage");   /* for HERROR */
-    int32      hdf_file_id;         /* HDF file ID */
     int32      stride[2];           /* pointer to the stride array */
     gr_info_t *gr_ptr;              /* ptr to the GR information for this grid */
     ri_info_t *ri_ptr;              /* ptr to the image to work with */
@@ -2694,7 +2693,6 @@ GRwriteimage(int32 riid, int32 start[2], int32 in_stride[2], int32 count[2], voi
     if (NULL == (ri_ptr = (ri_info_t *)HAatom_object(riid)))
         HGOTO_ERROR(DFE_RINOTFOUND, FAIL);
     gr_ptr      = ri_ptr->gr_ptr;
-    hdf_file_id = gr_ptr->hdf_file_id;
 
     comp_type = COMP_CODE_NONE;
     scheme    = ri_ptr->img_dim.comp_tag;
@@ -5764,7 +5762,6 @@ GRwritechunk(int32       riid,   /* IN: access aid to GR */
     int16           special;         /* Special code */
     int32           csize;           /* physical chunk size */
     sp_info_block_t info_block;      /* special info block */
-    uint32          byte_count;      /* bytes to write */
     int8            platnumsubclass; /* the machine type of the current platform */
     uintn           convert;         /* whether to convert or not */
     intn            i;
@@ -5854,10 +5851,6 @@ GRwritechunk(int32       riid,   /* IN: access aid to GR */
                 pixel_mem_size  = (uintn)(ri_ptr->img_dim.ncomps *
                                          DFKNTsize((ri_ptr->img_dim.nt | DFNT_NATIVE) & (~DFNT_LITEND)));
                 pixel_disk_size = (uintn)(ri_ptr->img_dim.ncomps * DFKNTsize(ri_ptr->img_dim.nt));
-
-                /* adjust for data type size */
-                /* csize *= pixel_mem_size; */
-                byte_count = csize * pixel_mem_size;
 
                 /* figure out if data needs to be converted */
                 /* Get number-type and conversion information */
@@ -5971,7 +5964,6 @@ GRreadchunk(int32  riid,   /* IN: access aid to GR */
     int16           special;         /* Special code */
     int32           csize;           /* physical chunk size */
     sp_info_block_t info_block;      /* special info block */
-    uint32          byte_count;      /* bytes to read */
     int8            platnumsubclass; /* the machine type of the current platform */
     uintn           convert;         /* whether to convert or not */
     intn            i;
@@ -5980,7 +5972,6 @@ GRreadchunk(int32  riid,   /* IN: access aid to GR */
     comp_coder_t    comp_type;
     comp_info       cinfo;
     intn            status           = FAIL;
-    intn            switch_interlace = FALSE; /* whether the memory interlace needs to be switched around */
     intn            ret_value        = SUCCEED;
 
     /* clear error stack and check validity of args */
@@ -6067,20 +6058,12 @@ GRreadchunk(int32  riid,   /* IN: access aid to GR */
                                          DFKNTsize((ri_ptr->img_dim.nt | DFNT_NATIVE) & (~DFNT_LITEND)));
                 pixel_disk_size = (uintn)(ri_ptr->img_dim.ncomps * DFKNTsize(ri_ptr->img_dim.nt));
 
-                /* adjust for number type size */
-                /* csize *= pixel_mem_size; */
-                byte_count = csize * pixel_mem_size;
-
                 /* figure out if data needs to be converted */
                 /* Get number-type and conversion information */
                 if (FAIL == (platnumsubclass = DFKgetPNSC(ri_ptr->img_dim.nt & (~DFNT_LITEND), DF_MT)))
                     HGOTO_ERROR(DFE_INTERNAL, FAIL);
                 convert = (ri_ptr->img_dim.file_nt_subclass != platnumsubclass) ||
                           (pixel_mem_size != pixel_disk_size); /* is conversion necessary? */
-
-                /* check interlace */
-                if (ri_ptr->img_dim.il != MFGR_INTERLACE_PIXEL)
-                    switch_interlace = TRUE;
 
                 /* read chunk in */
                 if (convert) {
@@ -6300,7 +6283,6 @@ GR2bmapped(int32 riid, intn *tobe_mapped, intn *name_generated)
     int32      ritype;             /* image's type */
     intn       special_type = 0;   /* specialness of the image data */
     int32      file_id;            /* shortcut file id */
-    intn       status;
     intn       ret_value = SUCCEED;
 
     /* Clear error stack */
@@ -6331,7 +6313,7 @@ GR2bmapped(int32 riid, intn *tobe_mapped, intn *name_generated)
        that it is mapped-able */
     else if (img_tag == DFTAG_RI || img_tag == DFTAG_CI) {
         /* Get the image data's type */
-        status = GRgetiminfo(riid, NULL, NULL, &ritype, NULL, NULL, NULL);
+        GRgetiminfo(riid, NULL, NULL, &ritype, NULL, NULL, NULL);
 
         /* If it is 8-bit, set flag to check further for special storage */
         if (ritype == DFNT_UCHAR8 || ritype == DFNT_CHAR8 || ritype == DFNT_UINT8 || ritype == DFNT_INT8) {
@@ -6339,7 +6321,7 @@ GR2bmapped(int32 riid, intn *tobe_mapped, intn *name_generated)
             if (ri_ptr->img_dim.ncomps == 1) {
                 /* Make sure no specialness or only with RLE compression */
                 comp_coder_t comp_type = COMP_CODE_NONE;
-                status                 = GRgetcomptype(riid, &comp_type);
+                GRgetcomptype(riid, &comp_type);
                 if (comp_type == COMP_CODE_RLE || comp_type == COMP_CODE_NONE) {
                     special_type = GRIisspecial_type(file_id, img_tag, img_ref);
                     /* In some cases, special_type = 0 for old image with RLE,

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -945,7 +945,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                                 case DFTAG_ID: /* Image description info */
                                 {
-                                    uint8     *p = GRtbuf;
+                                    uint8 *p = GRtbuf;
                                     if (Hgetelement(file_id, (uint16)img_tag, (uint16)img_ref, GRtbuf) !=
                                         FAIL)
                                         Decode_diminfo(p, &(new_image->img_dim));
@@ -978,7 +978,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                             new_image->img_dim.nt |= DFNT_LITEND;
                                     } /* end if */
                                     break;
-                                }     /* end case DFTAG_ID */
+                                } /* end case DFTAG_ID */
 
                                 case DFTAG_VH: /* Attribute information */
                                 {
@@ -2692,7 +2692,7 @@ GRwriteimage(int32 riid, int32 start[2], int32 in_stride[2], int32 count[2], voi
     /* locate RI's object in hash table */
     if (NULL == (ri_ptr = (ri_info_t *)HAatom_object(riid)))
         HGOTO_ERROR(DFE_RINOTFOUND, FAIL);
-    gr_ptr      = ri_ptr->gr_ptr;
+    gr_ptr = ri_ptr->gr_ptr;
 
     comp_type = COMP_CODE_NONE;
     scheme    = ri_ptr->img_dim.comp_tag;
@@ -5971,8 +5971,8 @@ GRreadchunk(int32  riid,   /* IN: access aid to GR */
     uint32          comp_config;
     comp_coder_t    comp_type;
     comp_info       cinfo;
-    intn            status           = FAIL;
-    intn            ret_value        = SUCCEED;
+    intn            status    = FAIL;
+    intn            ret_value = SUCCEED;
 
     /* clear error stack and check validity of args */
     HEclear();

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -69,7 +69,7 @@
 PRIVATE int16 local_sizetab[] = {LOCAL_UNTYPEDSIZE, LOCAL_CHARSIZE, LOCAL_INTSIZE,   LOCAL_FLOATSIZE,
                                  LOCAL_LONGSIZE,    LOCAL_BYTESIZE, LOCAL_SHORTSIZE, LOCAL_DOUBLESIZE};
 
-#define LOCALSIZETAB_SIZE sizeof(local_sizetab) / sizeof(int)
+#define LOCALSIZETAB_SIZE sizeof(local_sizetab) / (sizeof(int))
 
 /*
  ** returns the machine size of a field type

--- a/mfhdf/libsrc/hdfsds.c
+++ b/mfhdf/libsrc/hdfsds.c
@@ -977,7 +977,7 @@ hdf_read_ndgs(NC *handle)
     intn   i;
     intn   status;
     intn   tag_index;
-    uint8 *p         = NULL;
+    uint8 *p = NULL;
     intn   scale_offset; /* current offset into the scales record for the
                        current dimension's values */
     intn ret_value = SUCCEED;
@@ -1498,7 +1498,7 @@ hdf_read_ndgs(NC *handle)
              * If there is an annotation put in 'remarks'
              */
             {
-                err_code          = DFE_NONE;
+                err_code = DFE_NONE;
 
                 err_code = hdf_get_desc_annot(handle, ndgTag, ndgRef, &attrs[current_attr], &current_attr);
                 if (err_code != DFE_NONE) {
@@ -1512,7 +1512,7 @@ hdf_read_ndgs(NC *handle)
              * NOT 'long_name' 9/2/94)
              */
             {
-                err_code          = DFE_NONE;
+                err_code = DFE_NONE;
 
                 err_code = hdf_get_label_annot(handle, ndgTag, ndgRef, &attrs[current_attr], &current_attr);
                 if (err_code != DFE_NONE) {

--- a/mfhdf/libsrc/hdfsds.c
+++ b/mfhdf/libsrc/hdfsds.c
@@ -942,7 +942,6 @@ hdf_read_ndgs(NC *handle)
     int32          aid1;
     uint16         ndgTag;
     uint16         ndgRef;
-    uint16         sddRef;
     uint16         lRef;
     uint16         uRef;
     uint16         fRef;
@@ -979,7 +978,6 @@ hdf_read_ndgs(NC *handle)
     intn   status;
     intn   tag_index;
     uint8 *p         = NULL;
-    uint8  tBuf[128] = "";
     intn   scale_offset; /* current offset into the scales record for the
                        current dimension's values */
     intn ret_value = SUCCEED;
@@ -1028,9 +1026,6 @@ hdf_read_ndgs(NC *handle)
          */
         status = SUCCEED;
         while (status == SUCCEED) {
-            uint16 ntTag;
-            uint16 ntRef;
-
             if (HQuerytagref(aid, &ndgTag, &ndgRef) == FAIL) {
                 HGOTO_ERROR(DFE_INTERNAL, FAIL);
             }
@@ -1051,7 +1046,7 @@ hdf_read_ndgs(NC *handle)
                 HGOTO_ERROR(DFE_INTERNAL, FAIL);
             }
 
-            sddRef = lRef = uRef = fRef = sRef = sdRef = 0;
+            lRef = uRef = fRef = sRef = sdRef = 0;
 
             /* default number type is Float32 */
             type    = NC_FLOAT;
@@ -1151,7 +1146,6 @@ hdf_read_ndgs(NC *handle)
                             scaletypes[i] = temptype;
                         }
 
-                        sddRef = tmpRef; /* prepare for a new dim var */
                         if (Hendaccess(aid1) == FAIL) {
                             HGOTO_ERROR(DFE_CANTENDACCESS, FAIL);
                         }
@@ -1504,7 +1498,6 @@ hdf_read_ndgs(NC *handle)
              * If there is an annotation put in 'remarks'
              */
             {
-                NC_attr *tmp_attr = NULL;
                 err_code          = DFE_NONE;
 
                 err_code = hdf_get_desc_annot(handle, ndgTag, ndgRef, &attrs[current_attr], &current_attr);
@@ -1519,7 +1512,6 @@ hdf_read_ndgs(NC *handle)
              * NOT 'long_name' 9/2/94)
              */
             {
-                NC_attr *tmp_attr = NULL;
                 err_code          = DFE_NONE;
 
                 err_code = hdf_get_label_annot(handle, ndgTag, ndgRef, &attrs[current_attr], &current_attr);

--- a/mfhdf/libsrc/mfdatainfo.c
+++ b/mfhdf/libsrc/mfdatainfo.c
@@ -235,6 +235,8 @@ SDgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length)
 
     /* Get the attribute's name */
     status = SDattrinfo(id, attrindex, attrname, &ntype, &count);
+    if (status == FAIL)
+        HGOTO_ERROR(DFE_ARGS, FAIL);
 
     /* Check if the id given is a file id, or SDS id, or dimension id, and get
        appropriate info structure */
@@ -708,14 +710,13 @@ SDgetanndatainfo(int32 sdsid, ann_type annot_type, uintn size, int32 *offsetarra
     int32 file_id = FAIL, /* file, AN API, annotation IDs */
         an_id = FAIL, ann_id = FAIL;
     NC     *handle  = NULL;    /* file structure */
-    NC_var *var     = NULL;    /* variable structure of sds, to get NDG ref */
     int32  *dannots = NULL,    /* list of data annotation IDs */
         n_flabels   = 0,       /* number of file labels */
         n_fdescs    = 0,       /* number of file descriptions */
         n_dlabels   = 0,       /* number of object labels */
         n_ddescs    = 0;       /* number of file descriptions */
     uint16 elem_tag, elem_ref; /* tag/ref of dataset's NDG */
-    intn   num_annots,         /* number of annotation of requested type */
+    intn   num_annots = -1,    /* number of annotation of requested type */
         ii, ret_value = 0;
 
     /* Clear error stack */

--- a/mfhdf/libsrc/mfdatainfo.c
+++ b/mfhdf/libsrc/mfdatainfo.c
@@ -709,12 +709,12 @@ SDgetanndatainfo(int32 sdsid, ann_type annot_type, uintn size, int32 *offsetarra
     CONSTR(FUNC, "SDgetanndatainfo");
     int32 file_id = FAIL, /* file, AN API, annotation IDs */
         an_id = FAIL, ann_id = FAIL;
-    NC     *handle  = NULL;    /* file structure */
-    int32  *dannots = NULL,    /* list of data annotation IDs */
-        n_flabels   = 0,       /* number of file labels */
-        n_fdescs    = 0,       /* number of file descriptions */
-        n_dlabels   = 0,       /* number of object labels */
-        n_ddescs    = 0;       /* number of file descriptions */
+    NC    *handle  = NULL;     /* file structure */
+    int32 *dannots = NULL,     /* list of data annotation IDs */
+        n_flabels  = 0,        /* number of file labels */
+        n_fdescs   = 0,        /* number of file descriptions */
+        n_dlabels  = 0,        /* number of object labels */
+        n_ddescs   = 0;        /* number of file descriptions */
     uint16 elem_tag, elem_ref; /* tag/ref of dataset's NDG */
     intn   num_annots = -1,    /* number of annotation of requested type */
         ii, ret_value = 0;

--- a/mfhdf/libsrc/mfsd.c
+++ b/mfhdf/libsrc/mfsd.c
@@ -3217,11 +3217,9 @@ SDdiminfo(int32  id,   /* IN:  dimension ID */
     CONSTR(FUNC, "SDdiminfo"); /* for HGOTO_ERROR */
     NC      *handle = NULL;
     NC_dim  *dim    = NULL;
-    NC_var  *var    = NULL;
     NC_var **dp     = NULL;
     intn     ii;
     intn     len;
-    int32    varid;
     int      ret_value = SUCCEED;
 
 #ifdef SDDEBUG
@@ -3374,8 +3372,9 @@ SDgetdimstrs(int32 id, /* IN:  dataset ID */
                 if (namelen == (*dp)->name->len && HDstrncmp(name, (*dp)->name->values, HDstrlen(name)) == 0)
                     /* because a dim was given, make sure that this is a coord var */
                     /* if it is an SDS, the function will fail */
-                    if ((*dp)->var_type == IS_SDSVAR)
+                    if ((*dp)->var_type == IS_SDSVAR) {
                         HGOTO_ERROR(DFE_ARGS, FAIL)
+                    }
                     /* only proceed if this variable is a coordinate var or when
                     its status is unknown due to its being created prior to
                     the fix of bugzilla 624 - BMR - 05/14/2007 */
@@ -3788,6 +3787,8 @@ SDgetexternalfile(int32  id,           /* IN: dataset ID */
         /* Get the access id and then its special info */
         aid     = Hstartread(handle->hdf_file, var->data_tag, var->data_ref);
         retcode = HDget_special_info(aid, &info_block);
+        if ((retcode == FAIL) || (info_block.key == FAIL))
+            HGOTO_ERROR(DFE_CANTMOD, FAIL);
 
         /* If the SDS has external element, return the external file info */
         if (info_block.key == SPECIAL_EXT) {

--- a/mfhdf/libsrc/nssdc.c
+++ b/mfhdf/libsrc/nssdc.c
@@ -137,6 +137,8 @@ nssdc_read_cdf(XDR *xdrs, NC **handlep)
     NC_var            *var = NULL; /* shorthand for vars[current_var] */
     vix_t             *end;
 
+    (void)xdrs;
+
     /* interesting stuff in CDR record */
     int32 gdrOffset, vers, release, encoding, flags, inc;
 
@@ -853,6 +855,9 @@ nssdc_read_cdf(XDR *xdrs, NC **handlep)
 bool_t
 nssdc_write_cdf(XDR *xdrs, NC **handlep)
 {
+    (void)xdrs;
+    (void)handlep;
+
 #if DEBUG
     fprintf(stderr, "nssdc_write_cdf i've been called\n");
 #endif

--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -2182,8 +2182,8 @@ NC_fill_buffer(NC *handle, int varid, const long *edges, void *values)
 int
 ncvarget(int cdfid, int varid, const long *start, const long *edges, ncvoid *values)
 {
-    NC     *handle;
-    int     status = 0;
+    NC *handle;
+    int status = 0;
 
     cdf_routine_name = "ncvarget";
 

--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -966,6 +966,8 @@ hdf_xdr_NCvdata(NC *handle, NC_var *vp, u_long where, nc_type type, uint32 count
     intn   ret_value    = SUCCEED;
     int32  alloc_status = FAIL; /* no successful allocation yet */
 
+    (void)type;
+
 #ifdef DEBUG
     fprintf(stderr, "hdf_xdr_NCvdata I've been called : %s\n", vp->name->values);
 #endif
@@ -1542,6 +1544,9 @@ nssdc_xdr_NCvdata(NC *handle, NC_var *vp, u_long where, nc_type type, uint32 cou
 {
     int32 status;
     int32 byte_count;
+
+    (void)type;
+    (void)values;
 
 #ifdef DEBUG
     fprintf(stderr, "nssdc_xdr_NCvdata I've been called : %s\n", vp->name->values);
@@ -2150,12 +2155,13 @@ NC_fill_buffer(NC *handle, int varid, const long *edges, void *values)
 
     /* Find user-defined fill-value and fill the buffer with it */
     attr = NC_findattr(&vp->attrs, _FillValue);
-    if (attr != NULL)
+    if (attr != NULL) {
         if (HDmemfill(values, (*attr)->data->values, vp->szof, buf_size) == NULL)
             return (-1);
-        /* If no user-defined fill-value, fill the buffer with default fill-value */
-        else
-            NC_arrayfill(values, buf_size * vp->szof, vp->type);
+    }
+    /* If no user-defined fill-value, fill the buffer with default fill-value */
+    else
+        NC_arrayfill(values, buf_size * vp->szof, vp->type);
     return 0;
 }
 
@@ -2177,7 +2183,6 @@ int
 ncvarget(int cdfid, int varid, const long *start, const long *edges, ncvoid *values)
 {
     NC     *handle;
-    NC_var *vp;
     int     status = 0;
 
     cdf_routine_name = "ncvarget";


### PR DESCRIPTION
Filter out CDash warnings for ext libs.
Eliminate undefineds in the hdf/src and mfhdf/src files