### PR TITLE
Prefix BSD queue calls with H4 and drop unused functionality

### DIFF
--- a/hdf/src/hqueue.h
+++ b/hdf/src/hqueue.h
@@ -74,122 +74,18 @@
  *
  */
 
-/*
- * List definitions.
- */
-#define LIST_HEAD(name, type)                                                                                \
-    struct name {                                                                                            \
-        struct type *lh_first; /* first element */                                                           \
-    }
-
-#define LIST_ENTRY(type)                                                                                     \
-    struct {                                                                                                 \
-        struct type  *le_next; /* next element */                                                            \
-        struct type **le_prev; /* address of previous next element */                                        \
-    }
-
-/*
- * List functions.
- */
-#define LIST_INIT(head)                                                                                      \
-    {                                                                                                        \
-        (head)->lh_first = NULL;                                                                             \
-    }
-
-#define LIST_INSERT_AFTER(listelm, elm, field)                                                               \
-    {                                                                                                        \
-        if (((elm)->field.le_next = (listelm)->field.le_next) != NULL)                                       \
-            (listelm)->field.le_next->field.le_prev = &(elm)->field.le_next;                                 \
-        (listelm)->field.le_next = (elm);                                                                    \
-        (elm)->field.le_prev     = &(listelm)->field.le_next;                                                \
-    }
-
-#define LIST_INSERT_HEAD(head, elm, field)                                                                   \
-    {                                                                                                        \
-        if (((elm)->field.le_next = (head)->lh_first) != NULL)                                               \
-            (head)->lh_first->field.le_prev = &(elm)->field.le_next;                                         \
-        (head)->lh_first     = (elm);                                                                        \
-        (elm)->field.le_prev = &(head)->lh_first;                                                            \
-    }
-
-#define LIST_REMOVE(elm, field)                                                                              \
-    {                                                                                                        \
-        if ((elm)->field.le_next != NULL)                                                                    \
-            (elm)->field.le_next->field.le_prev = (elm)->field.le_prev;                                      \
-        *(elm)->field.le_prev = (elm)->field.le_next;                                                        \
-    }
-
-/*
- * Tail queue definitions.
- */
-#define TAILQ_HEAD(name, type)                                                                               \
-    struct name {                                                                                            \
-        struct type  *tqh_first; /* first element */                                                         \
-        struct type **tqh_last;  /* addr of last next element */                                             \
-    }
-
-#define TAILQ_ENTRY(type)                                                                                    \
-    struct {                                                                                                 \
-        struct type  *tqe_next; /* next element */                                                           \
-        struct type **tqe_prev; /* address of previous next element */                                       \
-    }
-
-/*
- * Tail queue functions.
- */
-#define TAILQ_INIT(head)                                                                                     \
-    {                                                                                                        \
-        (head)->tqh_first = NULL;                                                                            \
-        (head)->tqh_last  = &(head)->tqh_first;                                                              \
-    }
-
-#define TAILQ_INSERT_HEAD(head, elm, field)                                                                  \
-    {                                                                                                        \
-        if (((elm)->field.tqe_next = (head)->tqh_first) != NULL)                                             \
-            (elm)->field.tqe_next->field.tqe_prev = &(elm)->field.tqe_next;                                  \
-        else                                                                                                 \
-            (head)->tqh_last = &(elm)->field.tqe_next;                                                       \
-        (head)->tqh_first     = (elm);                                                                       \
-        (elm)->field.tqe_prev = &(head)->tqh_first;                                                          \
-    }
-
-#define TAILQ_INSERT_TAIL(head, elm, field)                                                                  \
-    {                                                                                                        \
-        (elm)->field.tqe_next = NULL;                                                                        \
-        (elm)->field.tqe_prev = (head)->tqh_last;                                                            \
-        *(head)->tqh_last     = (elm);                                                                       \
-        (head)->tqh_last      = &(elm)->field.tqe_next;                                                      \
-    }
-
-#define TAILQ_INSERT_AFTER(head, listelm, elm, field)                                                        \
-    {                                                                                                        \
-        if (((elm)->field.tqe_next = (listelm)->field.tqe_next) != NULL)                                     \
-            (elm)->field.tqe_next->field.tqe_prev = &(elm)->field.tqe_next;                                  \
-        else                                                                                                 \
-            (head)->tqh_last = &(elm)->field.tqe_next;                                                       \
-        (listelm)->field.tqe_next = (elm);                                                                   \
-        (elm)->field.tqe_prev     = &(listelm)->field.tqe_next;                                              \
-    }
-
-#define TAILQ_REMOVE(head, elm, field)                                                                       \
-    {                                                                                                        \
-        if (((elm)->field.tqe_next) != NULL)                                                                 \
-            (elm)->field.tqe_next->field.tqe_prev = (elm)->field.tqe_prev;                                   \
-        else                                                                                                 \
-            (head)->tqh_last = (elm)->field.tqe_prev;                                                        \
-        *(elm)->field.tqe_prev = (elm)->field.tqe_next;                                                      \
-    }
+/* NOTE: LIST and TAILQ implementations were removed */
 
 /*
  * Circular queue definitions.
  */
-#define CIRCLEQ_HEAD(name, type)                                                                             \
+#define H4_CIRCLEQ_HEAD(name, type)                                                                          \
     struct name {                                                                                            \
         struct type *cqh_first; /* first element */                                                          \
         struct type *cqh_last;  /* last element */                                                           \
     }
 
-#define CIRCLEQ_ENTRY(type)                                                                                  \
+#define H4_CIRCLEQ_ENTRY(type)                                                                               \
     struct {                                                                                                 \
         struct type *cqe_next; /* next element */                                                            \
         struct type *cqe_prev; /* previous element */                                                        \
@@ -198,13 +94,13 @@
 /*
  * Circular queue functions.
  */
-#define CIRCLEQ_INIT(head)                                                                                   \
+#define H4_CIRCLEQ_INIT(head)                                                                                \
     {                                                                                                        \
         (head)->cqh_first = (void *)(head);                                                                  \
         (head)->cqh_last  = (void *)(head);                                                                  \
     }
 
-#define CIRCLEQ_INSERT_AFTER(head, listelm, elm, field)                                                      \
+#define H4_CIRCLEQ_INSERT_AFTER(head, listelm, elm, field)                                                   \
     {                                                                                                        \
         (elm)->field.cqe_next = (listelm)->field.cqe_next;                                                   \
         (elm)->field.cqe_prev = (listelm);                                                                   \
@@ -215,7 +111,7 @@
         (listelm)->field.cqe_next = (elm);                                                                   \
     }
 
-#define CIRCLEQ_INSERT_BEFORE(head, listelm, elm, field)                                                     \
+#define H4_CIRCLEQ_INSERT_BEFORE(head, listelm, elm, field)                                                  \
     {                                                                                                        \
         (elm)->field.cqe_next = (listelm);                                                                   \
         (elm)->field.cqe_prev = (listelm)->field.cqe_prev;                                                   \
@@ -226,7 +122,7 @@
         (listelm)->field.cqe_prev = (elm);                                                                   \
     }
 
-#define CIRCLEQ_INSERT_HEAD(head, elm, field)                                                                \
+#define H4_CIRCLEQ_INSERT_HEAD(head, elm, field)                                                             \
     {                                                                                                        \
         (elm)->field.cqe_next = (head)->cqh_first;                                                           \
         (elm)->field.cqe_prev = (void *)(head);                                                              \
@@ -237,7 +133,7 @@
         (head)->cqh_first = (elm);                                                                           \
     }
 
-#define CIRCLEQ_INSERT_TAIL(head, elm, field)                                                                \
+#define H4_CIRCLEQ_INSERT_TAIL(head, elm, field)                                                             \
     {                                                                                                        \
         (elm)->field.cqe_next = (void *)(head);                                                              \
         (elm)->field.cqe_prev = (head)->cqh_last;                                                            \
@@ -248,7 +144,7 @@
         (head)->cqh_last = (elm);                                                                            \
     }
 
-#define CIRCLEQ_REMOVE(head, elm, field)                                                                     \
+#define H4_CIRCLEQ_REMOVE(head, elm, field)                                                                  \
     {                                                                                                        \
         if ((elm)->field.cqe_next == (void *)(head))                                                         \
             (head)->cqh_last = (elm)->field.cqe_prev;                                                        \

--- a/hdf/src/mcache.h
+++ b/hdf/src/mcache.h
@@ -86,19 +86,19 @@
 
 /* The BKT structures are the elements of the queues. */
 typedef struct _bkt {
-    CIRCLEQ_ENTRY(_bkt) hq; /* hash queue */
-    CIRCLEQ_ENTRY(_bkt) q;  /* lru queue */
-    VOID *page;             /* page */
-    int32 pgno;             /* page number */
-#define MCACHE_DIRTY  0x01  /* page needs to be written */
-#define MCACHE_PINNED 0x02  /* page is pinned into memory */
-    uint8 flags;            /* flags */
+    H4_CIRCLEQ_ENTRY(_bkt) hq; /* hash queue */
+    H4_CIRCLEQ_ENTRY(_bkt) q;  /* lru queue */
+    VOID *page;                /* page */
+    int32 pgno;                /* page number */
+#define MCACHE_DIRTY  0x01     /* page needs to be written */
+#define MCACHE_PINNED 0x02     /* page is pinned into memory */
+    uint8 flags;               /* flags */
 } BKT;
 
 /* The element structure for every page referenced(read/written) in object */
 typedef struct _lelem {
-    CIRCLEQ_ENTRY(_lelem) hl; /* hash list */
-    int32 pgno;               /* page number */
+    H4_CIRCLEQ_ENTRY(_lelem) hl; /* hash list */
+    int32 pgno;                  /* page number */
 #ifdef STATISTICS
     int32 elemhit; /* # of hits on page */
 #endif
@@ -114,9 +114,9 @@ typedef struct _lelem {
 
 /* Memory pool cache */
 typedef struct MCACHE {
-    CIRCLEQ_HEAD(_lqh, _bkt) lqh;                               /* lru queue head */
-    CIRCLEQ_HEAD(_hqh, _bkt) hqh[HASHSIZE];                     /* hash queue array */
-    CIRCLEQ_HEAD(_lhqh, _lelem) lhqh[HASHSIZE];                 /* hash of all elements */
+    H4_CIRCLEQ_HEAD(_lqh, _bkt) lqh;                            /* lru queue head */
+    H4_CIRCLEQ_HEAD(_hqh, _bkt) hqh[HASHSIZE];                  /* hash queue array */
+    H4_CIRCLEQ_HEAD(_lhqh, _lelem) lhqh[HASHSIZE];              /* hash of all elements */
     int32 curcache;                                             /* current num of cached pages */
     int32 maxcache;                                             /* max number of cached pages */
     int32 npages;                                               /* number of pages in the object */


### PR DESCRIPTION
Avoids redefinition issues on MacOS where queue.h is brought in by system headers.