### PR TITLE
Brings HDF5 Autotools configure scheme to HDF4

### DIFF
--- a/config/apple
+++ b/config/apple
@@ -20,11 +20,20 @@
 #       variable is set based on the incoming value of $CC and is only
 #       used within this file.
 
-# Use clang as the default C compiler.
+# The default compiler is `clang'.
 if test "X-$CC" = "X-"; then
     CC=clang
     CC_BASENAME=clang
 fi
+
+# Figure out GNU C compiler flags
+. $srcdir/config/gnu-flags
+
+# Figure out Intel C compiler flags
+. $srcdir/config/intel-flags
+
+# Figure out Clang C compiler flags
+. $srcdir/config/clang-flags
 
 # Use gfortran as the default F77 compiler.
 if test "X-$F77" = "X-"; then
@@ -32,96 +41,96 @@ if test "X-$F77" = "X-"; then
   F77_BASENAME=gfortran
 fi
 
-case $CC_BASENAME in
-  clang)
-    CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
-    DEBUG_CFLAGS="-g -ansi -Wall -pedantic "
-    DEBUG_CPPFLAGS=
-    # There is a bug somewhere in mfhdf/libsrc that is exposed by compiling
-    # with any optimization in $CC in Lion (Darwin 11) & up
-    # Use -O0 for now.
-    case "$host_os" in
-    darwin1[1-9].*)    # Lion & Mountain Lion & Mavericks & Yosemeti
-        xOFLAG="-O2"
-        ;;
-    *)        # Other OSX versions
-        xOFLAG="-O2"
-        ;;
-    esac
-    PROD_CFLAGS=${PROD_CFLAGS:-"$xOFLAG"}
-    PROD_CPPFLAGS=
-    PROFILE_CFLAGS="-pg"
-    PROFILE_CPPFLAGS=
-    ;;
+# Figure out GNU FC compiler flags
+. $srcdir/config/gnu-fflags
 
-  icc)
-    CFLAGS="$CFLAGS"
-    DEBUG_CFLAGS="-g"
-    DEBUG_CPPFLAGS=
-    # There is a bug somewhere in mfhdf/libsrc that is exposed by compiling
-    # with any optimization in $CC in Lion, Mountain Lion, Mavericks and Yosemeti systems.
-    # Use -O0 for now.
-    case "$host_os" in
-    darwin1[1-9].*)    # Lion & Mountain Lion & Mavericks & Yosemite & 5 more
-        xOFLAG="-O2"
-        ;;
-    *)        # Other OSX versions
-        xOFLAG="-O2"
-        ;;
-    esac
-    PROD_CFLAGS=${PROD_CFLAGS:-"$xOFLAG"}
-    PROD_CPPFLAGS=
-    PROFILE_CFLAGS="-pg"
-    PROFILE_CPPFLAGS=
-    ;;
+# compiler version strings
 
-  gcc)
-    if test $cc_vers_major -ge 10; then
-        CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
-    else
-        CFLAGS="$CFLAGS"
-    fi
-    DEBUG_CFLAGS="-g -ansi -Wall -pedantic "
-    DEBUG_CPPFLAGS=
-    # There is a bug somewhere in mfhdf/libsrc that is exposed by compiling
-    # with any optimization in $CC in Lion, Mountain Lion, Mavericks and Yosemeti systems.
-    # Use -O0 for now.
-    case "$host_os" in
-    darwin1[1-9].*)    # Lion & Mountain Lion & Mavericks & Yosemeti & 5 more
-        xOFLAG="-O2"
-        ;;
-    *)        # Other OSX versions
-        xOFLAG="-O2"
-        ;;
-    esac
-    PROD_CFLAGS=${PROD_CFLAGS:-"-ansi  -Wall -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wconversion -Wmissing-prototypes -Wnested-externs -pedantic $xOFLAG"}
-    PROD_CFLAGS=${PROD_CFLAGS:-"-ansi  -Wall -pedantic $xOFLAG"}
-    PROD_CPPFLAGS=
-    PROFILE_CFLAGS="-pg"
-    PROFILE_CPPFLAGS=
-    ;;
+# check if the compiler_version_info is already set
+if test -z "$cc_version_info"; then
 
-  *)
-    CFLAGS="$CFLAGS"
-    DEBUG_CFLAGS="-g"
-    DEBUG_CPPFLAGS=
-    PROD_CFLAGS=${PROD_CFLAGS:-"-O2"}
-    PROD_CPPFLAGS=
-    PROFILE_CFLAGS="-pg"
-    PROFILE_CPPFLAGS=
-    ;;
+case $CC in
+    # whatever matches *pgcc* will also match *gcc*, so this one must come first
+    *pgcc*)
+        cc_version_info=`$CC $CFLAGS $H5_CFLAGS -V 2>&1 | grep 'pgcc'`
+        ;;
+
+    *gcc*)
+        cc_version_info=`$CC $CFLAGS $H5_CFLAGS --version 2>&1 | grep -v 'PathScale' |\
+            grep 'GCC' | sed 's/\(.*(GCC) [-a-z0-9\. ]*\).*/\1/'`
+        ;;
+
+    *icc*)
+        cc_version_info=`$CC $CCFLAGS $H5_CCFLAGS -V 2>&1 | grep 'Version' |\
+            sed 's/\(Intel.* Compiler\).*\( Version [a-z0-9\.]*\).*\( Build [0-9]*\)/\1\2\3/'`
+        ;;
+
+    *clang*)
+        cc_version_info="`$CC $CFLAGS $H5_CFLAGS --version 2>&1 |\
+            grep 'clang version' | sed 's/.*clang version \([-a-z0-9\.]*\).*/\1/'`"
+        ;;
+
+    *)
+        echo "No match to get cc_version_info for $CC"
+        ;;
 esac
 
-case $F77_BASENAME in
-  gfortran)
-    if test $fc_vers_major -ge 10; then
-        FFLAGS="$FFLAGS -fallow-argument-mismatch"
-    else
-        FFLAGS="$FFLAGS"
-    fi
-    DEBUG_FFLAGS="-g"
-    PROD_FFLAGS="-O2"
-    PROFILE_FFLAGS="-pg"
-    ;;
+fi
+
+# get fortran version info
+case $F77 in
+    *gfortran*)
+        fc_version_info=`$F77 $FFLAGS --version 2>&1 |\
+            grep 'GCC' | sed 's/\(.*(GCC) [-a-z0-9\. ]*\).*/\1/'`
+        fc_version="`$F77 $FFLAGS -v 2>&1 |grep 'gcc version' |\
+                sed 's/.*gcc version \([-a-z0-9\.]*\).*/\1/'`"
+        if test X != "X$fc_version"; then
+            fc_version=`echo $fc_version |sed 's/[-a-z]//g'`
+        fi
+        ;;
+
+    *ifc*|*ifort*)
+        fc_version_info=`$F77 $FFLAGS -V 2>&1 | grep 'Version' |\
+            sed 's/\(Intel.* Compiler\).*\( Version [a-z0-9\.]*\).*\( Build [0-9]*\)/\1\2\3/'`
+        fc_version="`$F77 $FFLAGS -V 2>&1 |grep '^Intel'`"
+        if test X != "X$fc_version"; then
+            fc_version="`echo $fc_version |sed 's/.*Version \([-a-z0-9\.\-]*\).*/\1/'`"
+        fi
+        ;;
+
+    *f95*)
+        # Figure out which compiler we are using: pgf90 or Absoft f95
+        RM='rm -f'
+        tmpfile=/tmp/cmpver.$$
+        $F77 -V >$tmpfile
+        if test -s "$tmpfile"; then
+            if( grep -s 'Absoft' $tmpfile > /dev/null) then
+                FC_BASENAME=f95
+            fi
+        fi
+        $RM $tmpfile
+        fc_version_info=`$F77 -V | grep Absoft`
+        ;;
+
+    *g95*|*g77*)
+        fc_version_info=`$F77 $FFLAGS --version 2>&1 |\
+            grep 'GCC'`
+        ;;
+
+    *pgf90*)
+        fc_version_info=`$F77 $FFLAGS -V 2>&1 | grep 'pgf90'`
+        fc_version="`$F77 $FFLAGS -V 2>&1 |grep '^pgf90 '`"
+        if test X != "X$fc_version"; then
+            fc_version=`echo $fc_version |sed 's/pgf90 \([-a-z0-9\.\-]*\).*/\1/'`
+        fi
+        ;;
+
+     *)
+        echo "No match to get fc_version_info for $F77"
+        ;;
 esac
 
+if test X != "X$fc_version"; then
+    # Get the compiler version numbers
+    fc_vers_major=`echo $fc_version | cut -f1 -d.`
+fi

--- a/config/clang-flags
+++ b/config/clang-flags
@@ -1,0 +1,66 @@
+#                                                   -*- shell-script -*-
+#
+# This file is part of the HDF4 build script. It is processed shortly
+# after configure starts and defines, among other things, flags for
+# the various compilation modes.
+
+# Get the compiler version in a way that works for clang
+# unless a compiler version is already known
+#
+#   cc_vendor:    The compiler name: clang
+#   cc_version:   Version number: 6.0.0, 7.3.0, ... 10.0.1
+#
+if test "X-" = "X-$cc_flags_set"; then
+    # clang -v will return version number following "clang" on Linux machines,
+    # but on Xcode the version number will follow "Apple LLVM version"
+    # Note that the Xcode reported LLVM version doesn't match the canonical
+    # LLVM version, so you'll need to do different version checks for
+    # Xcode.
+    cc_version="`$CC $CFLAGS -v 2>&1 |\
+        grep 'clang version' | sed 's/.*clang version \([-a-z0-9\.]*\).*/\1/'`"
+    if test -n "$cc_version"; then
+        cc_vendor="clang"
+    else
+        cc_version="`$CC $CFLAGS $H5_CFLAGS -v 2>&1 |\
+            grep 'Apple LLVM version' | sed 's/.*Apple LLVM version \([-a-z0-9\.]*\).*/\1/'`"
+        if test -n "$cc_version"; then
+            cc_vendor="Apple LLVM"
+        fi
+    fi
+    if test "X-" != "X-$cc_version"; then
+
+        # Get the compiler version numbers
+        cc_vers_major=`echo $cc_version | cut -f1 -d.`
+        cc_vers_minor=`echo $cc_version | cut -f2 -d.`
+        cc_vers_patch=`echo $cc_version | cut -f3 -d.`
+        test -n "$cc_vers_major" || cc_vers_major=0
+        test -n "$cc_vers_minor" || cc_vers_minor=0
+        test -n "$cc_vers_patch" || cc_vers_patch=0
+    fi
+fi
+
+if test "X-clang" = "X-$cc_vendor" -o "X-Apple LLVM" = "X-$cc_vendor"; then
+    echo "compiler '$CC' is $cc_vendor-$cc_version"
+
+    CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
+    CFLAGS="$CFLAGS -ansi -Wall -pedantic"
+
+    DEBUG_CFLAGS="$CFLAGS -g"
+    DEBUG_CPPFLAGS=
+    PROD_CFLAGS="$CFLAGS -O2"
+    PROD_CPPFLAGS=
+    PROFILE_CFLAGS="-pg"
+    PROFILE_CPPFLAGS=
+
+    #################
+    # Flags are set #
+    #################
+    cc_flags_set=yes
+fi
+
+# Clear cc info if no flags set
+if test "X$cc_flags_set" = "X"; then
+    cc_vendor=
+    cc_version=
+fi
+

--- a/config/gnu-fflags
+++ b/config/gnu-fflags
@@ -1,0 +1,98 @@
+#                                                   -*- shell-script -*-
+#
+# This file is part of the HDF4 build script. It is processed shortly
+# after configure starts and defines, among other things, flags for
+# the various compilation modes.
+
+# C and Fortran Compiler and Preprocessor Flags
+# ---------------------------------------------------
+#
+# - Flags that end with `_CFLAGS' are always passed to the C compiler.
+# - Flags that end with `_FFLAGS' are always passed to the Fortran
+#   compiler.
+# - Flags that end with `_CPPFLAGS' are passed to the C compiler
+#   when compiling but not when linking.
+#
+#   DEBUG_CFLAGS
+#   DEBUG_FFLAGS
+#   DEBUG_CPPFLAGS  - Flags to pass to the compiler to create a
+#                     library suitable for use with debugging
+#                      tools. Usually this list will exclude
+#                     optimization switches (like `-O') and include
+#                     switches that turn on symbolic debugging support
+#                     (like `-g').
+#
+#   PROD_CFLAGS
+#   PROD_FFLAGS
+#   PROD_CPPFLAGS   - Flags to pass to the compiler to create a
+#                     production version of the library. These
+#                     usually exclude symbolic debugging switches (like
+#                     `-g') and include optimization switches (like
+#                     `-O').
+#
+#   PROFILE_CFLAGS
+#   PROFILE_FFLAGS
+#   PROFILE_CPPFLAGS- Flags to pass to the compiler to create a
+#                     library suitable for performance testing (like
+#                     `-pg').  This may or may not include debugging or
+#                     production flags.
+#
+#   FFLAGS
+#   CFLAGS          - Flags can be added to these variable which
+#                     might already be partially initialized. These
+#                     flags will always be passed to the compiler and
+#                     should include switches to turn on full warnings.
+#
+#                     WARNING: flags do not have to be added to the CFLAGS
+#                     or FFLAGS variable if the compiler is the GNU gcc
+#                     and gfortran compiler.
+#
+#                     FFLAGS and CFLAGS should contain *something* or else
+#                     configure will probably add `-g'. For most systems
+#                     this isn't a problem but some systems will disable
+#                     optimizations in favor of the `-g'. The configure
+#                     script will remove the `-g' flag in production mode
+#                     only.
+#
+# These flags should be set according to the compiler being used.
+# There are two ways to check the compiler. You can try using `-v' or
+# `--version' to see if the compiler will print a version string.  You
+# can use the value of $FOO_BASENAME which is the base name of the
+# first word in $FOO, where FOO is either CC or F77 (note that the
+# value of CC may have changed above).
+
+case $F77_BASENAME in
+  gfortran)
+    if test $fc_vers_major -ge 10; then
+        FFLAGS="$FFLAGS -fallow-argument-mismatch"
+    else
+        FFLAGS="$FFLAGS"
+    fi
+    DEBUG_FFLAGS="-g"
+    PROD_FFLAGS="-O"
+    PROFILE_FFLAGS="-pg"
+    ;;
+
+  g77)
+    FFLAGS="$FFLAGS "
+    DEBUG_FFLAGS="-g"
+    PROD_FFLAGS="-O3 -fomit-frame-pointer"
+    PROFILE_FFLAGS="-pg"
+    ;;
+
+  f95)
+    CFLAGS="$CFLAGS"
+    FFLAGS="$FFLAGS"
+    DEBUG_FFLAGS="-g"
+    PROD_FFLAGS="-O"
+    PROFILE_FFLAGS="-pg"
+    ;;
+
+  g95)
+    CFLAGS="$CFLAGS"
+    FFLAGS="$FFLAGS -i4"
+    DEBUG_FFLAGS="-g"
+    PROD_FFLAGS="-O"
+    PROFILE_FFLAGS="-pg"
+    ;;
+esac

--- a/config/gnu-flags
+++ b/config/gnu-flags
@@ -1,0 +1,124 @@
+#                                                   -*- shell-script -*-
+#
+# This file is part of the HDF4 build script. It is processed shortly
+# after configure starts and defines, among other things, flags for
+# the various compilation modes.
+
+# Get the compiler version in a way that works for gcc
+# unless a compiler version is already known
+#
+#   cc_vendor:    The compiler name: gcc
+#   cc_version:   Version number: 2.91.60, 2.7.2.1
+#
+if test "X-" = "X-$cc_flags_set"; then
+    # PathScale compiler spits out gcc version string too. Need to
+    # filter it out.
+    # icc beginning with version 12 includes a "gcc version compatibility"
+    # string, causing the gcc CFLAGS to be erroneously added.  The line
+    # "grep -v 'icc version'" causes the discarding of any output
+    # containing 'icc version'.  The cc_version for icc is correctly determined
+    # and flags added in the intel-flags script.
+    cc_version="`$CC $CFLAGS -v 2>&1 | grep -v 'PathScale' |\
+        grep -v '^icc.*version' |\
+        grep 'gcc version' | sed 's/.*gcc version \([-a-z0-9\.]*\).*/\1/'`"
+    cc_vendor=`echo $cc_version |sed 's/\([a-z]*\).*/\1/'`
+    cc_version=`echo $cc_version |sed 's/[-a-z]//g'`
+    if test X = "X$cc_vendor" -a X != "X$cc_version"; then
+        cc_vendor=gcc
+    fi
+    if test "-" != "$cc_vendor-$cc_version"; then
+        echo "compiler '$CC' is GNU $cc_vendor-$cc_version"
+    fi
+
+    # Get the compiler version numbers
+    cc_vers_major=`echo $cc_version | cut -f1 -d.`
+    cc_vers_minor=`echo $cc_version | cut -f2 -d.`
+    cc_vers_patch=`echo $cc_version | cut -f3 -d.`
+    test -n "$cc_vers_major" || cc_vers_major=0
+    test -n "$cc_vers_minor" || cc_vers_minor=0
+    test -n "$cc_vers_patch" || cc_vers_patch=0
+fi
+
+# C and Fortran Compiler and Preprocessor Flags
+# ---------------------------------------------------
+#
+# - Flags that end with `_CFLAGS' are always passed to the C compiler.
+# - Flags that end with `_FFLAGS' are always passed to the Fortran
+#   compiler.
+# - Flags that end with `_CPPFLAGS' are passed to the C compiler
+#   when compiling but not when linking.
+#
+#   DEBUG_CFLAGS
+#   DEBUG_FFLAGS
+#   DEBUG_CPPFLAGS  - Flags to pass to the compiler to create a
+#                     library suitable for use with debugging
+#                      tools. Usually this list will exclude
+#                     optimization switches (like `-O') and include
+#                     switches that turn on symbolic debugging support
+#                     (like `-g').
+#
+#   PROD_CFLAGS
+#   PROD_FFLAGS
+#   PROD_CPPFLAGS   - Flags to pass to the compiler to create a
+#                     production version of the library. These
+#                     usually exclude symbolic debugging switches (like
+#                     `-g') and include optimization switches (like
+#                     `-O').
+#
+#   PROFILE_CFLAGS
+#   PROFILE_FFLAGS
+#   PROFILE_CPPFLAGS- Flags to pass to the compiler to create a
+#                     library suitable for performance testing (like
+#                     `-pg').  This may or may not include debugging or
+#                     production flags.
+#
+#   FFLAGS
+#   CFLAGS          - Flags can be added to these variable which
+#                     might already be partially initialized. These
+#                     flags will always be passed to the compiler and
+#                     should include switches to turn on full warnings.
+#
+#                     WARNING: flags do not have to be added to the CFLAGS
+#                     or FFLAGS variable if the compiler is the GNU gcc
+#                     and gfortran compiler.
+#
+#                     FFLAGS and CFLAGS should contain *something* or else
+#                     configure will probably add `-g'. For most systems
+#                     this isn't a problem but some systems will disable
+#                     optimizations in favor of the `-g'. The configure
+#                     script will remove the `-g' flag in production mode
+#                     only.
+#
+# These flags should be set according to the compiler being used.
+# There are two ways to check the compiler. You can try using `-v' or
+# `--version' to see if the compiler will print a version string.  You
+# can use the value of $FOO_BASENAME which is the base name of the
+# first word in $FOO, where FOO is either CC or F77 (note that the
+# value of CC may have changed above).
+
+if test "X-gcc" = "X-$cc_vendor"; then
+
+    CFLAGS="-Wall -Wcast-qual -Wconversion -Wextra -Wfloat-equal -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-include-dirs -Wshadow -Wundef -Wwrite-strings -pedantic -Wno-c++-compat"
+    if test $cc_vers_major -ge 10; then
+        CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
+    else
+        CFLAGS="$CFLAGS"
+    fi
+    DEBUG_CFLAGS="$CFLAGS -g -fverbose-asm"
+    DEBUG_CPPFLAGS=
+    PROD_CFLAGS="$CFLAGS -O3 -fomit-frame-pointer"
+    PROD_CPPFLAGS=
+    PROFILE_CFLAGS="-pg"
+    PROFILE_CPPFLAGS=
+
+    #################
+    # Flags are set #
+    #################
+    cc_flags_set=yes
+fi
+
+# Clear cc info if no flags set
+if test "X$cc_flags_set" = "X"; then
+    cc_vendor=
+    cc_version=
+fi

--- a/config/intel-flags
+++ b/config/intel-flags
@@ -30,9 +30,11 @@ if test X = "X$cc_flags_set"; then
 fi
 
 # Common Intel flags for various situations
-if test "X-icc" = "X-$cc_vendor"; then
+if test "X-icc" = "X-$cc_vendor" -o "X-icx" = "X-$cc_vendor"; then
 
+    # -diag-disable=10441 disables the icc deprecation message
     CFLAGS="$CFLAGS -Wall -diag-disable=10441"
+    CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
 
     DEBUG_CFLAGS="$CFLAGS -g"
     DEBUG_CPPFLAGS=

--- a/config/intel-flags
+++ b/config/intel-flags
@@ -1,0 +1,55 @@
+#                                                   -*- shell-script -*-
+#
+# This file is part of the HDF4 build script. It is processed shortly
+# after configure starts and defines, among other things, flags for
+# the various compilation modes.
+
+# Get the compiler version in a way that works for icc
+# icc unless a compiler version is already known
+#
+#   cc_vendor:    The compiler name: icc
+#   cc_version:   Version number: 8.0
+#
+if test X = "X$cc_flags_set"; then
+    cc_version="`$CC $CFLAGS -V 2>&1 |grep 'Version'`"
+    if test X != "X$cc_version"; then
+        cc_vendor=icc
+        cc_version=`echo $cc_version |sed 's/.*Version \([-a-z0-9\.\-]*\).*/\1/'`
+        echo "compiler '$CC' is Intel $cc_vendor-$cc_version"
+
+        # Some version numbers
+        # Intel version numbers are of the form: "major.minor"
+        cc_vers_major=`echo $cc_version | cut -f1 -d.`
+        cc_vers_minor=`echo $cc_version | cut -f2 -d.`
+        #cc_vers_patch=`echo $cc_version | cut -f2 -d.`
+        test -n "$cc_vers_major" || cc_vers_major=0
+        test -n "$cc_vers_minor" || cc_vers_minor=0
+        test -n "$cc_vers_patch" || cc_vers_patch=0
+        cc_vers_all=`expr $cc_vers_major '*' 1000000 + $cc_vers_minor '*' 1000 + $cc_vers_patch`
+    fi
+fi
+
+# Common Intel flags for various situations
+if test "X-icc" = "X-$cc_vendor"; then
+
+    CFLAGS="$CFLAGS -Wall -diag-disable=10441"
+
+    DEBUG_CFLAGS="$CFLAGS -g"
+    DEBUG_CPPFLAGS=
+    PROD_CFLAGS="$CFLAGS -O3"
+    PROD_CPPFLAGS=
+    PROFILE_CFLAGS="-pg"
+    PROFILE_CPPFLAGS=
+
+
+    #################
+    # Flags are set #
+    #################
+    cc_flags_set=yes
+fi
+
+# Clear cc info if no flags set
+if test "X-$cc_flags_set" = "X-"; then
+    cc_vendor=
+    cc_version=
+fi

--- a/config/linux-gnu
+++ b/config/linux-gnu
@@ -85,14 +85,6 @@ case $CC in
         cc_version_info=`$CC $CFLAGS $H5_CFLAGS --version 2>&1 | grep -v 'PathScale' |\
             grep 'GCC' | sed 's/\(.*(GCC) [-a-z0-9\. ]*\).*/\1/'`
         ;;
-    # this must come before *icc* for the same reason
-    *mpicc*)
-        cc_version_info=`$CC $CCFLAGS $H5_CCFLAGS -v 2>&1 | grep 'version' |\
-            sed 's/^[a-z0-9]* for //' |\
-            sed 's/\"/\\\"/g' |\
-            sed 's/^\([a-z]* \)/ built with \1/1'`
-        cc_version_info=`echo $cc_version_info`
-        ;; 
 
     *icc*)
         cc_version_info=`$CC $CCFLAGS $H5_CCFLAGS -V 2>&1 | grep 'Version' |\

--- a/config/linux-gnu
+++ b/config/linux-gnu
@@ -26,6 +26,16 @@ if test -z "$CC"; then
   CC_BASENAME=gcc
 fi
 
+# Figure out GNU C compiler flags
+. $srcdir/config/gnu-flags
+
+# Figure out Intel C compiler flags
+. $srcdir/config/intel-flags
+
+# Figure out Clang C compiler flags
+. $srcdir/config/clang-flags
+
+# Use default Fortran compiler according to what C compiler is used.
 if test "X-$F77" = "X-"; then
   F77=gfortran
   F77_BASENAME=gfortran
@@ -57,27 +67,41 @@ else
     esac
 fi
 
+# Figure out GNU FC compiler flags
+. $srcdir/config/gnu-fflags
 
 # compiler version strings
+
+# check if the compiler_version_info is already set
+if test -z "$cc_version_info"; then
+
 case $CC in
     # whatever matches *pgcc* will also match *gcc*, so this one must come first
     *pgcc*)
-        cc_version_info=`$CC $CFLAGS -V 2>&1 | grep 'pgcc'`
-        cc_version=`echo $cc_version |sed 's/pgcc \([-a-z0-9\.\-]*\).*/\1/'`
+        cc_version_info=`$CC $CFLAGS $H5_CFLAGS -V 2>&1 | grep 'pgcc'`
         ;;
 
     *gcc*)
-        cc_version_info=`$CC $CFLAGS --version 2>&1 | grep -v 'PathScale' |\
+        cc_version_info=`$CC $CFLAGS $H5_CFLAGS --version 2>&1 | grep -v 'PathScale' |\
             grep 'GCC' | sed 's/\(.*(GCC) [-a-z0-9\. ]*\).*/\1/'`
-        cc_version="`$CC $CFLAGS -v 2>&1 | grep -v 'PathScale' |\
-            grep -v '^icc.*version' |\
-            grep 'gcc version' | sed 's/.*gcc version \([-a-z0-9\.]*\).*/\1/'`"
         ;;
+    # this must come before *icc* for the same reason
+    *mpicc*)
+        cc_version_info=`$CC $CCFLAGS $H5_CCFLAGS -v 2>&1 | grep 'version' |\
+            sed 's/^[a-z0-9]* for //' |\
+            sed 's/\"/\\\"/g' |\
+            sed 's/^\([a-z]* \)/ built with \1/1'`
+        cc_version_info=`echo $cc_version_info`
+        ;; 
 
     *icc*)
-        cc_version_info=`$CC $CFLAGS -V 2>&1 | grep 'Version' |\
+        cc_version_info=`$CC $CCFLAGS $H5_CCFLAGS -V 2>&1 | grep 'Version' |\
             sed 's/\(Intel.* Compiler\).*\( Version [a-z0-9\.]*\).*\( Build [0-9]*\)/\1\2\3/'`
-        cc_version=`echo $cc_version |sed 's/.*Version \([-a-z0-9\.\-]*\).*/\1/'`
+        ;;
+
+    *clang*)
+        cc_version_info="`$CC $CFLAGS $H5_CFLAGS --version 2>&1 |\
+            grep 'clang version' | sed 's/.*clang version \([-a-z0-9\.]*\).*/\1/'`"
         ;;
 
     *)
@@ -85,14 +109,7 @@ case $CC in
         ;;
 esac
 
-if test X != "X$cc_version"; then
-    # Get the compiler version numbers
-    cc_vers_major=`echo $cc_version | cut -f1 -d.`
 fi
-test -n "$cc_vers_major" || cc_vers_major=0
-
-# Figure out GNU C compiler flags
-. $srcdir/config/gnu-flags
 
 # get fortran version info
 case $F77 in
@@ -151,9 +168,6 @@ if test X != "X$fc_version"; then
     # Get the compiler version numbers
     fc_vers_major=`echo $fc_version | cut -f1 -d.`
 fi
-
-# Figure out GNU FC compiler flags
-. $srcdir/config/gnu-fflags
 
 # Overriding Configure Tests
 # --------------------------

--- a/config/linux-gnu
+++ b/config/linux-gnu
@@ -20,7 +20,8 @@
 #       variable is set based on the incoming value of $CC and is only
 #       used within this file.
 
-if test "X-$CC" = "X-"; then
+# The default compiler is `gcc'.
+if test -z "$CC"; then
   CC=gcc
   CC_BASENAME=gcc
 fi
@@ -90,6 +91,9 @@ if test X != "X$cc_version"; then
 fi
 test -n "$cc_vers_major" || cc_vers_major=0
 
+# Figure out GNU C compiler flags
+. $srcdir/config/gnu-flags
+
 # get fortran version info
 case $F77 in
     *gfortran*)
@@ -148,126 +152,8 @@ if test X != "X$fc_version"; then
     fc_vers_major=`echo $fc_version | cut -f1 -d.`
 fi
 
-
-# C and Fortran Compiler and Preprocessor Flags
-# ---------------------------------------------------
-#
-# - Flags that end with `_CFLAGS' are always passed to the C compiler.
-# - Flags that end with `_FFLAGS' are always passed to the Fortran
-#   compiler.
-# - Flags that end with `_CPPFLAGS' are passed to the C compiler
-#   when compiling but not when linking.
-#
-#   DEBUG_CFLAGS
-#   DEBUG_FFLAGS
-#   DEBUG_CPPFLAGS  - Flags to pass to the compiler to create a
-#                     library suitable for use with debugging
-#                      tools. Usually this list will exclude
-#                     optimization switches (like `-O') and include
-#                     switches that turn on symbolic debugging support
-#                     (like `-g').
-#
-#   PROD_CFLAGS
-#   PROD_FFLAGS
-#   PROD_CPPFLAGS   - Flags to pass to the compiler to create a
-#                     production version of the library. These
-#                     usually exclude symbolic debugging switches (like
-#                     `-g') and include optimization switches (like
-#                     `-O').
-#
-#   PROFILE_CFLAGS
-#   PROFILE_FFLAGS
-#   PROFILE_CPPFLAGS- Flags to pass to the compiler to create a
-#                     library suitable for performance testing (like
-#                     `-pg').  This may or may not include debugging or
-#                     production flags.
-#
-#   FFLAGS
-#   CFLAGS          - Flags can be added to these variable which
-#                     might already be partially initialized. These
-#                     flags will always be passed to the compiler and
-#                     should include switches to turn on full warnings.
-#
-#                     WARNING: flags do not have to be added to the CFLAGS
-#                     or FFLAGS variable if the compiler is the GNU gcc
-#                     and gfortran compiler.
-#
-#                     FFLAGS and CFLAGS should contain *something* or else
-#                     configure will probably add `-g'. For most systems
-#                     this isn't a problem but some systems will disable
-#                     optimizations in favor of the `-g'. The configure
-#                     script will remove the `-g' flag in production mode
-#                     only.
-#
-# These flags should be set according to the compiler being used.
-# There are two ways to check the compiler. You can try using `-v' or
-# `--version' to see if the compiler will print a version string.  You
-# can use the value of $FOO_BASENAME which is the base name of the
-# first word in $FOO, where FOO is either CC or F77 (note that the
-# value of CC may have changed above).
-
-case $CC_BASENAME in
-  gcc)
-    CFLAGS="-Wall -Wcast-qual -Wconversion -Wextra -Wfloat-equal -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-include-dirs -Wshadow -Wundef -Wwrite-strings -pedantic -Wno-c++-compat"
-    if test $cc_vers_major -ge 10; then
-        CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
-    else
-        CFLAGS="$CFLAGS"
-    fi
-    DEBUG_CFLAGS="$CFLAGS -g -fverbose-asm"
-    DEBUG_CPPFLAGS=
-    PROD_CFLAGS="$CFLAGS -O3 -fomit-frame-pointer"
-    PROD_CPPFLAGS=
-    PROFILE_CFLAGS="-pg"
-    PROFILE_CPPFLAGS=
-    ;;
-
-  *)
-    CFLAGS="$CFLAGS"
-    DEBUG_CFLAGS="-g"
-    DEBUG_CPPFLAGS=
-    PROD_CFLAGS="-O"
-    PROD_CPPFLAGS=
-    PROFILE_CFLAGS="-pg"
-    PROFILE_CPPFLAGS=
-    ;;
-esac
-
-case $F77_BASENAME in
-  gfortran)
-    if test $fc_vers_major -ge 10; then
-        FFLAGS="$FFLAGS -fallow-argument-mismatch"
-    else
-        FFLAGS="$FFLAGS"
-    fi
-    DEBUG_FFLAGS="-g"
-    PROD_FFLAGS="-O"
-    PROFILE_FFLAGS="-pg"
-    ;;
-
-  g77)
-    FFLAGS="$FFLAGS "
-    DEBUG_FFLAGS="-g"
-    PROD_FFLAGS="-O3 -fomit-frame-pointer"
-    PROFILE_FFLAGS="-pg"
-    ;;
-
-  f95)
-    CFLAGS="$CFLAGS"
-    FFLAGS="$FFLAGS"
-    DEBUG_FFLAGS="-g"
-    PROD_FFLAGS="-O"
-    PROFILE_FFLAGS="-pg"
-    ;;
-
-  g95)
-    CFLAGS="$CFLAGS"
-    FFLAGS="$FFLAGS -i4"
-    DEBUG_FFLAGS="-g"
-    PROD_FFLAGS="-O"
-    PROFILE_FFLAGS="-pg"
-    ;;
-esac
+# Figure out GNU FC compiler flags
+. $srcdir/config/gnu-fflags
 
 # Overriding Configure Tests
 # --------------------------

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -38,6 +38,20 @@ New features and changes
 ========================
     Configuration:
     -------------
+    - Better Autotools compiler support on Linux and MacOS
+
+      The machine configuration files have been split into machine and
+      compiler files, which have been updated with additional warning
+      flags and compiler support.
+
+      Both Linux and MacOS now support:
+
+        * gcc
+        * clang
+        * icc/icx
+
+      (DER - 2023/01/20)
+
     - The Fortran interface is considered deprecated
 
       The Fortran interface is broken on 64-bit systems (see the known

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -41,9 +41,9 @@ New features and changes
     - The Fortran interface is considered deprecated
 
       The Fortran interface is broken on 64-bit systems (see the known
-      problems section) and is currently disabled by default. It will
-      be removed in a future version of the library, possibly as early
-      as 4.2.17.
+      problems section) and is currently disabled by default. It may
+      be removed in a future version of the library or replaced with an
+      alternative Fortran wrapper, possibly as early as 4.2.17.
 
       (DER - 2023/01/15)
 
@@ -202,6 +202,23 @@ Support for new platforms and compilers
 
 Bugs fixed since HDF 4.2.15
 ===========================
+    - Specifying CC on the command line works correctly in the Autotools
+
+      The CC variable was processed incorrectly in the Autotools build files
+      which led to minimal CFLAGS, etc. flags being specified when anything
+      other than CC=gcc was specified.
+
+      (DER - 2023/01/20)
+
+    - --enable-production in the Autotools works correctly
+
+      The variable that was checked when processing --enable-production in
+      the Autotools was spelled incorrectly, leading an Autotools build
+      to default to a "user defined" build that specified minimal flags
+      in CFLAGS, etc.
+
+      (DER - 2023/01/20)
+
     - Segfault is replaced with a failure
 
       Mathworks reported that a segfault had occurred when reading a


### PR DESCRIPTION
This splits the machine and compiler options into separate files. Only MacOs and Linux have been modified since those are the only machines I have available for testing.

Both Apple and Linux now support:
* icc/icx (icx is the new compiler from OneAPI, icc is considered deprecated)
* gcc
* clang

MacOS currently has a known failure w/ Autotools that does not appear w/ CMake. This is under investigation.

The HDF5 warning scheme has not been brought over at this time. Instead, the "generic" warnings that should work with most currently-used compiler versions are simply added to CFLAGS. When these warnings have been cleaned up, we can bring over the HDF5 scheme and its additional warnings.