### PR TITLE
Fixed HDFFR-1593

### DIFF
--- a/mfhdf/dumper/hdp_vd.c
+++ b/mfhdf/dumper/hdp_vd.c
@@ -509,8 +509,8 @@ dumpvd_ascii(dump_info_t *dumpvd_opts, int32 file_id, const char *file_name, FIL
     intn          dumpall = 0;
     file_format_t ff      = DASCII;
     vd_info_t     curr_vd;
-    int32         vd_id     = FAIL;
-    int32         an_handle = FAIL;
+    int32         vd_id      = FAIL;
+    int32         an_handle  = FAIL;
     int32         num_fields = 0;
     intn          status = SUCCEED, ret_value = SUCCEED;
     char          fields[VSFIELDMAX * FIELDNAMELENMAX];

--- a/mfhdf/dumper/hdp_vd.c
+++ b/mfhdf/dumper/hdp_vd.c
@@ -511,6 +511,7 @@ dumpvd_ascii(dump_info_t *dumpvd_opts, int32 file_id, const char *file_name, FIL
     vd_info_t     curr_vd;
     int32         vd_id     = FAIL;
     int32         an_handle = FAIL;
+    int32         num_fields = 0;
     intn          status = SUCCEED, ret_value = SUCCEED;
     char          fields[VSFIELDMAX * FIELDNAMELENMAX];
 
@@ -563,6 +564,15 @@ dumpvd_ascii(dump_info_t *dumpvd_opts, int32 file_id, const char *file_name, FIL
         if (FAIL == VSinquire(vd_id, &nvf, &interlace, fields, NULL, vdname))
             ERROR_CONT_END("in %s: VSinquire failed for vdata with ref#=%d", "dumpvd_ascii", (int)vdata_ref,
                            vd_id);
+
+        /* Get the number of fields in the vdata, continue to the next vdata
+           if this failed.  If succeeded, check for exceeding max allowed */
+        num_fields = VFnfields(vd_id);
+        if (num_fields == FAIL)
+            ERROR_CONT_END("in %s: VFnfields failed for vdata with ref#=%d", "dumpvd_ascii", (int)vdata_ref, vd_id);
+
+        if (num_fields >= VSFIELDMAX)
+            ERROR_CONT_END("in %s: Number of fields exceeded the max allowed for vdata with ref#=%d, i.e., possible data corruption", "dumpvd_ascii", (int)vdata_ref, vd_id);
 
         /* Get the HDF size of the specified fields of the vdata; VShdfsize
            returns 0 if there are no fields previously defined */

--- a/mfhdf/dumper/hdp_vd.c
+++ b/mfhdf/dumper/hdp_vd.c
@@ -569,10 +569,13 @@ dumpvd_ascii(dump_info_t *dumpvd_opts, int32 file_id, const char *file_name, FIL
            if this failed.  If succeeded, check for exceeding max allowed */
         num_fields = VFnfields(vd_id);
         if (num_fields == FAIL)
-            ERROR_CONT_END("in %s: VFnfields failed for vdata with ref#=%d", "dumpvd_ascii", (int)vdata_ref, vd_id);
+            ERROR_CONT_END("in %s: VFnfields failed for vdata with ref#=%d", "dumpvd_ascii", (int)vdata_ref,
+                           vd_id);
 
         if (num_fields >= VSFIELDMAX)
-            ERROR_CONT_END("in %s: Number of fields exceeded the max allowed for vdata with ref#=%d, i.e., possible data corruption", "dumpvd_ascii", (int)vdata_ref, vd_id);
+            ERROR_CONT_END("in %s: Number of fields exceeded the max allowed for vdata with ref#=%d, i.e., "
+                           "possible data corruption",
+                           "dumpvd_ascii", (int)vdata_ref, vd_id);
 
         /* Get the HDF size of the specified fields of the vdata; VShdfsize
            returns 0 if there are no fields previously defined */

--- a/mfhdf/dumper/hdp_vg.c
+++ b/mfhdf/dumper/hdp_vg.c
@@ -1064,10 +1064,13 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                    if this failed.  If succeeded, check for exceeding max allowed */
                 num_fields = VFnfields(vs);
                 if (num_fields == FAIL)
-                    ERROR_CONT_END("in %s: VFnfields failed for vdata with ref#=%d", "dumpvd_ascii", (int)elem_ref, vs);
+                    ERROR_CONT_END("in %s: VFnfields failed for vdata with ref#=%d", "dumpvd_ascii",
+                                   (int)elem_ref, vs);
 
                 if (num_fields >= VSFIELDMAX)
-                    ERROR_CONT_END("in %s: Number of fields exceeded the max allowed for vdata with ref#=%d, i.e., possible data corruption", "dumpvd_ascii", (int)elem_ref, vs);
+                    ERROR_CONT_END("in %s: Number of fields exceeded the max allowed for vdata with ref#=%d, "
+                                   "i.e., possible data corruption",
+                                   "dumpvd_ascii", (int)elem_ref, vs);
 
                 vsize = VShdfsize(vs, fields);
                 if (vsize == FAIL)

--- a/mfhdf/dumper/hdp_vg.c
+++ b/mfhdf/dumper/hdp_vg.c
@@ -959,6 +959,7 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
     int32 nv;
     int32 interlace;
     int32 vsize;
+    int32 num_fields = 0;
     char  vsname[MAXNAMELEN];
     char  vsclass[VSNAMELENMAX + 1];
     char *vgname    = NULL;
@@ -1058,6 +1059,15 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 if (FAIL == status)
                     ERROR_NOTIFY_2("in %s: VSinquire failed for vdata with ref#=%d", "vgdumpfull",
                                    (int)elem_ref);
+
+                /* Get the number of fields in the vdata, continue to the next vdata
+                   if this failed.  If succeeded, check for exceeding max allowed */
+                num_fields = VFnfields(vs);
+                if (num_fields == FAIL)
+                    ERROR_CONT_END("in %s: VFnfields failed for vdata with ref#=%d", "dumpvd_ascii", (int)elem_ref, vs);
+
+                if (num_fields >= VSFIELDMAX)
+                    ERROR_CONT_END("in %s: Number of fields exceeded the max allowed for vdata with ref#=%d, i.e., possible data corruption", "dumpvd_ascii", (int)elem_ref, vs);
 
                 vsize = VShdfsize(vs, fields);
                 if (vsize == FAIL)


### PR DESCRIPTION
The number of fields in a vdata from the user's file was corrupted and exceeded the maximum allowed.  Continuing the process with it will likely cause segfault at a later time.  This commit added checks for both dumpvd and dumpvg to fail when such number of fields was read from the file.