### PR TITLE
Executables do not import/export symbols within itself.

### DIFF
--- a/hdf/src/H4api_adpt.h
+++ b/hdf/src/H4api_adpt.h
@@ -97,11 +97,9 @@
 #if defined(_MSC_VER) || defined(__MINGW32__) /* MSVC Compiler Case */
 #define HDFPUBLIC   __declspec(dllimport)
 #define HDFLIBAPI   extern __declspec(dllimport)
-#define HDFTOOLSAPI extern __declspec(dllexport)
 #elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
 #define HDFPUBLIC   __attribute__((visibility("default")))
 #define HDFLIBAPI   extern __attribute__((visibility("default")))
-#define HDFTOOLSAPI extern __attribute__((visibility("default")))
 #endif
 #endif /* mfhdf_hdiff_shared_EXPORTS */
 
@@ -109,11 +107,9 @@
 #if defined(_MSC_VER) || defined(__MINGW32__) /* MSVC Compiler Case */
 #define HDFPUBLIC   __declspec(dllimport)
 #define HDFLIBAPI   extern __declspec(dllimport)
-#define HDFTOOLSAPI extern __declspec(dllexport)
 #elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
 #define HDFPUBLIC   __attribute__((visibility("default")))
 #define HDFLIBAPI   extern __attribute__((visibility("default")))
-#define HDFTOOLSAPI extern __attribute__((visibility("default")))
 #endif
 #endif /* mfhdf_hrepack_shared_EXPORTS */
 
@@ -152,13 +148,6 @@
 #define HDFFCLIBAPI extern __attribute__((visibility("default")))
 #endif
 #endif
-#if !defined(HDFTOOLSAPI)
-#if defined(_MSC_VER) || defined(__MINGW32__) /* MSVC Compiler Case */
-#define HDFTOOLSAPI extern __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define HDFTOOLSAPI extern __attribute__((visibility("default")))
-#endif
-#endif
 
 #else
 #define XDRLIBAPI    extern
@@ -166,7 +155,6 @@
 #define HDFPUBLIC
 #define HDFLIBAPI   extern
 #define HDFFCLIBAPI extern
-#define HDFTOOLSAPI extern
 #endif /*H4_BUILT_AS_DYNAMIC_LIB  */
 
 #endif /* H4API_ADPT_H */

--- a/hdf/src/H4api_adpt.h
+++ b/hdf/src/H4api_adpt.h
@@ -95,21 +95,21 @@
 
 #if defined(mfhdf_hdiff_shared_EXPORTS)
 #if defined(_MSC_VER) || defined(__MINGW32__) /* MSVC Compiler Case */
-#define HDFPUBLIC   __declspec(dllimport)
-#define HDFLIBAPI   extern __declspec(dllimport)
+#define HDFPUBLIC __declspec(dllimport)
+#define HDFLIBAPI extern __declspec(dllimport)
 #elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define HDFPUBLIC   __attribute__((visibility("default")))
-#define HDFLIBAPI   extern __attribute__((visibility("default")))
+#define HDFPUBLIC __attribute__((visibility("default")))
+#define HDFLIBAPI extern __attribute__((visibility("default")))
 #endif
 #endif /* mfhdf_hdiff_shared_EXPORTS */
 
 #if defined(mfhdf_hrepack_shared_EXPORTS)
 #if defined(_MSC_VER) || defined(__MINGW32__) /* MSVC Compiler Case */
-#define HDFPUBLIC   __declspec(dllimport)
-#define HDFLIBAPI   extern __declspec(dllimport)
+#define HDFPUBLIC __declspec(dllimport)
+#define HDFLIBAPI extern __declspec(dllimport)
 #elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define HDFPUBLIC   __attribute__((visibility("default")))
-#define HDFLIBAPI   extern __attribute__((visibility("default")))
+#define HDFPUBLIC __attribute__((visibility("default")))
+#define HDFLIBAPI extern __attribute__((visibility("default")))
 #endif
 #endif /* mfhdf_hrepack_shared_EXPORTS */
 

--- a/mfhdf/hdiff/hdiff.h
+++ b/mfhdf/hdiff/hdiff.h
@@ -99,8 +99,8 @@ typedef struct {        /* selection for comparison  */
 extern "C" {
 #endif
 
-HDFTOOLSAPI uint32 hdiff(const char *fname1, const char *fname2, diff_opt_t *opt);
-HDFTOOLSAPI void   make_vars(char *optarg, diff_opt_t *opt, int option);
+uint32 hdiff(const char *fname1, const char *fname2, diff_opt_t *opt);
+void   make_vars(char *optarg, diff_opt_t *opt, int option);
 
 #ifdef __cplusplus
 }

--- a/mfhdf/hrepack/hrepack.h
+++ b/mfhdf/hrepack/hrepack.h
@@ -72,15 +72,15 @@ typedef struct {
 extern "C" {
 #endif
 
-HDFTOOLSAPI int  hrepack(const char *infname, const char *outfname, options_t *options);
-HDFTOOLSAPI int  hrepack_addcomp(const char *str, options_t *options);
-HDFTOOLSAPI int  hrepack_addchunk(const char *str, options_t *options);
-HDFTOOLSAPI void hrepack_init(options_t *options, int verbose);
-HDFTOOLSAPI void hrepack_end(options_t *options);
-HDFTOOLSAPI int  hrepack_main(const char *infile, const char *outfile, options_t *options);
+int  hrepack(const char *infname, const char *outfname, options_t *options);
+int  hrepack_addcomp(const char *str, options_t *options);
+int  hrepack_addchunk(const char *str, options_t *options);
+void hrepack_init(options_t *options, int verbose);
+void hrepack_end(options_t *options);
+int  hrepack_main(const char *infile, const char *outfile, options_t *options);
 
-HDFTOOLSAPI int list(const char *infname, const char *outfname, options_t *options);
-HDFTOOLSAPI int read_info(const char *filename, options_t *options);
+int list(const char *infname, const char *outfname, options_t *options);
+int read_info(const char *filename, options_t *options);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes mingw and windows warnings about imports