### PR TITLE
Fix an issue where comparison w/ empty variable causes unary op warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1144,10 +1144,10 @@ AC_CONFIG_FILES([Makefile
                  hdf/util/h4redeploy
                  hdf/util/testutil.sh
                  man/Makefile
-        mfhdf/fortran/ftest.f
-        mfhdf/fortran/jackets.c
-        mfhdf/fortran/netcdf.inc
-        mfhdf/libsrc/netcdf.h
+                 mfhdf/fortran/ftest.f
+                 mfhdf/fortran/jackets.c
+                 mfhdf/fortran/netcdf.inc
+                 mfhdf/libsrc/netcdf.h
                  mfhdf/Makefile
                  mfhdf/dumper/Makefile
                  mfhdf/dumper/testhdp.sh

--- a/mfhdf/ncgen/testncgen.sh.in
+++ b/mfhdf/ncgen/testncgen.sh.in
@@ -110,8 +110,8 @@ RUN() {
    ${TESTS_ENVIRONMENT} $NCDUMP -n test1 test0.nc > test1.cdl
 
    # Run test.
-   if [ $HDF_BUILD_NETCDF -ne 0 ]; then
-      if [ $HDF_BUILD_FORTRAN -ne 0 ]; then
+   if [ "$HDF_BUILD_NETCDF" = "0" ]; then
+      if [ "$HDF_BUILD_FORTRAN" = "0" ]; then
          bcheck
          ccheck
          fcheck
@@ -137,4 +137,3 @@ RUN
 
 # End of test, return exit code
 FINISH
-    


### PR DESCRIPTION
Fixes `[: =: unary operator expected`