### PR TITLE
Removes PRIVATE and EXPORT macros

### DIFF
--- a/hdf/src/cdeflate.c
+++ b/hdf/src/cdeflate.c
@@ -43,7 +43,7 @@
 /* #define TESTING */
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIcdeflate_init(compinfo_t *info);
+static int32 HCIcdeflate_init(compinfo_t *info);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -64,7 +64,7 @@ PRIVATE int32 HCIcdeflate_init(compinfo_t *info);
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcdeflate_init(compinfo_t *info)
 {
     comp_coder_deflate_info_t *deflate_info; /* ptr to deflate info */
@@ -109,7 +109,7 @@ HCIcdeflate_init(compinfo_t *info)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcdeflate_decode(compinfo_t *info, int32 length, uint8 *buf)
 {
     comp_coder_deflate_info_t *deflate_info; /* ptr to deflate info */
@@ -176,7 +176,7 @@ HCIcdeflate_decode(compinfo_t *info, int32 length, uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcdeflate_encode(compinfo_t *info, int32 length, void *buf)
 {
     comp_coder_deflate_info_t *deflate_info; /* ptr to skipping Huffman info */
@@ -227,7 +227,7 @@ HCIcdeflate_encode(compinfo_t *info, int32 length, void *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcdeflate_term(compinfo_t *info, uint32 acc_mode)
 {
     comp_coder_deflate_info_t *deflate_info; /* ptr to deflation info */
@@ -297,7 +297,7 @@ HCIcdeflate_term(compinfo_t *info, uint32 acc_mode)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcdeflate_staccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t                *info;         /* special element information */
@@ -354,7 +354,7 @@ HCIcdeflate_staccess(accrec_t *access_rec, int16 acc_mode)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcdeflate_staccess2(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t                *info;         /* special element information */

--- a/hdf/src/cnbit.c
+++ b/hdf/src/cnbit.c
@@ -55,15 +55,15 @@ static const uint32 mask_arr32[33] = {/* array of values with [n] bits set */
                                       0x3FFFFFFF, 0x7FFFFFFF, 0xFFFFFFFFUL};
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIcnbit_staccess(accrec_t *access_rec, int16 acc_mode);
+static int32 HCIcnbit_staccess(accrec_t *access_rec, int16 acc_mode);
 
-PRIVATE int32 HCIcnbit_init(accrec_t *access_rec);
+static int32 HCIcnbit_init(accrec_t *access_rec);
 
-PRIVATE int32 HCIcnbit_decode(compinfo_t *info, int32 length, uint8 *buf);
+static int32 HCIcnbit_decode(compinfo_t *info, int32 length, uint8 *buf);
 
-PRIVATE int32 HCIcnbit_encode(compinfo_t *info, int32 length, const uint8 *buf);
+static int32 HCIcnbit_encode(compinfo_t *info, int32 length, const uint8 *buf);
 
-PRIVATE int32 HCIcnbit_term(compinfo_t *info);
+static int32 HCIcnbit_term(compinfo_t *info);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -84,7 +84,7 @@ PRIVATE int32 HCIcnbit_term(compinfo_t *info);
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcnbit_init(accrec_t *access_rec)
 {
     compinfo_t             *info;               /* special element information */
@@ -216,7 +216,7 @@ HCIcnbit_init(accrec_t *access_rec)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcnbit_decode(compinfo_t *info, int32 length, uint8 *buf)
 {
     comp_coder_nbit_info_t *nbit_info;   /* ptr to n-bit info */
@@ -366,7 +366,7 @@ HCIcnbit_decode(compinfo_t *info, int32 length, uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcnbit_encode(compinfo_t *info, int32 length, const uint8 *buf)
 {
     comp_coder_nbit_info_t *nbit_info;   /* ptr to n-bit info */
@@ -431,7 +431,7 @@ HCIcnbit_encode(compinfo_t *info, int32 length, const uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcnbit_term(compinfo_t *info)
 {
     (void)info;
@@ -462,7 +462,7 @@ HCIcnbit_term(compinfo_t *info)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcnbit_staccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t *info; /* special element information */

--- a/hdf/src/cnone.c
+++ b/hdf/src/cnone.c
@@ -42,7 +42,7 @@
 #include "hcompi.h" /* Internal definitions for compression */
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode);
+static int32 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -64,7 +64,7 @@ PRIVATE int32 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode);
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t *info; /* special element information */

--- a/hdf/src/crle.c
+++ b/hdf/src/crle.c
@@ -48,15 +48,15 @@
 /* #define TESTING */
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIcrle_staccess(accrec_t *access_rec, int16 acc_mode);
+static int32 HCIcrle_staccess(accrec_t *access_rec, int16 acc_mode);
 
-PRIVATE int32 HCIcrle_init(accrec_t *access_rec);
+static int32 HCIcrle_init(accrec_t *access_rec);
 
-PRIVATE int32 HCIcrle_decode(compinfo_t *info, int32 length, uint8 *buf);
+static int32 HCIcrle_decode(compinfo_t *info, int32 length, uint8 *buf);
 
-PRIVATE int32 HCIcrle_encode(compinfo_t *info, int32 length, const uint8 *buf);
+static int32 HCIcrle_encode(compinfo_t *info, int32 length, const uint8 *buf);
 
-PRIVATE int32 HCIcrle_term(compinfo_t *info);
+static int32 HCIcrle_term(compinfo_t *info);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -77,7 +77,7 @@ PRIVATE int32 HCIcrle_term(compinfo_t *info);
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcrle_init(accrec_t *access_rec)
 {
     compinfo_t            *info;     /* special element information */
@@ -120,7 +120,7 @@ HCIcrle_init(accrec_t *access_rec)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcrle_decode(compinfo_t *info, int32 length, uint8 *buf)
 {
     comp_coder_rle_info_t *rle_info;    /* ptr to RLE info */
@@ -195,7 +195,7 @@ HCIcrle_decode(compinfo_t *info, int32 length, uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcrle_encode(compinfo_t *info, int32 length, const uint8 *buf)
 {
     comp_coder_rle_info_t *rle_info;    /* ptr to RLE info */
@@ -305,7 +305,7 @@ HCIcrle_encode(compinfo_t *info, int32 length, const uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcrle_term(compinfo_t *info)
 {
     comp_coder_rle_info_t *rle_info; /* ptr to RLE info */
@@ -358,7 +358,7 @@ HCIcrle_term(compinfo_t *info)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcrle_staccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t *info; /* special element information */

--- a/hdf/src/cskphuff.c
+++ b/hdf/src/cskphuff.c
@@ -49,7 +49,7 @@
  */
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIcskphuff_init(accrec_t *access_rec, uintn alloc_buf);
+static int32 HCIcskphuff_init(accrec_t *access_rec, uintn alloc_buf);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -138,7 +138,7 @@ HCIcskphuff_splay(comp_coder_skphuff_info_t *skphuff_info, uint8 plain)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcskphuff_init(accrec_t *access_rec, uintn alloc_buf)
 {
     compinfo_t                *info;         /* special element information */
@@ -227,7 +227,7 @@ HCIcskphuff_init(accrec_t *access_rec, uintn alloc_buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcskphuff_decode(compinfo_t *info, int32 length, uint8 *buf)
 {
     comp_coder_skphuff_info_t *skphuff_info; /* ptr to skipping Huffman info */
@@ -288,7 +288,7 @@ HCIcskphuff_decode(compinfo_t *info, int32 length, uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcskphuff_encode(compinfo_t *info, int32 length, const uint8 *buf)
 {
     comp_coder_skphuff_info_t *skphuff_info; /* ptr to skipping Huffman info */
@@ -361,7 +361,7 @@ HCIcskphuff_encode(compinfo_t *info, int32 length, const uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcskphuff_term(compinfo_t *info)
 {
     comp_coder_skphuff_info_t *skphuff_info; /* ptr to skipping Huffman info */
@@ -406,7 +406,7 @@ HCIcskphuff_term(compinfo_t *info)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcskphuff_staccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t *info; /* special element information */

--- a/hdf/src/cszip.c
+++ b/hdf/src/cszip.c
@@ -29,15 +29,15 @@
 #define TMP_BUF_SIZE 8192 /* size of throw-away buffer */
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIcszip_staccess(accrec_t *access_rec, int16 acc_mode);
+static int32 HCIcszip_staccess(accrec_t *access_rec, int16 acc_mode);
 
-PRIVATE int32 HCIcszip_init(accrec_t *access_rec);
+static int32 HCIcszip_init(accrec_t *access_rec);
 
-PRIVATE int32 HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf);
+static int32 HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf);
 
-PRIVATE int32 HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf);
+static int32 HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf);
 
-PRIVATE int32 HCIcszip_term(compinfo_t *info);
+static int32 HCIcszip_term(compinfo_t *info);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -58,7 +58,7 @@ PRIVATE int32 HCIcszip_term(compinfo_t *info);
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcszip_init(accrec_t *access_rec)
 {
     compinfo_t             *info;      /* special element information */
@@ -120,7 +120,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
 {
 #ifdef H4_HAVE_LIBSZ
@@ -347,7 +347,7 @@ HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf)
 {
 #ifdef H4_HAVE_SZIP_ENCODER
@@ -412,7 +412,7 @@ HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcszip_term(compinfo_t *info)
 {
 #ifdef H4_HAVE_SZIP_ENCODER
@@ -630,7 +630,7 @@ HCIcszip_term(compinfo_t *info)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIcszip_staccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t *info; /* special element information */

--- a/hdf/src/dfan.c
+++ b/hdf/src/dfan.c
@@ -53,27 +53,27 @@
 
 #include "hdf.h"
 #include "dfan.h"
-PRIVATE uint16 Lastref        = 0; /* Last ref read/written */
-PRIVATE uint16 Next_label_ref = 0; /* Next file label ref to read/write */
-PRIVATE uint16 Next_desc_ref  = 0; /* Next file desc ref to read/write */
+static uint16 Lastref        = 0; /* Last ref read/written */
+static uint16 Next_label_ref = 0; /* Next file label ref to read/write */
+static uint16 Next_desc_ref  = 0; /* Next file desc ref to read/write */
 
-PRIVATE char *Lastfile = NULL;
+static char *Lastfile = NULL;
 
 /* pointers to directories of object annotations */
-PRIVATE DFANdirhead *DFANdir[2] = {
+static DFANdirhead *DFANdir[2] = {
     NULL, /* object labels       */
     NULL  /* object descriptions */
 };
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 /*
  ** Prototypes for local functions
  */
 
-PRIVATE int32 DFANIopen(const char *filename, intn acc_mode);
-PRIVATE intn  DFANIstart(void);
+static int32 DFANIopen(const char *filename, intn acc_mode);
+static intn  DFANIstart(void);
 
 /*-----------------------------------------------------------------------------
  * HDF object (i.e. tag/ref) label and description input routines
@@ -621,7 +621,7 @@ done:
  NAME
        DFANIopen -- open or reopen a file
  USAGE
-       PRIVATE int32 DFANIopen(filename, acc_mode)
+       static int32 DFANIopen(filename, acc_mode)
        char *filename;  IN: name of file to open
        intn acc_mode;     IN: access mode
  RETURNS
@@ -636,7 +636,7 @@ done:
  REVISION LOG
 
  *------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 DFANIopen(const char *filename, intn acc_mode)
 {
     int32        file_id;
@@ -1542,7 +1542,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFANIstart(void)
 {
     intn ret_value = SUCCEED;

--- a/hdf/src/dfconv.c
+++ b/hdf/src/dfconv.c
@@ -19,7 +19,7 @@
 
  Invokes:
 
- PRIVATE conversion functions: All of these are now in separate files!
+ Static conversion functions: All of these are now in separate files!
     dfknat.c
     DFKnb1b -  Native mode for 8 bit integers
     DFKnb2b -  Native mode for 16 bit integers
@@ -49,7 +49,7 @@
 
 /*****************************************************************************/
 /*                                                                           */
-/*    All the routines in this file marked as PRIVATE have been marked so    */
+/*    All the routines in this file marked as static have been marked so    */
 /*  for a reason.  *ANY* of these routines may or may nor be supported in    */
 /*  the next version of HDF (4.00).  Furthurmore, the names, parameters, or   */
 /*  functionality is *NOT* guaranteed to remain the same.                    */
@@ -70,7 +70,7 @@
 /*
  **  Static function prototypes
  */
-PRIVATE int DFKInoset(VOIDP source, VOIDP dest, uint32 num_elm, uint32 source_stride, uint32 dest_stride);
+static int DFKInoset(VOIDP source, VOIDP dest, uint32 num_elm, uint32 source_stride, uint32 dest_stride);
 
 /* Prototypes */
 extern int32 DFKqueryNT(void);
@@ -92,7 +92,7 @@ static int (*DFKnumout)(VOIDP source, VOIDP dest, uint32 num_elm, uint32 source_
  * If the programmer forgot to call DFKsetntype, then let
  * them know about it.
  ************************************************************/
-PRIVATE int
+static int
 DFKInoset(VOIDP source, VOIDP dest, uint32 num_elm, uint32 source_stride, uint32 dest_stride)
 {
     (void)source;
@@ -112,7 +112,7 @@ DFKInoset(VOIDP source, VOIDP dest, uint32 num_elm, uint32 source_stride, uint32
  * Routines that depend on the above information
  *****************************************************************************/
 
-PRIVATE int32 g_ntype = DFNT_NONE; /* Holds current number type. */
+static int32 g_ntype = DFNT_NONE; /* Holds current number type. */
                                    /* Initially not set.         */
 
 /************************************************************

--- a/hdf/src/dfconv.c
+++ b/hdf/src/dfconv.c
@@ -113,7 +113,7 @@ DFKInoset(VOIDP source, VOIDP dest, uint32 num_elm, uint32 source_stride, uint32
  *****************************************************************************/
 
 static int32 g_ntype = DFNT_NONE; /* Holds current number type. */
-                                   /* Initially not set.         */
+                                  /* Initially not set.         */
 
 /************************************************************
  * DFKqueryNT()

--- a/hdf/src/dfgr.c
+++ b/hdf/src/dfgr.c
@@ -56,10 +56,10 @@ static uint16 Grrefset   = 0;       /* Ref of image to get next */
 static uint16 Grlastref  = 0;       /* Last ref read/written */
 static intn   Grreqil[2] = {0, 0};  /* requested lut/image il */
 static struct {                     /* track refs of set vals written before */
-    intn  lut;                       /* -1: no vals set */
-    int16 dims[2];                   /* 0: vals set, not written */
-    intn  nt;                        /* non-zero: ref of val in file */
-} Ref                  = {-1, {-1, -1}, -1};
+    intn  lut;                      /* -1: no vals set */
+    int16 dims[2];                  /* 0: vals set, not written */
+    intn  nt;                       /* non-zero: ref of val in file */
+} Ref                 = {-1, {-1, -1}, -1};
 static DFGRrig Grread = {
     /* information about RIG being read */
     NULL,

--- a/hdf/src/dfgr.c
+++ b/hdf/src/dfgr.c
@@ -46,21 +46,21 @@
 #include "hdf.h"
 #include "dfgr.h"
 
-PRIVATE char     *Grlastfile = NULL;
-PRIVATE uint8    *Grlutdata  = NULL; /* points to lut, if in memory */
-PRIVATE intn      Grnewdata  = 0;    /* does Grread contain fresh data? */
-PRIVATE intn      Grcompr    = 0;    /* compression scheme to use */
-PRIVATE comp_info Grcinfo;           /* Compression information for each
+static char     *Grlastfile = NULL;
+static uint8    *Grlutdata  = NULL; /* points to lut, if in memory */
+static intn      Grnewdata  = 0;    /* does Grread contain fresh data? */
+static intn      Grcompr    = 0;    /* compression scheme to use */
+static comp_info Grcinfo;           /* Compression information for each
                                         scheme */
-PRIVATE uint16 Grrefset   = 0;       /* Ref of image to get next */
-PRIVATE uint16 Grlastref  = 0;       /* Last ref read/written */
-PRIVATE intn   Grreqil[2] = {0, 0};  /* requested lut/image il */
-PRIVATE struct {                     /* track refs of set vals written before */
+static uint16 Grrefset   = 0;       /* Ref of image to get next */
+static uint16 Grlastref  = 0;       /* Last ref read/written */
+static intn   Grreqil[2] = {0, 0};  /* requested lut/image il */
+static struct {                     /* track refs of set vals written before */
     intn  lut;                       /* -1: no vals set */
     int16 dims[2];                   /* 0: vals set, not written */
     intn  nt;                        /* non-zero: ref of val in file */
 } Ref                  = {-1, {-1, -1}, -1};
-PRIVATE DFGRrig Grread = {
+static DFGRrig Grread = {
     /* information about RIG being read */
     NULL,
     0,
@@ -82,7 +82,7 @@ PRIVATE DFGRrig Grread = {
         {0, 0, 0, 0, {0, 0}, {0, 0}},
     },
 };
-PRIVATE DFGRrig Grwrite = {
+static DFGRrig Grwrite = {
     /* information about RIG being written */
     NULL,
     0,
@@ -104,7 +104,7 @@ PRIVATE DFGRrig Grwrite = {
         {0, 0, 0, 0, {0, 0}, {0, 0}},
     },
 };
-PRIVATE DFGRrig Grzrig = {
+static DFGRrig Grzrig = {
     /* empty RIG for initialization */
     NULL,
     0,
@@ -128,16 +128,16 @@ PRIVATE DFGRrig Grzrig = {
 };
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 #define LUT   0
 #define IMAGE 1
 
 /* private functions */
-PRIVATE int  DFGRIriginfo(int32 file_id);
-PRIVATE int  DFGRgetrig(int32 file_id, uint16 ref, DFGRrig *rig);
-PRIVATE int  DFGRaddrig(int32 file_id, uint16 ref, DFGRrig *rig);
-PRIVATE intn DFGRIstart(void);
+static int  DFGRIriginfo(int32 file_id);
+static int  DFGRgetrig(int32 file_id, uint16 ref, DFGRrig *rig);
+static int  DFGRaddrig(int32 file_id, uint16 ref, DFGRrig *rig);
+static intn DFGRIstart(void);
 
 /*-----------------------------------------------------------------------------
  * Name:    DFGRgetlutdims
@@ -458,7 +458,7 @@ done:
  * Remarks: incomplete - does not support DFTAG_MA etc.
  *---------------------------------------------------------------------------*/
 
-PRIVATE int
+static int
 DFGRgetrig(int32 file_id, uint16 ref, DFGRrig *rig)
 {
     uint16 elt_tag, elt_ref;
@@ -552,7 +552,7 @@ done:
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-PRIVATE int
+static int
 DFGRaddrig(int32 file_id, uint16 ref, DFGRrig *rig)
 {
     uint8 ntstring[4];
@@ -733,7 +733,7 @@ done:
  * Remarks: if Grrefset set, gets image with that ref, if any
  *---------------------------------------------------------------------------*/
 
-PRIVATE int
+static int
 DFGRIriginfo(int32 file_id)
 {
     int    i, isfirst;
@@ -1380,7 +1380,7 @@ DFGRIlastref(void)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFGRIstart(void)
 {
     intn ret_value = SUCCEED;

--- a/hdf/src/dfgroup.c
+++ b/hdf/src/dfgroup.c
@@ -50,7 +50,7 @@ static DIlist_ptr Group_list[MAX_GROUPS] = {NULL};
  * Invokes:
  * Remarks: Allocates internal storage if necessary
  *---------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 setgroupREC(DIlist_ptr list_rec)
 {
     uintn i;

--- a/hdf/src/dfimcomp.c
+++ b/hdf/src/dfimcomp.c
@@ -66,26 +66,26 @@ static struct rgb *color_pt = (struct rgb *)NULL; /*contains the hi-lo */
 static uint8 *image;           /* contains the compressed image            */
 static int    trans[MAXCOLOR]; /* color translation table                  */
 
-PRIVATE VOID        compress(unsigned char raster[], int block);
-PRIVATE VOID        init_global(int32 xdim, int32 ydim, VOIDP out, VOIDP out_pal);
-PRIVATE int         cnt_color(int blocks);
-PRIVATE VOID        set_palette(int blocks);
-PRIVATE VOID        fillin_color(int blocks);
-PRIVATE int         indx(unsigned char r, unsigned char g, unsigned char b);
-PRIVATE VOID        map(int blocks);
-PRIVATE int         nearest_color(uint8 r, uint8 g, uint8 b);
-PRIVATE uint32      sqr(int16 x);
-PRIVATE VOID        sel_palette(int blocks, int distinct, struct rgb *my_color_pt);
-PRIVATE VOID        init(int blocks, int distinct, struct rgb *my_color_pt);
-PRIVATE VOID        sort(int l, int r, int dim, int rank[]);
-PRIVATE int         partition(int l, int r, int dim, int rank[]);
-PRIVATE struct box *find_box(void);
-PRIVATE VOID        split_box(struct box *ptr);
-PRIVATE VOID        assign_color(void);
-PRIVATE int         select_dim(struct box *ptr);
-PRIVATE float       find_med(struct box *ptr, int dim);
-PRIVATE VOID        classify(struct box *ptr, struct box *child);
-PRIVATE int         next_pt(int dim, int i, int rank[], int distinct);
+static VOID        compress(unsigned char raster[], int block);
+static VOID        init_global(int32 xdim, int32 ydim, VOIDP out, VOIDP out_pal);
+static int         cnt_color(int blocks);
+static VOID        set_palette(int blocks);
+static VOID        fillin_color(int blocks);
+static int         indx(unsigned char r, unsigned char g, unsigned char b);
+static VOID        map(int blocks);
+static int         nearest_color(uint8 r, uint8 g, uint8 b);
+static uint32      sqr(int16 x);
+static VOID        sel_palette(int blocks, int distinct, struct rgb *my_color_pt);
+static VOID        init(int blocks, int distinct, struct rgb *my_color_pt);
+static VOID        sort(int l, int r, int dim, int rank[]);
+static int         partition(int l, int r, int dim, int rank[]);
+static struct box *find_box(void);
+static VOID        split_box(struct box *ptr);
+static VOID        assign_color(void);
+static int         select_dim(struct box *ptr);
+static float       find_med(struct box *ptr, int dim);
+static VOID        classify(struct box *ptr, struct box *child);
+static int         next_pt(int dim, int i, int rank[], int distinct);
 
 /************************************************************************/
 /*  Function: DFCIimcomp                                                */
@@ -190,7 +190,7 @@ DFCIimcomp(int32 xdim, int32 ydim, const uint8 *in, uint8 out[], uint8 in_pal[],
 /*  Calls       : none                                                  */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 compress(unsigned char raster[], int block)
 {
     float32 y[16], y_av;
@@ -265,7 +265,7 @@ compress(unsigned char raster[], int block)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 init_global(int32 xdim, int32 ydim, VOIDP out, VOIDP out_pal)
 {
     int32 i, j;
@@ -303,7 +303,7 @@ init_global(int32 xdim, int32 ydim, VOIDP out, VOIDP out_pal)
 /*  Calls       : indx()                        */
 /************************************************************************/
 
-PRIVATE int
+static int
 cnt_color(int blocks)
 {
     int temp[MAXCOLOR];
@@ -342,7 +342,7 @@ cnt_color(int blocks)
 /*  Calls       : indx()                        */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 set_palette(int blocks)
 {
     int ent, i, k;
@@ -371,7 +371,7 @@ set_palette(int blocks)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 fillin_color(int blocks)
 {
     int i, j, k;
@@ -394,7 +394,7 @@ fillin_color(int blocks)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE int
+static int
 indx(unsigned char r, unsigned char g, unsigned char b)
 {
     int temp;
@@ -415,7 +415,7 @@ indx(unsigned char r, unsigned char g, unsigned char b)
 /*  Calls       : nearest_color()                   */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 map(int blocks)
 {
     int   i, k;
@@ -449,7 +449,7 @@ map(int blocks)
 /*  Calls       : sqr()                         */
 /************************************************************************/
 
-PRIVATE int
+static int
 nearest_color(uint8 r, uint8 g, uint8 b)
 {
     int      i, nearest;
@@ -479,7 +479,7 @@ nearest_color(uint8 r, uint8 g, uint8 b)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE uint32
+static uint32
 sqr(int16 x)
 {
     return ((uint32)x * (uint32)x);
@@ -550,7 +550,7 @@ DFCIunimcomp(int32 xdim, int32 ydim, uint8 in[], uint8 out[])
 /*  Calls       : init(), split_box(), find_box(), assign_color()   */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 sel_palette(int blocks, int distinct, struct rgb *my_color_pt)
 {
     int boxes;
@@ -597,7 +597,7 @@ sel_palette(int blocks, int distinct, struct rgb *my_color_pt)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 init(int blocks, int distinct, struct rgb *my_color_pt)
 {
     int         i, j, k, l;
@@ -684,7 +684,7 @@ init(int blocks, int distinct, struct rgb *my_color_pt)
 /*  Calls       : partition()                       */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 sort(int l, int r, int dim, int rank[])
 {
     int i;
@@ -709,7 +709,7 @@ sort(int l, int r, int dim, int rank[])
  *  Calls       : none
  ************************************************************************/
 
-PRIVATE int
+static int
 partition(int l, int r, int dim, int rank[])
 {
     int   i, j, temp;
@@ -758,7 +758,7 @@ partition(int l, int r, int dim, int rank[])
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE struct box *
+static struct box *
 find_box(void)
 {
     struct box *temp;
@@ -795,7 +795,7 @@ find_box(void)
 /*  Calls       : find_med(), select_dim(), classify()          */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 split_box(struct box *ptr)
 {
     int         dim, j, i;
@@ -842,7 +842,7 @@ split_box(struct box *ptr)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 assign_color(void)
 {
     struct box *temp;
@@ -891,7 +891,7 @@ assign_color(void)
 /*  Called by   : split_box()                       */
 /*  Calls       : none                          */
 /************************************************************************/
-PRIVATE int
+static int
 select_dim(struct box *ptr)
 {
     int   i, j;
@@ -935,7 +935,7 @@ select_dim(struct box *ptr)
 /*  Calls       : next_pt()                     */
 /************************************************************************/
 
-PRIVATE float
+static float
 find_med(struct box *ptr, int dim)
 {
     int     i, j, count, next, prev;
@@ -986,7 +986,7 @@ find_med(struct box *ptr, int dim)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE VOID
+static VOID
 classify(struct box *ptr, struct box *child)
 {
     int  i, j;
@@ -1044,7 +1044,7 @@ classify(struct box *ptr, struct box *child)
 /*  Calls       : none                          */
 /************************************************************************/
 
-PRIVATE int
+static int
 next_pt(int dim, int i, int rank[], int distinct)
 {
     int   j;

--- a/hdf/src/dfp.c
+++ b/hdf/src/dfp.c
@@ -30,14 +30,14 @@
 #include "hdf.h"
 
 /* remember that '0' is invalid ref number */
-PRIVATE uint16 Readref  = 0;
-PRIVATE uint16 Writeref = 0;
-PRIVATE uint16 Refset   = 0; /* Ref of palette to get next */
-PRIVATE uint16 Lastref  = 0; /* Last ref read/written */
+static uint16 Readref  = 0;
+static uint16 Writeref = 0;
+static uint16 Refset   = 0; /* Ref of palette to get next */
+static uint16 Lastref  = 0; /* Last ref read/written */
 
-PRIVATE char Lastfile[DF_MAXFNLEN] = ""; /* last file opened */
+static char Lastfile[DF_MAXFNLEN] = ""; /* last file opened */
 
-PRIVATE int32 DFPIopen(const char *filename, intn acc_mode);
+static int32 DFPIopen(const char *filename, intn acc_mode);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -479,7 +479,7 @@ DFPlastref(void)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 DFPIopen(const char *filename, intn acc_mode)
 {
     int32 file_id;

--- a/hdf/src/dfr8.c
+++ b/hdf/src/dfr8.c
@@ -44,25 +44,25 @@
 #include "dfrig.h"
 
 /* Private Variables */
-PRIVATE uint8 *paletteBuf = NULL;
-PRIVATE uint16 Refset     = 0;  /* Ref of image to get next */
-PRIVATE uint16 Lastref    = 0;  /* Last ref read/written */
-PRIVATE uint16 Writeref   = 0;  /* ref of next image to put in this file */
-PRIVATE intn   foundRig   = -1; /* -1: don't know if HDF file has RIGs
+static uint8 *paletteBuf = NULL;
+static uint16 Refset     = 0;  /* Ref of image to get next */
+static uint16 Lastref    = 0;  /* Last ref read/written */
+static uint16 Writeref   = 0;  /* ref of next image to put in this file */
+static intn   foundRig   = -1; /* -1: don't know if HDF file has RIGs
                                    0: No RIGs, try for RI8s etc.
                                    1: RIGs used, ignore RI8s etc. */
-PRIVATE intn Newdata    = 0;    /* does Readrig contain fresh data? */
-PRIVATE intn Newpalette = -1;   /* -1 = no palette is associated
+static intn Newdata    = 0;    /* does Readrig contain fresh data? */
+static intn Newpalette = -1;   /* -1 = no palette is associated
                                    0 = palette already written out
                                    1 = new palette, not yet written out */
 
-PRIVATE intn CompressSet = FALSE;        /* Whether the compression parameters have
+static intn CompressSet = FALSE;        /* Whether the compression parameters have
                                             been set for the next image */
-PRIVATE int32 CompType = COMP_NONE;      /* What compression to use for the next
+static int32 CompType = COMP_NONE;      /* What compression to use for the next
                                             image */
-PRIVATE comp_info CompInfo;              /* Params for compression to perform */
-PRIVATE char      Lastfile[DF_MAXFNLEN]; /* last file opened */
-PRIVATE DFRrig    Readrig = {
+static comp_info CompInfo;              /* Params for compression to perform */
+static char      Lastfile[DF_MAXFNLEN]; /* last file opened */
+static DFRrig    Readrig = {
     /* information about RIG being read */
     NULL,
     0,
@@ -80,7 +80,7 @@ PRIVATE DFRrig    Readrig = {
     {0, 0},
     {0, 0, 0, 0, {0, 0}, {0, 0}},
 };
-PRIVATE DFRrig Writerig = {
+static DFRrig Writerig = {
     /* information about RIG being written */
     NULL,
     0,
@@ -98,7 +98,7 @@ PRIVATE DFRrig Writerig = {
     {0, 0},
     {0, 0, 0, 0, {0, 0}, {0, 0}},
 };
-PRIVATE DFRrig Zrig = {
+static DFRrig Zrig = {
     /* empty RIG for initialization */
     NULL,
     0,
@@ -118,21 +118,21 @@ PRIVATE DFRrig Zrig = {
 };
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 /* private functions */
-PRIVATE intn DFR8Iputimage(const char *filename, const void *image, int32 xdim, int32 ydim, uint16 compress,
+static intn DFR8Iputimage(const char *filename, const void *image, int32 xdim, int32 ydim, uint16 compress,
                            intn append);
 
-PRIVATE int32 DFR8Iopen(const char *filename, intn acc_mode);
+static int32 DFR8Iopen(const char *filename, intn acc_mode);
 
-PRIVATE intn DFR8Iriginfo(int32 file_id);
+static intn DFR8Iriginfo(int32 file_id);
 
-PRIVATE intn DFR8getrig(int32 file_id, uint16 ref, DFRrig *rig);
+static intn DFR8getrig(int32 file_id, uint16 ref, DFRrig *rig);
 
-PRIVATE intn DFR8putrig(int32 file_id, uint16 ref, DFRrig *rig, intn wdim);
+static intn DFR8putrig(int32 file_id, uint16 ref, DFRrig *rig, intn wdim);
 
-PRIVATE intn DFR8Istart(void);
+static intn DFR8Istart(void);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -424,7 +424,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFR8Iputimage(const char *filename, const void *image, int32 xdim, int32 ydim, uint16 compress, intn append)
 {
     intn   acc_mode; /* create if op 0, write if op 1 */
@@ -662,7 +662,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFR8getrig(int32 file_id, uint16 ref, DFRrig *rig)
 {
     uint16 elt_tag;
@@ -768,7 +768,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFR8putrig(int32 file_id, uint16 ref, DFRrig *rig, intn wdim)
 {
     static uint16 prevdimref = 0; /*ref of previous dimension record, to reuse */
@@ -1212,7 +1212,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 DFR8Iopen(const char *filename, intn acc_mode)
 {
     int32 file_id;
@@ -1264,7 +1264,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFR8Iriginfo(int32 file_id)
 {
     uint16 riref = 0, ciref = 0;
@@ -1417,7 +1417,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFR8Istart(void)
 {
     intn ret_value = SUCCEED;

--- a/hdf/src/dfr8.c
+++ b/hdf/src/dfr8.c
@@ -122,7 +122,7 @@ static intn library_terminate = FALSE;
 
 /* private functions */
 static intn DFR8Iputimage(const char *filename, const void *image, int32 xdim, int32 ydim, uint16 compress,
-                           intn append);
+                          intn append);
 
 static int32 DFR8Iopen(const char *filename, intn acc_mode);
 

--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -154,14 +154,14 @@ static DFSsdg Writesdg = /* struct for writing */
 
 static uint16 Writeref = 0;         /* ref of next SDG/NDG to write to file */
 static intn   Newdata  = (-1);      /* Values in Readsdg fresh? */
-                                     /* -1 : no descriptor read */
-                                     /* 1 : descriptor read */
+                                    /* -1 : no descriptor read */
+                                    /* 1 : descriptor read */
 static intn Nextsdg = 1;            /* Signal if DFSDgetdata should get the */
-                                     /* next SDG/NDG */
+                                    /* next SDG/NDG */
 static int32  Sfile_id = DF_NOFILE; /* pointer to file for slice writes */
 static int32 *Sddims;               /*dims written so far in slice write */
 
-static struct {   /* Indicators of status (s) of info:    */
+static struct {    /* Indicators of status (s) of info:    */
     intn dims;     /* s = -1: there is no info in this category */
     intn nt;       /* s = 0: info was set, but not yet written */
     intn coordsys; /* s > 0: info was set and written with ref no.s */

--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -105,10 +105,10 @@ Fortran stub functions:
 #define NFGSDG_TYPE_SDGNDG 2 /* an SDG in NDG */
 
 /* Init NSDG table header      */
-PRIVATE DFnsdg_t_hdr *nsdghdr = NULL;
+static DFnsdg_t_hdr *nsdghdr = NULL;
 
 /* initialize aid to -1 and numbertype to DFNT_NONE.   S. Xu    */
-PRIVATE DFSsdg Readsdg = /* struct for reading */
+static DFSsdg Readsdg = /* struct for reading */
     {{(uint16)0, (uint16)0},
      (intn)0,
      NULL,
@@ -130,7 +130,7 @@ PRIVATE DFSsdg Readsdg = /* struct for reading */
      {0},
      0};
 
-PRIVATE DFSsdg Writesdg = /* struct for writing */
+static DFSsdg Writesdg = /* struct for writing */
     {{(uint16)0, (uint16)0},
      (intn)0,
      NULL,
@@ -152,16 +152,16 @@ PRIVATE DFSsdg Writesdg = /* struct for writing */
      {0},
      0};
 
-PRIVATE uint16 Writeref = 0;         /* ref of next SDG/NDG to write to file */
-PRIVATE intn   Newdata  = (-1);      /* Values in Readsdg fresh? */
+static uint16 Writeref = 0;         /* ref of next SDG/NDG to write to file */
+static intn   Newdata  = (-1);      /* Values in Readsdg fresh? */
                                      /* -1 : no descriptor read */
                                      /* 1 : descriptor read */
-PRIVATE intn Nextsdg = 1;            /* Signal if DFSDgetdata should get the */
+static intn Nextsdg = 1;            /* Signal if DFSDgetdata should get the */
                                      /* next SDG/NDG */
-PRIVATE int32  Sfile_id = DF_NOFILE; /* pointer to file for slice writes */
-PRIVATE int32 *Sddims;               /*dims written so far in slice write */
+static int32  Sfile_id = DF_NOFILE; /* pointer to file for slice writes */
+static int32 *Sddims;               /*dims written so far in slice write */
 
-PRIVATE struct {   /* Indicators of status (s) of info:    */
+static struct {   /* Indicators of status (s) of info:    */
     intn dims;     /* s = -1: there is no info in this category */
     intn nt;       /* s = 0: info was set, but not yet written */
     intn coordsys; /* s > 0: info was set and written with ref no.s */
@@ -174,11 +174,11 @@ PRIVATE struct {   /* Indicators of status (s) of info:    */
     intn new_ndg;
 } Ref = {-1, -1, -1, {-1, -1, -1}, -1, -1, -1, -1, -1, -1};
 
-PRIVATE intn Maxstrlen[4]  = {DFS_MAXLEN, DFS_MAXLEN, DFS_MAXLEN, DFS_MAXLEN};
-PRIVATE intn Ismaxmin      = 0; /* is there a max/min value on read?  */
-PRIVATE intn FileTranspose = 0; /* is the data in column major order? */
-PRIVATE intn Fortorder     = 0; /* should data be written col major?  */
-PRIVATE intn IsCal         = 0; /* has calibration info been set?     */
+static intn Maxstrlen[4]  = {DFS_MAXLEN, DFS_MAXLEN, DFS_MAXLEN, DFS_MAXLEN};
+static intn Ismaxmin      = 0; /* is there a max/min value on read?  */
+static intn FileTranspose = 0; /* is the data in column major order? */
+static intn Fortorder     = 0; /* should data be written col major?  */
+static intn IsCal         = 0; /* has calibration info been set?     */
 
 /* In ver. 3.2 numbertype and file number format (subclass) are included  */
 /* in DFSsdg, and  fileNTsize is local to functions .           */
@@ -188,16 +188,16 @@ PRIVATE intn IsCal         = 0; /* has calibration info been set?     */
 /*           outNTsize=4,                        */
 /*           userNT=DFNTF_IEEE ;         default */
 
-PRIVATE uint16 Readref  = 0; /* ref of next SDG/NDG to be read? */
-PRIVATE char  *Lastfile = NULL;
-PRIVATE uint16 Lastref  = 0; /* Last ref to be read/written? */
-PRIVATE DFdi   lastnsdg;     /* last read nsdg in nsdg_t */
+static uint16 Readref  = 0; /* ref of next SDG/NDG to be read? */
+static char  *Lastfile = NULL;
+static uint16 Lastref  = 0; /* Last ref to be read/written? */
+static DFdi   lastnsdg;     /* last read nsdg in nsdg_t */
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 /* Private buffer */
-PRIVATE uint8 *ptbuf = NULL;
+static uint8 *ptbuf = NULL;
 
 /* Prototypes */
 static intn DFSDIsetnsdg_t(int32 file_id, DFnsdg_t_hdr *l_nsdghdr);
@@ -5002,7 +5002,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 DFSDIstart(void)
 {
     intn ret_value = SUCCEED;

--- a/hdf/src/dfstubs.c
+++ b/hdf/src/dfstubs.c
@@ -86,12 +86,12 @@
 /*
  *  Important Internal Variables
  */
-PRIVATE DF *DFlist = NULL; /* pointer to list of open DFs */
+static DF *DFlist = NULL; /* pointer to list of open DFs */
 #ifdef PERM_OUT
-PRIVATE int            DFinuse    = 0;    /* How many are currently in use */
-PRIVATE uint16         DFmaxref   = 0;    /* which is the largest ref used? */
-PRIVATE unsigned char *DFreflist  = NULL; /* list of refs in use */
-PRIVATE char           patterns[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+static int            DFinuse    = 0;    /* How many are currently in use */
+static uint16         DFmaxref   = 0;    /* which is the largest ref used? */
+static unsigned char *DFreflist  = NULL; /* list of refs in use */
+static char           patterns[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
 #endif /* PERM_OUT */
 
 /*
@@ -505,7 +505,7 @@ DFaccess(DF *dfile, uint16 tag, uint16 ref, char *acc_mode)
     return (0);
 }
 
-PRIVATE int
+static int
 DFIclearacc(void)
 {
     Hendaccess(DFaid);
@@ -1051,7 +1051,7 @@ DFerrno(void)
  * Users:   HDF systems programmers, several routines in this file
  *---------------------------------------------------------------------------*/
 
-PRIVATE int
+static int
 DFIcheck(DF *dfile)
 {
     DFerror = DFE_NONE;

--- a/hdf/src/dfstubs.h
+++ b/hdf/src/dfstubs.h
@@ -37,29 +37,29 @@
 #define DFSRCH_OLD    0
 #define DFSRCH_NEW    1
 
-PRIVATE int32  DFid        = 0;
-PRIVATE int32  DFaid       = 0;
-PRIVATE int    DFaccmode   = 0;
-PRIVATE int    DFelaccmode = 0;
-PRIVATE uint16 search_tag  = 0;
-PRIVATE uint16 search_ref  = 0;
-PRIVATE int    search_stat = DFSRCH_NEW;
-PRIVATE int32  search_aid  = 0;
-PRIVATE int    DFelstat    = DFEL_ABSENT;
-PRIVATE int32  DFelsize    = 0;
-PRIVATE int32  DFelseekpos = 0;
-PRIVATE uint16 acc_tag     = 0;
-PRIVATE uint16 acc_ref     = 0;
-PRIVATE char  *DFelement   = NULL;
+static int32  DFid        = 0;
+static int32  DFaid       = 0;
+static int    DFaccmode   = 0;
+static int    DFelaccmode = 0;
+static uint16 search_tag  = 0;
+static uint16 search_ref  = 0;
+static int    search_stat = DFSRCH_NEW;
+static int32  search_aid  = 0;
+static int    DFelstat    = DFEL_ABSENT;
+static int32  DFelsize    = 0;
+static int32  DFelseekpos = 0;
+static uint16 acc_tag     = 0;
+static uint16 acc_ref     = 0;
+static char  *DFelement   = NULL;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* prototypes for internal routines */
-PRIVATE int DFIclearacc(void);
+static int DFIclearacc(void);
 
-PRIVATE int DFIcheck(DF *dfile);
+static int DFIcheck(DF *dfile);
 
 #ifdef __cplusplus
 }

--- a/hdf/src/hbitio.c
+++ b/hdf/src/hbitio.c
@@ -47,17 +47,17 @@ MODIFICATION HISTORY
 /* Local Variables */
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 /* Local Function Declarations */
-PRIVATE bitrec_t *HIget_bitfile_rec(void);
+static bitrec_t *HIget_bitfile_rec(void);
 
-PRIVATE intn HIbitflush(bitrec_t *bitfile_rec, intn flushbit, intn writeout);
+static intn HIbitflush(bitrec_t *bitfile_rec, intn flushbit, intn writeout);
 
-PRIVATE intn HIwrite2read(bitrec_t *bitfile_rec);
-PRIVATE intn HIread2write(bitrec_t *bitfile_rec);
+static intn HIwrite2read(bitrec_t *bitfile_rec);
+static intn HIread2write(bitrec_t *bitfile_rec);
 
-PRIVATE intn HIbitstart(void);
+static intn HIbitstart(void);
 
 /* #define TESTING */
 /* Actual Function Definitions */
@@ -695,7 +695,7 @@ Hendbitaccess(int32 bitfile_id, intn flushbit)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIbitstart(void)
 {
     intn ret_value = SUCCEED;
@@ -741,7 +741,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIbitflush(bitrec_t *bitfile_rec, intn flushbit, intn writeout)
 {
     intn write_size; /* number of bytes to write out */
@@ -784,7 +784,7 @@ HIbitflush(bitrec_t *bitfile_rec, intn flushbit, intn writeout)
 /*--------------------------------------------------------------------------
  HIget_bitfile_rec - get a new bitfile record
 --------------------------------------------------------------------------*/
-PRIVATE bitrec_t *
+static bitrec_t *
 HIget_bitfile_rec(void)
 {
     bitrec_t *ret_value = NULL;
@@ -814,7 +814,7 @@ HIget_bitfile_rec(void)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIread2write(bitrec_t *bitfile_rec)
 {
 
@@ -842,7 +842,7 @@ HIread2write(bitrec_t *bitfile_rec)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIwrite2read(bitrec_t *bitfile_rec)
 {
     intn  prev_count  = bitfile_rec->count; /* preserve this for later */

--- a/hdf/src/hblocks.c
+++ b/hdf/src/hblocks.c
@@ -148,11 +148,11 @@ typedef struct linkinfo_t {
 } linkinfo_t;
 
 /* private functions */
-PRIVATE int32 HLIstaccess(accrec_t *access_rec, int16 acc_mode);
+static int32 HLIstaccess(accrec_t *access_rec, int16 acc_mode);
 
-PRIVATE link_t *HLInewlink(int32 file_id, int32 number_blocks, uint16 link_ref, uint16 first_block_ref);
+static link_t *HLInewlink(int32 file_id, int32 number_blocks, uint16 link_ref, uint16 first_block_ref);
 
-PRIVATE link_t *HLIgetlink(int32 file_id, uint16 ref, int32 number_blocks);
+static link_t *HLIgetlink(int32 file_id, uint16 ref, int32 number_blocks);
 
 /* the accessing function table for linked blocks */
 funclist_t linked_funcs = {
@@ -594,7 +594,7 @@ DESCRIPTION
    pull in the information ourselves
 
 ----------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HLIstaccess(accrec_t *access_rec, int16 acc_mode)
 {
     filerec_t  *file_rec;           /* file record */
@@ -957,7 +957,7 @@ DESCRIPTION
    It seems that num_blocks is redundant.
 
 ---------------------------------------------------------------------------*/
-PRIVATE link_t *
+static link_t *
 HLIgetlink(int32 file_id, uint16 ref, int32 number_blocks)
 {
     int32   access_id; /* access record id */
@@ -1423,7 +1423,7 @@ DESCRIPTION
    ptr to the new link/block table.
 
 ---------------------------------------------------------------------------*/
-PRIVATE link_t *
+static link_t *
 HLInewlink(int32 file_id, int32 number_blocks, uint16 link_ref, uint16 first_block_ref)
 {
     int32   link_id;          /* access record id of new link */

--- a/hdf/src/hchunks.c
+++ b/hdf/src/hchunks.c
@@ -271,7 +271,7 @@ LOCAL ROUTINES
 
 /* private functions */
 static int32 HMCIstaccess(accrec_t *access_rec, /* IN: access record to fill in */
-                           int16     acc_mode /* IN: access mode */);
+                          int16     acc_mode /* IN: access mode */);
 
 /* -------------------------------------------------------------------------
 NAME

--- a/hdf/src/hchunks.c
+++ b/hdf/src/hchunks.c
@@ -270,7 +270,7 @@ LOCAL ROUTINES
 #include "hchunks.h"
 
 /* private functions */
-PRIVATE int32 HMCIstaccess(accrec_t *access_rec, /* IN: access record to fill in */
+static int32 HMCIstaccess(accrec_t *access_rec, /* IN: access record to fill in */
                            int16     acc_mode /* IN: access mode */);
 
 /* -------------------------------------------------------------------------
@@ -290,7 +290,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 create_dim_recs(DIM_REC **dptr, /* OUT: dimension record pointers */
                 int32   **sbi,  /* OUT: seek chunk indices array */
                 int32   **spb,  /* OUT: seek pos w/ chunk array */
@@ -357,7 +357,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 update_chunk_indices_seek(int32    sloc,    /* IN: physical Seek loc in element */
                           int32    ndims,   /* IN: number of dimensions of elem */
                           int32    nt_size, /* IN: number type size */
@@ -405,7 +405,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 compute_chunk_to_seek(int32   *chunk_seek, /* OUT: new physical chunk seek pos in element*/
                       int32    ndims,      /* IN: number of dims */
                       int32    nt_size,    /* IN: number type size */
@@ -465,7 +465,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 compute_chunk_to_array(int32   *chunk_indices,   /* IN: chunk indices */
                        int32   *chunk_array_ind, /* IN: chunk array indices */
                        int32   *array_indices,   /* OUT: array indices */
@@ -505,7 +505,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 compute_array_to_seek(int32   *user_seek,     /* OUT: user seek */
                       int32   *array_indices, /* IN: user array indices */
                       int32    nt_size,       /* IN: number type size */
@@ -540,7 +540,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 calculate_seek_in_chunk(int32   *chunk_seek, /* OUT: new physical seek pos in element*/
                         int32    ndims,      /* IN: number of dims */
                         int32    nt_size,    /* IN: number type size */
@@ -575,7 +575,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 update_seek_pos_chunk(int32    chunk_seek, /* IN: physical seek pos in chunk */
                       int32    ndims,      /* IN: number of dims */
                       int32    nt_size,    /* IN: number type size */
@@ -613,7 +613,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 calculate_chunk_num(int32   *chunk_num, /* OUT: new chunk number within element */
                     int32    ndims,     /* IN: number of dims */
                     int32   *sbi,       /* IN: seek chunk array */
@@ -646,7 +646,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ---------------------------------------------------------------------------*/
-PRIVATE void
+static void
 calculate_chunk_for_chunk(int32   *chunk_size,     /* OUT: chunk size for this chunk */
                           int32    ndims,          /* IN: number of dims */
                           int32    nt_size,        /* IN: number type size */
@@ -781,7 +781,7 @@ RETURNS
 AUTHOR
    -GeorgeV - 9/3/96
 ----------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HMCIstaccess(accrec_t *access_rec, /* IN: access record to fill in */
              int16     acc_mode /* IN: access mode */)
 {

--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -87,17 +87,17 @@ MODIFICATION HISTORY
 #define COMP_START_BLOCK    0
 
 /* declaration of the functions provided in this module */
-PRIVATE int32 HCIstaccess(accrec_t *access_rec, int16 acc_mode);
+static int32 HCIstaccess(accrec_t *access_rec, int16 acc_mode);
 
-PRIVATE int32 HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type,
+static int32 HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type,
                             comp_info *coder_info);
 
-PRIVATE int32 HCIread_header(accrec_t *access_rec, compinfo_t *info, comp_info *c_info, model_info *m_info);
+static int32 HCIread_header(accrec_t *access_rec, compinfo_t *info, comp_info *c_info, model_info *m_info);
 
-PRIVATE int32 HCIwrite_header(atom_t file_id, compinfo_t *info, uint16 special_tag, uint16 ref,
+static int32 HCIwrite_header(atom_t file_id, compinfo_t *info, uint16 special_tag, uint16 ref,
                               comp_info *c_info, model_info *m_info);
 
-PRIVATE int32 HCIinit_model(int16 acc_mode, comp_model_info_t *minfo, comp_model_t model_type,
+static int32 HCIinit_model(int16 acc_mode, comp_model_info_t *minfo, comp_model_t model_type,
                             model_info *m_info);
 
 /* comp_funcs -- struct of accessing functions for the compressed
@@ -137,7 +137,7 @@ funclist_t comp_funcs = {
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type, comp_info *c_info)
 {
     uint32 comp_config_info;
@@ -257,7 +257,7 @@ HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type,
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIinit_model(int16 acc_mode, comp_model_info_t *minfo, comp_model_t model_type, model_info *m_info)
 {
     (void)acc_mode;
@@ -576,7 +576,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIwrite_header(atom_t file_id, compinfo_t *info, uint16 special_tag, uint16 ref, comp_info *c_info,
                 model_info *m_info)
 {
@@ -630,7 +630,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIread_header(accrec_t *access_rec, compinfo_t *info, comp_info *c_info, model_info *m_info)
 {
     uint16 header_version; /* version of the compression header */
@@ -1018,7 +1018,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HCIstaccess(accrec_t *access_rec, int16 acc_mode)
 {
     compinfo_t *info = NULL; /* special element information */

--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -90,15 +90,15 @@ MODIFICATION HISTORY
 static int32 HCIstaccess(accrec_t *access_rec, int16 acc_mode);
 
 static int32 HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type,
-                            comp_info *coder_info);
+                           comp_info *coder_info);
 
 static int32 HCIread_header(accrec_t *access_rec, compinfo_t *info, comp_info *c_info, model_info *m_info);
 
 static int32 HCIwrite_header(atom_t file_id, compinfo_t *info, uint16 special_tag, uint16 ref,
-                              comp_info *c_info, model_info *m_info);
+                             comp_info *c_info, model_info *m_info);
 
 static int32 HCIinit_model(int16 acc_mode, comp_model_info_t *minfo, comp_model_t model_type,
-                            model_info *m_info);
+                           model_info *m_info);
 
 /* comp_funcs -- struct of accessing functions for the compressed
    data element function modules.  The position of each function in

--- a/hdf/src/hdf.h
+++ b/hdf/src/hdf.h
@@ -100,17 +100,6 @@ typedef enum {
 #define STREQ(s, t)     (HDstrcmp((s), (t)) == 0)
 #define NSTREQ(s, t, n) (HDstrncmp((s), (t), (n)) == 0)
 
-/*
- * Macros used for variable and function scoping in code.....
- */
-#ifndef EXPORT
-#define EXPORT
-#endif
-
-#ifndef PRIVATE
-#define PRIVATE static
-#endif
-
 /* Include the Number-type definitions */
 #include "hntdefs.h"
 

--- a/hdf/src/herr.c
+++ b/hdf/src/herr.c
@@ -52,7 +52,7 @@ typedef struct error_t {
 } error_t;
 
 /* pointer to the structure to hold error messages */
-PRIVATE error_t *error_stack = NULL;
+static error_t *error_stack = NULL;
 
 #ifndef DEFAULT_MESG
 #define DEFAULT_MESG "Unknown error"

--- a/hdf/src/herr.h
+++ b/hdf/src/herr.h
@@ -323,7 +323,7 @@ typedef struct error_messages_t {
     const char    *str;
 } error_messages_t;
 
-PRIVATE const struct error_messages_t error_messages[] = {
+static const struct error_messages_t error_messages[] = {
     {DFE_NONE, "No error"},
     /* Low-level I/O errors */
     {DFE_FNF, "File not found"},

--- a/hdf/src/hextelt.c
+++ b/hdf/src/hextelt.c
@@ -1154,8 +1154,7 @@ DESCRIPTION
 #define HDstrcpy3(s1, s2, s3, s4)     (HDstrcat(HDstrcat(HDstrcpy(s1, s2), s3), s4))
 #define HDstrcpy4(s1, s2, s3, s4, s5) (HDstrcat(HDstrcat(HDstrcat(HDstrcpy(s1, s2), s3), s4), s5))
 
-static
-char *
+static char *
 HXIbuildfilename(const char *ext_fname, const intn acc_mode)
 {
     int        fname_len;        /* string length of the ext_fname */

--- a/hdf/src/hextelt.c
+++ b/hdf/src/hextelt.c
@@ -109,8 +109,8 @@ typedef struct {
 } extinfo_t;
 
 /* forward declaration of the functions provided in this module */
-PRIVATE int32 HXIstaccess(accrec_t *access_rec, int16 access);
-PRIVATE char *HXIbuildfilename(const char *ext_fname, const intn acc_mode);
+static int32 HXIstaccess(accrec_t *access_rec, int16 access);
+static char *HXIbuildfilename(const char *ext_fname, const intn acc_mode);
 
 /* ext_funcs -- table of the accessing functions of the external
    data element function modules.  The position of each function in
@@ -436,7 +436,7 @@ DESCRIPTION
    pull in the information ourselves
 
 ---------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 HXIstaccess(accrec_t *access_rec, int16 acc_mode)
 {
     extinfo_t *info     = NULL; /* special element information */
@@ -1154,7 +1154,7 @@ DESCRIPTION
 #define HDstrcpy3(s1, s2, s3, s4)     (HDstrcat(HDstrcat(HDstrcpy(s1, s2), s3), s4))
 #define HDstrcpy4(s1, s2, s3, s4, s5) (HDstrcat(HDstrcat(HDstrcat(HDstrcpy(s1, s2), s3), s4), s5))
 
-PRIVATE
+static
 char *
 HXIbuildfilename(const char *ext_fname, const intn acc_mode)
 {

--- a/hdf/src/hfile.c
+++ b/hdf/src/hfile.c
@@ -123,14 +123,14 @@
 /*--------------------- Locally defined Globals -----------------------------*/
 
 /* The default state of the file DD caching */
-PRIVATE intn default_cache = TRUE;
+static intn default_cache = TRUE;
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn          library_terminate = FALSE;
-PRIVATE Generic_list *cleanup_list      = NULL;
+static intn          library_terminate = FALSE;
+static Generic_list *cleanup_list      = NULL;
 
 /* Whether to install the atexit routine */
-PRIVATE intn install_atexit = TRUE;
+static intn install_atexit = TRUE;
 
 /*--------------------- Externally defined Globals --------------------------*/
 /* Function tables declarations.  These function tables contain pointers
@@ -180,27 +180,27 @@ functab_t functab[] = {
 /*
  ** Declaration of private functions.
  */
-PRIVATE intn HIunlock(filerec_t *file_rec);
+static intn HIunlock(filerec_t *file_rec);
 
-PRIVATE filerec_t *HIget_filerec_node(const char *path);
+static filerec_t *HIget_filerec_node(const char *path);
 
-PRIVATE intn HIrelease_filerec_node(filerec_t *file_rec);
+static intn HIrelease_filerec_node(filerec_t *file_rec);
 
-PRIVATE intn HIvalid_magic(hdf_file_t file);
+static intn HIvalid_magic(hdf_file_t file);
 
-PRIVATE intn HIextend_file(filerec_t *file_rec);
+static intn HIextend_file(filerec_t *file_rec);
 
-PRIVATE funclist_t *HIget_function_table(accrec_t *access_rec);
+static funclist_t *HIget_function_table(accrec_t *access_rec);
 
-PRIVATE intn HIupdate_version(int32);
+static intn HIupdate_version(int32);
 
-PRIVATE intn HIread_version(int32);
+static intn HIread_version(int32);
 
-PRIVATE intn HIcheckfileversion(int32 file_id);
+static intn HIcheckfileversion(int32 file_id);
 
-PRIVATE intn HIsync(filerec_t *file_rec);
+static intn HIsync(filerec_t *file_rec);
 
-PRIVATE intn HIstart(void);
+static intn HIstart(void);
 
 /* #define TESTING */
 
@@ -1839,7 +1839,7 @@ DESCRIPTION
 NOTE
 
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIsync(filerec_t *file_rec)
 {
     intn ret_value = SUCCEED;
@@ -2083,7 +2083,7 @@ Internal Routines
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIstart(void)
 {
     intn ret_value = SUCCEED;
@@ -2221,7 +2221,7 @@ DESCRIPTION
    member of the file_rec.  This is mainly written as a function so that
    the functionality is localized.
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIextend_file(filerec_t *file_rec)
 {
     uint8 temp      = 0;
@@ -2248,7 +2248,7 @@ DESCRIPTION
    Set up the table of special functions for a given special element
 
 --------------------------------------------------------------------------*/
-PRIVATE funclist_t *
+static funclist_t *
 HIget_function_table(accrec_t *access_rec)
 {
     filerec_t  *file_rec; /* file record */
@@ -2324,7 +2324,7 @@ done:
 /*--------------------------------------------------------------------------
 HIunlock -- unlock a previously locked file record
 --------------------------------------------------------------------------*/
-PRIVATE int
+static int
 HIunlock(filerec_t *file_rec)
 {
     /* unlock the file record */
@@ -2364,7 +2364,7 @@ typedef struct special_table_t {
     uint16 special_tag;
 } special_table_t;
 
-PRIVATE special_table_t special_table[] = {
+static special_table_t special_table[] = {
     {0x8010, 0x4000 | 0x8010}, /* dummy */
 };
 
@@ -2526,7 +2526,7 @@ done:
     Checks that the file's version is current and update it if it isn't.
 
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIcheckfileversion(int32 file_id)
 {
     filerec_t *file_rec;
@@ -2585,7 +2585,7 @@ done:
        absolute paths.
 
 --------------------------------------------------------------------------*/
-PRIVATE filerec_t *
+static filerec_t *
 HIget_filerec_node(const char *path)
 {
     filerec_t *ret_value = NULL;
@@ -2624,7 +2624,7 @@ done:
         Release a file record back to the system
 
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIrelease_filerec_node(filerec_t *file_rec)
 {
     /* Close file if it's opened */
@@ -2755,7 +2755,7 @@ done:
        file are the HDF "magic number" HDFMAGIC
 
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 HIvalid_magic(hdf_file_t file)
 {
     char b[MAGICLEN];       /* Temporary buffer */
@@ -2846,7 +2846,7 @@ HIrelease_accrec_node(accrec_t *acc)
     entry.
 
 --------------------------------------------------------------------------*/
-PRIVATE int
+static int
 HIupdate_version(int32 file_id)
 {
     /* uint32 lmajorv, lminorv, lrelease; */
@@ -2904,7 +2904,7 @@ done:
     Writes to version fields of appropriate file_records[] entry.
 
 --------------------------------------------------------------------------*/
-PRIVATE int
+static int
 HIread_version(int32 file_id)
 {
     filerec_t *file_rec;

--- a/hdf/src/hkit.h
+++ b/hdf/src/hkit.h
@@ -37,7 +37,7 @@ typedef struct tag_descript_t {
  *        Please keep tag descriptions <= 30 characters - a
  *        lot of pretty-printing code depends on it.
  */
-PRIVATE const tag_descript_t tag_descriptions[] = {
+static const tag_descript_t tag_descriptions[] = {
     /* low-level set */
     {DFTAG_NULL, string(DFTAG_NULL), "No Data"},
     {DFTAG_LINKED, string(DFTAG_LINKED), "Linked Blocks Indicator"},
@@ -124,7 +124,7 @@ typedef struct nt_descript_t {
     const char *desc; /* nt description */
 } nt_descript_t;
 
-PRIVATE const nt_descript_t nt_descriptions[] = {
+static const nt_descript_t nt_descriptions[] = {
 
     /* Masks for types */
     {DFNT_NATIVE, string(DFNT_NATIVE), "native format"},

--- a/hdf/src/mfan.c
+++ b/hdf/src/mfan.c
@@ -90,18 +90,18 @@
 
 /* Whether we've installed the library termination function yet for this
    interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
-/* Function Prototypes for fcns used by TBBT. Can not be PRIVATE. */
+/* Function Prototypes for fcns used by TBBT. Can not be static. */
 extern void ANfreedata(void *data);
 extern void ANfreekey(void *key);
 extern void dumpentryKey(void *key, void *data);
 extern intn ANIanncmp(void *i, void *j, intn value);
 
 /* private initialization routine */
-PRIVATE intn ANIstart(void);
+static intn ANIstart(void);
 /* private destroy routine */
-PRIVATE intn ANIdestroy(void);
+static intn ANIdestroy(void);
 
 /*-----------------------------------------------------------------------------
  *                          Internal Routines
@@ -217,7 +217,7 @@ ANIdestroy(void)
     GeorgeV.
 
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 ANIstart(void)
 {
     intn ret_value = SUCCEED;
@@ -249,7 +249,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-PRIVATE int32
+static int32
 ANIinit(void)
 {
     int32 ret_value = SUCCEED;
@@ -285,7 +285,7 @@ done:
     GeorgeV.
 
  -------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 ANIaddentry(int32    an_id, /* IN: annotation interface id */
             ann_type type,  /* IN: annotation type
                                    AN_DATA_LABEL for data labels,
@@ -414,7 +414,7 @@ done:
     GeorgeV.
 
  -------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 ANIcreate_ann_tree(int32    an_id,/* IN: annotation interface id */
                    ann_type type  /* IN: AN_DATA_LABEL for data labels,
                                          AN_DATA_DESC for data descriptions,
@@ -594,7 +594,7 @@ done:
     GeorgeV.
 
  -------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 ANIfind(int32    an_id, /* IN: annotation interface id */
         ann_type type,  /* IN: AN_DATA_LABEL for data labels,
                                AN_DATA_DESC for data descriptions,
@@ -663,7 +663,7 @@ done:
     GeorgeV.
 
  -------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 ANInumann(int32    an_id,  /* IN: annotation interface id */
           ann_type type,   /* IN: AN_DATA_LABEL for data labels,
                                   AN_DATA_DESC for data descriptions,
@@ -723,7 +723,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 ANIannlist(int32    an_id,  /* IN: annotation interface id */
            ann_type type,   /* IN: AN_DATA_LABEL for data labels,
                                    AN_DATA_DESC for data descriptions,
@@ -783,7 +783,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 ANIannlen(int32 ann_id /*  IN: annotation id */)
 {
     ANnode *ann_node = NULL;
@@ -865,7 +865,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 ANIreadann(int32 ann_id, /* IN: annotation id (handle) */
            char *ann,    /* OUT: space to return annotation in */
            int32 maxlen /* IN: size of space to return annotation in */)
@@ -991,7 +991,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 ANIwriteann(int32       ann_id, /* IN: annotation id */
             const char *ann,    /* IN: annotation to write */
             int32       ann_len /* IN: length of annotation */)
@@ -1138,7 +1138,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-PRIVATE intn
+static intn
 ANIcreate(int32    file_id,  /* IN: file ID */
           uint16   elem_tag, /* IN: tag of item to be assigned annotation */
           uint16   elem_ref, /* IN: reference number of itme to be assigned ann */
@@ -1220,7 +1220,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-EXPORT int32
+int32
 ANstart(int32 file_id /* IN: file to start annotation access on*/)
 {
     filerec_t *file_rec  = NULL; /* file record pointer */
@@ -1261,7 +1261,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------------*/
-EXPORT intn
+intn
 ANfileinfo(int32  an_id,        /* IN:  annotation interface id */
            int32 *n_file_label, /* OUT: the # of file labels */
            int32 *n_file_desc,  /* OUT: the # of file descriptions */
@@ -1325,7 +1325,7 @@ done:
  RETURNS
     SUCCEED / FAIL
 --------------------------------------------------------------------------- */
-EXPORT int32
+int32
 ANend(int32 an_id /* IN: Annotation ID of file to close */)
 {
     filerec_t *file_rec  = NULL; /* file record pointer */
@@ -1450,7 +1450,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-EXPORT int32
+int32
 ANcreate(int32    an_id,    /* IN: annotation interface ID */
          uint16   elem_tag, /* IN: tag of item to be assigned annotation */
          uint16   elem_ref, /* IN: reference number of itme to be assigned ann */
@@ -1479,7 +1479,7 @@ ANcreate(int32    an_id,    /* IN: annotation interface ID */
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-EXPORT int32
+int32
 ANcreatef(int32    an_id,/* IN: annotation interface ID */
           ann_type type  /* IN:  AN_FILE_LABEL for file labels,
                                  AN_FILE_DESC for file descriptions.*/)
@@ -1524,7 +1524,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-EXPORT int32
+int32
 ANselect(int32    an_id, /* IN: annotation interface ID */
          int32    index, /* IN: index of annottion to get ID for */
          ann_type type   /* IN: AN_DATA_LABEL for data labels,
@@ -1587,7 +1587,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-EXPORT intn
+intn
 ANnumann(int32    an_id,  /* IN: annotation interface id */
          ann_type type,   /* IN: AN_DATA_LABEL for data labels,
                                  AN_DATA_DESC for data descriptions,
@@ -1625,7 +1625,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-EXPORT intn
+intn
 ANannlist(int32    an_id,  /* IN: annotation interface id */
           ann_type type,   /* IN: AN_DATA_LABEL for data labels,
                                   AN_DATA_DESC for data descriptions,
@@ -1661,7 +1661,7 @@ done:
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-EXPORT int32
+int32
 ANannlen(int32 ann_id /* IN: annotation id */)
 {
     int32 ret_value;
@@ -1685,7 +1685,7 @@ ANannlen(int32 ann_id /* IN: annotation id */)
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-EXPORT int32
+int32
 ANwriteann(int32       ann_id, /* IN: annotation id */
            const char *ann,    /* IN: annotation to write */
            int32       annlen /* IN: length of annotation */)
@@ -1711,7 +1711,7 @@ ANwriteann(int32       ann_id, /* IN: annotation id */
     GeorgeV.
 
  ------------------------------------------------------------------------*/
-EXPORT int32
+int32
 ANreadann(int32 ann_id, /* IN: annotation id (handle) */
           char *ann,    /* OUT: space to return annotation in */
           int32 maxlen /* IN: size of space to return annotation in */)
@@ -1736,7 +1736,7 @@ ANreadann(int32 ann_id, /* IN: annotation id (handle) */
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-EXPORT intn
+intn
 ANendaccess(int32 ann_id /* IN: annotation id */)
 {
     intn ret_value = SUCCEED;
@@ -1762,7 +1762,7 @@ ANendaccess(int32 ann_id /* IN: annotation id */)
     GeorgeV.
 
 --------------------------------------------------------------------------- */
-EXPORT int32
+int32
 ANget_tagref(int32    an_id, /* IN: annotation interface ID */
              int32    index, /* IN: index of annotation to get tag/ref for */
              ann_type type,  /* IN: AN_DATA_LABEL for data labels,
@@ -1989,7 +1989,7 @@ done:
     GeorgeV.
 
 --------------------------------------------------------------------*/
-EXPORT uint16
+uint16
 ANatype2tag(ann_type atype /* IN: Annotation type */)
 { /* Switch on annotation type "atype" */
     uint16 ann_tag;
@@ -2027,7 +2027,7 @@ ANatype2tag(ann_type atype /* IN: Annotation type */)
     GeorgeV.
 
 --------------------------------------------------------------------*/
-EXPORT ann_type
+ann_type
 ANtag2atype(uint16 atag /* IN: annotation tag */)
 { /* Switch on annotation tag */
     ann_type atype;

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -181,7 +181,7 @@ MODIFICATION HISTORY
 static TBBT_TREE *gr_tree = NULL;
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 typedef struct image_info_struct {
     uint16 grp_tag, grp_ref; /* tag/ref of the group the image is in */
@@ -190,22 +190,22 @@ typedef struct image_info_struct {
     int32  offset;           /* offset of the image data */
 } imginfo_t;
 
-PRIVATE intn GRIupdatemeta(int32 hdf_file_id, ri_info_t *img_ptr);
+static intn GRIupdatemeta(int32 hdf_file_id, ri_info_t *img_ptr);
 
-PRIVATE intn GRIupdateRIG(int32 hdf_file_id, ri_info_t *img_ptr);
+static intn GRIupdateRIG(int32 hdf_file_id, ri_info_t *img_ptr);
 
-PRIVATE intn GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr);
+static intn GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr);
 
-PRIVATE intn GRIup_attr_data(int32 hdf_file_id, at_info_t *attr_ptr);
+static intn GRIup_attr_data(int32 hdf_file_id, at_info_t *attr_ptr);
 
-PRIVATE intn GRIstart(void);
+static intn GRIstart(void);
 
-PRIVATE intn GRIgetaid(ri_info_t *img_ptr, intn acc_perm);
+static intn GRIgetaid(ri_info_t *img_ptr, intn acc_perm);
 
-PRIVATE intn GRIisspecial_type(int32 file_id, uint16 tag, uint16 ref);
+static intn GRIisspecial_type(int32 file_id, uint16 tag, uint16 ref);
 
 #ifdef H4_HAVE_LIBSZ /* we have the library */
-PRIVATE intn GRsetup_szip_parms(ri_info_t *ri_ptr, comp_info *c_info, int32 *cdims);
+static intn GRsetup_szip_parms(ri_info_t *ri_ptr, comp_info *c_info, int32 *cdims);
 #endif
 
 /*--------------------------------------------------------------------------
@@ -332,7 +332,7 @@ GRIridestroynode(void *n)
    Looks in the TBBT gr_tree for the file ID of a file.
    Returns a pointer to the gr_info_t for that file on success, otherwise NULL.
  */
-PRIVATE gr_info_t *
+static gr_info_t *
 Get_grfile(HFILEID f)
 {
     void **t; /* vfile_t pointer from tree */
@@ -373,7 +373,7 @@ Get_grfile(HFILEID f)
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIisspecial_type(int32 file_id, uint16 tag, uint16 ref)
 {
     accrec_t *access_rec = NULL; /* access element record */
@@ -425,7 +425,7 @@ done:
    Creates gr_info_t structure and adds it to the tree
    Returns a pointer to the gr_info_t for that file on success, otherwise NULL.
  */
-PRIVATE gr_info_t *
+static gr_info_t *
 New_grfile(HFILEID f)
 {
     gr_info_t *g;
@@ -447,7 +447,7 @@ New_grfile(HFILEID f)
 
    Added to refactor repeated code. -BMR, Jun 7, 2015
  */
-PRIVATE void
+static void
 Store_imginfo(imginfo_t *imginfo, uint16 grp_tag, uint16 grp_ref, uint16 img_tag, uint16 img_ref)
 {
     imginfo->grp_tag = (uint16)grp_tag;
@@ -467,7 +467,7 @@ Store_imginfo(imginfo_t *imginfo, uint16 grp_tag, uint16 grp_ref, uint16 img_tag
 
    Added to refactor repeated code. -BMR, Jul 13, 2015
  */
-PRIVATE intn
+static intn
 Get_oldimgs(int32 file_id, imginfo_t *img_info, uint16 searched_tag)
 {
     uint16     find_tag, find_ref;
@@ -496,7 +496,7 @@ Get_oldimgs(int32 file_id, imginfo_t *img_info, uint16 searched_tag)
 
    Added to refactor repeated code. -BMR, Apr 23, 2015
  */
-PRIVATE void
+static void
 Init_diminfo(dim_info_t *dim_info)
 { /* Init_diminfo */
     dim_info->dim_ref          = DFREF_WILDCARD;
@@ -521,7 +521,7 @@ Init_diminfo(dim_info_t *dim_info)
 
    Added to refactor repeated code. -BMR, Apr 23, 2015
  */
-PRIVATE void
+static void
 Decode_diminfo(uint8 *p, dim_info_t *dim_info)
 {
     int16 int16var; /* temp var */
@@ -1613,7 +1613,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIupdatemeta(int32 hdf_file_id, ri_info_t *img_ptr)
 {
     uint8  GRtbuf[64];  /* local buffer for reading RIG info */
@@ -1727,7 +1727,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIupdateRIG(int32 hdf_file_id, ri_info_t *img_ptr)
 {
     int32 GroupID; /* RIG id for group interface */
@@ -1803,7 +1803,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr)
 {
     int32 GroupID; /* RI vgroup id */
@@ -1908,7 +1908,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIup_attr_data(int32 hdf_file_id, at_info_t *attr_ptr)
 {
     intn ret_value = SUCCEED;
@@ -4854,7 +4854,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIstart(void)
 {
     intn ret_value = SUCCEED;
@@ -4894,7 +4894,7 @@ done:
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-PRIVATE intn
+static intn
 GRIgetaid(ri_info_t *ri_ptr, intn acc_perm)
 {
     int32      hdf_file_id; /* HDF file ID */

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -67,7 +67,7 @@
  */
 
 static int16 local_sizetab[] = {LOCAL_UNTYPEDSIZE, LOCAL_CHARSIZE, LOCAL_INTSIZE,   LOCAL_FLOATSIZE,
-                                 LOCAL_LONGSIZE,    LOCAL_BYTESIZE, LOCAL_SHORTSIZE, LOCAL_DOUBLESIZE};
+                                LOCAL_LONGSIZE,    LOCAL_BYTESIZE, LOCAL_SHORTSIZE, LOCAL_DOUBLESIZE};
 
 #define LOCALSIZETAB_SIZE sizeof(local_sizetab) / (sizeof(int))
 

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -32,7 +32,7 @@
 
 /*
  ** ==================================================================
- ** PRIVATE data areas and routines
+ ** static data areas and routines
  ** ==================================================================
  * */
 
@@ -66,7 +66,7 @@
    stores sizes of local machine's known types
  */
 
-PRIVATE int16 local_sizetab[] = {LOCAL_UNTYPEDSIZE, LOCAL_CHARSIZE, LOCAL_INTSIZE,   LOCAL_FLOATSIZE,
+static int16 local_sizetab[] = {LOCAL_UNTYPEDSIZE, LOCAL_CHARSIZE, LOCAL_INTSIZE,   LOCAL_FLOATSIZE,
                                  LOCAL_LONGSIZE,    LOCAL_BYTESIZE, LOCAL_SHORTSIZE, LOCAL_DOUBLESIZE};
 
 #define LOCALSIZETAB_SIZE sizeof(local_sizetab) / (sizeof(int))
@@ -75,7 +75,7 @@ PRIVATE int16 local_sizetab[] = {LOCAL_UNTYPEDSIZE, LOCAL_CHARSIZE, LOCAL_INTSIZ
  ** returns the machine size of a field type
  ** returns FAIL if error
  */
-PRIVATE int16
+static int16
 VSIZEOF(int16 x)
 {
     if (x < 0 || x > (int16)(LOCALSIZETAB_SIZE - 1)) {
@@ -96,8 +96,8 @@ VSIZEOF(int16 x)
 
 /* ------------------------------------------------------------------ */
 
-PRIVATE void oldunpackvg(VGROUP *vg, uint8 buf[], int32 *size);
-PRIVATE void oldunpackvs(VDATA *vs, uint8 buf[], int32 *size);
+static void oldunpackvg(VGROUP *vg, uint8 buf[], int32 *size);
+static void oldunpackvs(VDATA *vs, uint8 buf[], int32 *size);
 
 /*
  *  this routine checks that the given OPENED file is compatible with

--- a/hdf/src/vg.c
+++ b/hdf/src/vg.c
@@ -72,7 +72,7 @@ const char *HDF_INTERNAL_VDS[] = {DIM_VALS,    DIM_VALS01,      _HDF_ATTRIBUTE, 
 
 /* Private functions */
 #ifdef VDATA_FIELDS_ALL_UPPER
-PRIVATE int32 matchnocase(char *strx, char *stry);
+static int32 matchnocase(char *strx, char *stry);
 #endif /* VDATA_FIELDS_ALL_UPPER */
 
 #ifdef VDATA_FIELDS_ALL_UPPER
@@ -87,7 +87,7 @@ RETURNS
    if strings match return TRUE,
    else FALSE
 --------------------------------------------------------------------*/
-PRIVATE int32
+static int32
 matchnocase(char *strx, /* IN: first string to be compared */
             char *stry /* IN: second string to be compared */)
 {
@@ -1294,7 +1294,7 @@ RETURNS
    return TRUE, else FALSE.
    BMR - 2010/11/30
 *******************************************************************************/
-PRIVATE intn
+static intn
 vscheckclass(int32 id, /* IN: vgroup id or file id */
 	    uint16 vs_ref, /* IN: reference number of vdata being checked */
 	    const char *vsclass  /* IN: class name to be queried or NULL for

--- a/hdf/src/vgint.h
+++ b/hdf/src/vgint.h
@@ -172,7 +172,7 @@ struct vdata_desc {
 /* .................................................................. */
 /* Private data structures. Unlikely to be of interest to applications */
 /*
- * These are just typedefs. Actual vfile_ts are declared PRIVATE and
+ * These are just typedefs. Actual vfile_ts are declared static and
  * are not accessible by applications. However, you may change VFILEMAX
  * to allow however many files to be opened.
  *

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -112,17 +112,17 @@ const char *HDF_INTERNAL_VGS[] = {_HDF_VARIABLE, _HDF_DIMENSION, _HDF_UDIMENSION
 /* Prototypes */
 extern VOID vprint(VOIDP k1);
 
-PRIVATE intn Load_vfile(HFILEID f);
+static intn Load_vfile(HFILEID f);
 
-PRIVATE intn Remove_vfile(HFILEID f);
+static intn Remove_vfile(HFILEID f);
 
-PRIVATE intn vunpackvg(VGROUP *vg, uint8 buf[], intn len);
+static intn vunpackvg(VGROUP *vg, uint8 buf[], intn len);
 
-PRIVATE intn VIstart(void);
+static intn VIstart(void);
 
 /*
  * --------------------------------------------------------------------
- * PRIVATE  data structure and routines.
+ * Private data structure and routines.
  *
  * Info about all vgroups in the file are loaded into vgtab  at start;
  * and the vg field set to NULL until that vgroup is attached,
@@ -136,11 +136,11 @@ PRIVATE intn VIstart(void);
 TBBT_TREE *vtree = NULL;
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 /* Temporary buffer for I/O */
-PRIVATE uint32 Vgbufsize = 0;
-PRIVATE uint8 *Vgbuf     = NULL;
+static uint32 Vgbufsize = 0;
+static uint8 *Vgbuf     = NULL;
 
 /* Pointers to the VGROUP & vginstance node free lists */
 static VGROUP       *vgroup_free_list     = NULL;
@@ -291,7 +291,7 @@ RETURNS
    Returns a pointer to the vfile_t for that file on success, otherwise NULL.
 
 *******************************************************************************/
-PRIVATE vfile_t *
+static vfile_t *
 New_vfile(HFILEID f /* IN: file handle */)
 {
     vfile_t *v = NULL;
@@ -325,7 +325,7 @@ RETURNS
    RETURNS SUCCEED if ok.
 
 *******************************************************************************/
-PRIVATE intn
+static intn
 Load_vfile(HFILEID f /* IN: file handle */)
 {
     vfile_t      *vf = NULL;
@@ -476,7 +476,7 @@ DESCRIPTION
 RETURNS
 
 *******************************************************************************/
-PRIVATE intn
+static intn
 Remove_vfile(HFILEID f /* IN: file handle */)
 {
     VOIDP   *t         = NULL;
@@ -890,7 +890,7 @@ RETURNS
    NO RETURN VALUES
 
 *******************************************************************************/
-PRIVATE intn
+static intn
 vunpackvg(VGROUP *vg,    /* IN/OUT: */
           uint8   buf[], /* IN: */
           intn    len /* IN: */)
@@ -2821,7 +2821,7 @@ done:
  RETURNS
     Returns SUCCEED/FAIL
 *******************************************************************************/
-PRIVATE intn
+static intn
 VIstart(void)
 {
     intn ret_value = SUCCEED;

--- a/hdf/src/vio.c
+++ b/hdf/src/vio.c
@@ -17,8 +17,8 @@
  Part of the HDF Vset interface.
 
  VDATAs are handled by routines in here.
- PRIVATE functions manipulate vsdir and are used only within this file.
- PRIVATE data structures in here pertain to vdatas in vsdir only.
+ static functions manipulate vsdir and are used only within this file.
+ static data structures in here pertain to vdatas in vsdir only.
 
 
 LOCAL ROUTINES
@@ -62,11 +62,11 @@ EXPORTED ROUTINES
 #include "hdf.h"
 
 /* Private Function Prototypes */
-PRIVATE intn vunpackvs(VDATA *vs, uint8 buf[], int32 len);
+static intn vunpackvs(VDATA *vs, uint8 buf[], int32 len);
 
 /* Temporary buffer for I/O */
-PRIVATE uint32 Vhbufsize = 0;
-PRIVATE uint8 *Vhbuf     = NULL;
+static uint32 Vhbufsize = 0;
+static uint8 *Vhbuf     = NULL;
 
 /* Pointers to the VDATA & vsinstance node free lists */
 static VDATA        *vdata_free_list      = NULL;
@@ -326,7 +326,7 @@ CONTENTS of VS stored in HDF file with tag VSDESCTAG:
 
 /* ------------------------------- vpackvs ----------------------------------- */
 /*
-   The following 2 PRIVATE routines, vpackvs and vunpackvs, packs and unpacks
+   The following 2 static routines, vpackvs and vunpackvs, packs and unpacks
    a VDATA structure into a compact form suitable for storing in the HDF file.
  */
 
@@ -471,7 +471,7 @@ RETURNS
    SUCCEED / FAIL
 
 *******************************************************************************/
-PRIVATE intn
+static intn
 vunpackvs(VDATA *vs,    /* IN/OUT: */
           uint8  buf[], /* IN: */
           int32  len /* IN: */)

--- a/hdf/src/vparse.c
+++ b/hdf/src/vparse.c
@@ -27,13 +27,13 @@
 
 #define ISCOMMA(c) ((c == ',') ? 1 : 0)
 
-PRIVATE char *symptr[VSFIELDMAX];                   /* array of ptrs to tokens  ? */
-PRIVATE char  sym[VSFIELDMAX][FIELDNAMELENMAX + 1]; /* array of tokens ? */
-PRIVATE intn  nsym;                                 /* token index ? */
+static char *symptr[VSFIELDMAX];                   /* array of ptrs to tokens  ? */
+static char  sym[VSFIELDMAX][FIELDNAMELENMAX + 1]; /* array of tokens ? */
+static intn  nsym;                                 /* token index ? */
 
 /* Temporary buffer for I/O */
-PRIVATE uint32 Vpbufsize = 0;
-PRIVATE uint8 *Vpbuf     = NULL;
+static uint32 Vpbufsize = 0;
+static uint8 *Vpbuf     = NULL;
 
 /*******************************************************************************
  NAME

--- a/hdf/src/vrw.c
+++ b/hdf/src/vrw.c
@@ -41,8 +41,8 @@ EXPORTED ROUTINES
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif /* MIN */
 
-PRIVATE uint32 Vtbufsize = 0;
-PRIVATE uint8 *Vtbuf     = NULL;
+static uint32 Vtbufsize = 0;
+static uint8 *Vtbuf     = NULL;
 
 /*******************************************************************************
  NAME

--- a/hdf/test/tree.c
+++ b/hdf/test/tree.c
@@ -41,11 +41,11 @@
 #define SEED(s)       (srand(s))
 #define RandInt(a, b) ((rand() % (((b) - (a)) + 1)) + (a))
 
-PRIVATE VOID swap_arr(int32 *arr, intn a, intn b);
+static VOID swap_arr(int32 *arr, intn a, intn b);
 
 intn tcompare(VOIDP k1, VOIDP k2, intn cmparg);
 
-PRIVATE VOID
+static VOID
 swap_arr(int32 *arr, intn a, intn b)
 {
     int32 t;

--- a/hdf/util/hdf2jpeg.c
+++ b/hdf/util/hdf2jpeg.c
@@ -17,7 +17,7 @@
 /* Size of the file buffer to copy through */
 #define MAX_FILE_BUF 16384
 
-PRIVATE uint8 file_buf[MAX_FILE_BUF]; /* size of the buffer to copy through */
+static uint8 file_buf[MAX_FILE_BUF]; /* size of the buffer to copy through */
 
 static VOID usage(void);
 

--- a/hdf/util/jpeg2hdf.c
+++ b/hdf/util/jpeg2hdf.c
@@ -72,11 +72,11 @@ typedef enum { /* JPEG marker codes */
                M_ERROR = 0x100
 } JPEG_MARKER;
 
-PRIVATE int32 num_bytes;              /* number of bytes until the SOS code. */
-PRIVATE int32 image_width    = 0;     /* width of the JPEG image in pixels */
-PRIVATE int32 image_height   = 0;     /* height of the JPEG image in pixels */
-PRIVATE intn  num_components = 0;     /* number of components in the JPEG image */
-PRIVATE uint8 file_buf[MAX_FILE_BUF]; /* size of the buffer to copy through */
+static int32 num_bytes;              /* number of bytes until the SOS code. */
+static int32 image_width    = 0;     /* width of the JPEG image in pixels */
+static int32 image_height   = 0;     /* height of the JPEG image in pixels */
+static intn  num_components = 0;     /* number of components in the JPEG image */
+static uint8 file_buf[MAX_FILE_BUF]; /* size of the buffer to copy through */
 
 /*
  * Routines to parse JPEG markers & save away the useful info.

--- a/mfhdf/libsrc/hdfsds.c
+++ b/mfhdf/libsrc/hdfsds.c
@@ -78,17 +78,17 @@
 #define SDG_MAX_INITIAL 100
 
 /* local variables */
-PRIVATE intn    sdgCurrent;
-PRIVATE intn    sdgMax;
-PRIVATE uint16 *sdgTable = NULL;
-PRIVATE uint8  *ptbuf    = NULL;
+static intn    sdgCurrent;
+static intn    sdgMax;
+static uint16 *sdgTable = NULL;
+static uint8  *ptbuf    = NULL;
 
 /* Local routines */
-PRIVATE intn hdf_query_seen_sdg(uint16 ndgRef);
+static intn hdf_query_seen_sdg(uint16 ndgRef);
 
-PRIVATE intn hdf_register_seen_sdg(uint16 ndgRef);
+static intn hdf_register_seen_sdg(uint16 ndgRef);
 
-PRIVATE intn hdf_read_ndgs(NC *handle);
+static intn hdf_read_ndgs(NC *handle);
 
 uint8 *hdf_get_pred_str_attr(NC *handle, uint16 stratt_tag, uint16 satt_ref, int null_count);
 
@@ -107,7 +107,7 @@ uint8 *hdf_get_pred_str_attr(NC *handle, uint16 stratt_tag, uint16 satt_ref, int
    TRUE / FALSE
 
 ******************************************************************************/
-PRIVATE intn
+static intn
 hdf_query_seen_sdg(uint16 ndgRef)
 {
     intn i;
@@ -135,7 +135,7 @@ hdf_query_seen_sdg(uint16 ndgRef)
    SUCCEED / FAIL
 
 ******************************************************************************/
-PRIVATE intn
+static intn
 hdf_register_seen_sdg(uint16 sdgRef)
 {
     intn ret_value = SUCCEED;
@@ -180,7 +180,7 @@ done:
    SUCCEED / FAIL
 
 ******************************************************************************/
-PRIVATE intn
+static intn
 hdf_check_nt(uint8 *ntstring, int32 *type)
 {
     intn ret_value = SUCCEED;
@@ -212,7 +212,7 @@ hdf_check_nt(uint8 *ntstring, int32 *type)
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_read_rank(int32 acc_id, int16 *rank)
 {
     uint8         *p, *local_buf = NULL;
@@ -260,7 +260,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_read_dimsizes(int32 acc_id, int16 rank, int32 *dimsizes)
 {
     uint8         *p, *local_buf = NULL;
@@ -309,7 +309,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_read_NT(int32 acc_id, NC *handle, uint8 *ntstring_buf)
 {
     uint16         ntTag;
@@ -356,7 +356,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_get_sdc(NC *handle, uint16 tmpRef, NC_attr **tmp_attr, intn *curr_attr)
 {
     uint8         *coordbuf = NULL; /* buffer to store coord system info */
@@ -466,7 +466,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_get_desc_annot(NC *handle, uint16 ndgTag, uint16 ndgRef, NC_attr **tmp_attr, intn *curr_attr)
 {
     intn           i;
@@ -567,7 +567,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_get_label_annot(NC *handle, uint16 ndgTag, uint16 ndgRef, NC_attr **tmp_attr, intn *curr_attr)
 {
     intn           i;
@@ -669,7 +669,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_luf_to_attrs(char *labelstr, char *unitstr, char *formatstr, NC_attr **tmp_attr, intn *curr_attr)
 {
     hdf_err_code_t ret_value = DFE_NONE;
@@ -738,7 +738,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_get_rangeinfo(nc_type nctype, int32 hdftype, NC_attr **tmp_attr, intn *curr_attr)
 {
     uint8          tBuf[128] = "";
@@ -794,7 +794,7 @@ done:
    DFE_NONE / <error code>
 
 ******************************************************************************/
-PRIVATE hdf_err_code_t
+static hdf_err_code_t
 hdf_get_cal(nc_type nctype, int32 hdftype, NC_attr **tmp_attr, intn *curr_attr)
 {
     uint8          tBuf[128] = "";
@@ -904,7 +904,7 @@ done:
    SUCCEED / FAIL
 
 ******************************************************************************/
-PRIVATE intn
+static intn
 hdf_read_ndgs(NC *handle)
 {
     char  tmpname[80] = "";

--- a/mfhdf/libsrc/mfdatainfo.c
+++ b/mfhdf/libsrc/mfdatainfo.c
@@ -63,7 +63,7 @@ LOCAL ROUTINES
 #include "mfprivate.h"
 #endif
 
-PRIVATE intn get_attr_tag(char *attr_name, uint16 *attr_tag);
+static intn get_attr_tag(char *attr_name, uint16 *attr_tag);
 
 /******************************************************************************
  NAME
@@ -410,7 +410,7 @@ done:
     application can use tag/ref to read the attribute string.
 
  ******************************************************************************/
-PRIVATE intn
+static intn
 get_attr_tag(char *attr_name, uint16 *attr_tag)
 {
     intn ret_value = SUCCEED;

--- a/mfhdf/libsrc/mfsd.c
+++ b/mfhdf/libsrc/mfsd.c
@@ -114,7 +114,7 @@ NOTE: This file needs to have the comments cleaned up for most of the
 intn SDsetup_szip_parms(int32 id, NC *handle, comp_info *c_info, int32 *cdims);
 
 /* Whether we've installed the library termination function yet for this interface */
-PRIVATE intn library_terminate = FALSE;
+static intn library_terminate = FALSE;
 
 #ifdef MFSD_INTERNAL
 /******************************************************************************

--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -633,10 +633,10 @@ xdr_NCv1data(XDR *xdrs, u_long where, nc_type type, Void *values)
 
 #ifdef HDF
 
-PRIVATE int32 tBuf_size    = 0;
-PRIVATE int32 tValues_size = 0;
-PRIVATE int8 *tBuf         = NULL;
-PRIVATE int8 *tValues      = NULL;
+static int32 tBuf_size    = 0;
+static int32 tValues_size = 0;
+static int8 *tBuf         = NULL;
+static int8 *tValues      = NULL;
 
 /* ------------------------------ SDPfreebuf ------------------------------ */
 /*


### PR DESCRIPTION
PRIVATE was defined to `static` and EXPORT to nothing. There is no need to create a private dialect of C.