### PR TITLE
Correct -Waddress warnings

### DIFF
--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -388,7 +388,7 @@ DFSDgetdimstrs(int dim, char *label, char *unit, char *format)
     for (luf = LABEL; luf <= FORMAT; luf++) {
         lufp = (luf == LABEL) ? label : (luf == UNIT) ? unit : format;
         if (lufp) {
-            if (!Readsdg.dimluf) { /* no labels etc */
+            if (Readsdg.dimluf[0] == NULL) { /* no labels etc */
                 *lufp = '\0';
                 continue;
             }

--- a/hdf/src/vg.c
+++ b/hdf/src/vg.c
@@ -506,8 +506,7 @@ VSsetname(int32       vkey, /* IN: Vdata key */
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
     /* get current length of vdata name */
-    if (vs->vsname != NULL)
-        curr_len = HDstrlen(vs->vsname);
+    curr_len = strnlen(vs->vsname, VSNAMELENMAX + 1);
 
     /* check length of new name against MAX length */
     if ((slen = HDstrlen(vsname)) > VSNAMELENMAX) { /* truncate name */
@@ -1315,7 +1314,7 @@ vscheckclass(int32 id, /* IN: vgroup id or file id */
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
     /* Make sure this vdata has a class name before checking */
-    if (vs->vsclass != NULL && HDstrlen(vs->vsclass) != 0) {
+    if (strnlen(vs->vsclass, VSNAMELENMAX + 1) != 0) {
         /* If user-created vdatas are being checked for, then set flag
            if this vdata is not internally created by the library */
         if (vsclass == NULL) {

--- a/mfhdf/dumper/hdp_vd.c
+++ b/mfhdf/dumper/hdp_vd.c
@@ -416,7 +416,7 @@ printHeader(FILE *fp, char *fldstring, char *fields, vd_info_t *curr_vd)
         fprintf(fp, "   name = %s;", curr_vd->name);
 
     /* print class name - Note that vdclass can be NULL */
-    if (curr_vd->clss[0] == '\0' || curr_vd->clss == NULL)
+    if (curr_vd->clss[0] == '\0')
         fprintf(fp, " class = <Undefined>;\n");
     else
         fprintf(fp, " class = %s;\n", curr_vd->clss);

--- a/mfhdf/hdiff/hdiff_list.c
+++ b/mfhdf/hdiff/hdiff_list.c
@@ -1183,7 +1183,7 @@ insert_vs(int32 file_id, int32 ref, /* ref of input VS */
     }
 
     /* ignore reserved HDF groups/vdatas; they are lone ones */
-    if (is_lone == 1 && vdata_class != NULL) {
+    if (is_lone == 1 && vdata_class[0] == '\0') {
         if (is_reserved(vdata_class)) {
             if (VSdetach(vdata_id) == FAIL)
                 printf("Failed to detach vdata <%s>\n", path_name);

--- a/mfhdf/hrepack/hrepack_vs.c
+++ b/mfhdf/hrepack/hrepack_vs.c
@@ -72,7 +72,7 @@ copy_vs(int32 infile_id, int32 outfile_id, int32 tag, /* tag of input VS */
     }
 
     /* ignore reserved HDF groups/vdatas; they are lone ones */
-    if (is_lone == 1 && vdata_class != NULL) {
+    if (is_lone == 1 && vdata_class[0] == '\0') {
         if (is_reserved(vdata_class)) {
             if (VSdetach(vdata_id) == FAIL)
                 printf("Failed to detach vdata <%s>\n", path_name);

--- a/mfhdf/ncdump/ncdump.c
+++ b/mfhdf/ncdump/ncdump.c
@@ -270,9 +270,6 @@ fixstr(char *str, bool fix_str)
 
 static void
 do_ncdump(char *path, struct fspec *specp)
-/*     char *path;
-     struct fspec* specp;
-*/
 {
     int          ndims;       /* number of dimensions */
     int          nvars;       /* number of variables */
@@ -330,8 +327,7 @@ do_ncdump(char *path, struct fspec *specp)
             (void)ncdiminq(ncid, dimid, dims[dimid].name, &dims[dimid].size);
             fixed_str = fixstr(dims[dimid].name, specp->fix_str);
 
-            if (!fixed_str && dims[dimid].name) {
-                /* strdup(3) failed */
+            if (fixed_str == NULL) {
                 (void)ncclose(ncid);
                 return;
             }
@@ -354,8 +350,7 @@ do_ncdump(char *path, struct fspec *specp)
         (void)ncvarinq(ncid, varid, var.name, &var.type, &var.ndims, var.dims, &var.natts);
         fixed_var = fixstr(var.name, specp->fix_str);
 
-        if (!fixed_var && var.name) {
-            /* strdup(3) failed */
+        if (fixed_var == NULL) {
             (void)ncclose(ncid);
             return;
         }
@@ -368,8 +363,7 @@ do_ncdump(char *path, struct fspec *specp)
         for (id = 0; id < var.ndims; id++) {
             char *fixed_dim = fixstr(dims[var.dims[id]].name, specp->fix_str);
 
-            if (!fixed_dim && dims[var.dims[id]].name) {
-                /* strdup(3) failed */
+            if (fixed_dim == NULL) {
                 (void)ncclose(ncid);
                 free(fixed_var);
                 return;


### PR DESCRIPTION
There were several places where the library attempted to perform a NULL pointer check on an array. These were switched to checking for a \0 or NULL pointer in the first element of the array or removed if useless.