### PR TITLE
Fixes a memory leak in the atom code

### DIFF
--- a/hdf/src/atom.c
+++ b/hdf/src/atom.c
@@ -595,6 +595,7 @@ HAshutdown(void)
 
     for (i = 0; i < (intn)MAXGROUP; i++)
         if (atom_group_list[i] != NULL) {
+            HDfree(atom_group_list[i]->atom_list);
             HDfree(atom_group_list[i]);
             atom_group_list[i] = NULL;
         } /* end if */

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -244,6 +244,13 @@ Support for new platforms and compilers
 
 Bugs fixed since HDF 4.2.15
 ===========================
+    - Fixed a small memory leak in the atom code
+
+      The atom list hast table of each atom group list was not cleaned up at
+      library shutdown, leading to a small memory leak (at most, a few kB).
+
+      (DER - 2023/01/29)
+
     - Specifying CC on the command line works correctly in the Autotools
 
       The CC variable was processed incorrectly in the Autotools build files


### PR DESCRIPTION
The atom list hash table of each atom group was not cleaned at shutdown, leading to a small leak (a few kB, at most).