### PR TITLE
Fix a segfault in ncdump when CFLAGS=-std=c99

### DIFF
--- a/mfhdf/ncdump/ncdump.c
+++ b/mfhdf/ncdump/ncdump.c
@@ -232,34 +232,31 @@ pr_att_vals(nc_type type, int len, void *vals)
 }
 
 /*
- * fixstr
+ * sanitize_string
  *
  * 	If the string contains characters other than alpha-numerics,
  * 	an underscore, or a hyphen, convert it to an underscore.
- *
- * Modification:
- *	- Added "fix_str" to determine whether the conversion should be
- *	  carried out, based on user's request. - bug #934, BMR 7/3/2005
  */
 char *
-fixstr(char *str, bool fix_str)
+sanitize_string(char *str, bool sanitize)
 {
-#ifndef __GNUC__
-    char *strdup(const char *);
-#endif /* linux */
-    char *new_str, *ptr;
+    char *new_str = NULL;
 
     if (!str)
         return NULL;
 
-    ptr = new_str = strdup(str);
-
-    if (!ptr) {
+    new_str = HDstrdup(str);
+    if (NULL == new_str) {
         error("Out of memory!");
         return NULL;
     }
 
-    if (fix_str) {
+    if (sanitize) {
+        char *ptr = new_str;
+
+        /* Convert all non-alpha, non-numeric, non-hyphen, non-underscore
+         * characters to underscores
+         */
         for (; *ptr; ptr++)
             if (!isalnum(*ptr) && *ptr != '_' && *ptr != '-')
                 *ptr = '_';
@@ -322,11 +319,12 @@ do_ncdump(char *path, struct fspec *specp)
         Printf("dimensions:\n");
 
         for (dimid = 0; dimid < ndims; dimid++) {
-            char *fixed_str;
+            char *fixed_str = NULL;
 
-            (void)ncdiminq(ncid, dimid, dims[dimid].name, &dims[dimid].size);
-            fixed_str = fixstr(dims[dimid].name, specp->fix_str);
+            if (ncdiminq(ncid, dimid, dims[dimid].name, &dims[dimid].size) < 0)
+                fprintf(stderr, "Error calling ncdiminq on dimid = %d\n", dimid);
 
+            fixed_str = sanitize_string(dims[dimid].name, specp->fix_str);
             if (fixed_str == NULL) {
                 (void)ncclose(ncid);
                 return;
@@ -348,7 +346,7 @@ do_ncdump(char *path, struct fspec *specp)
         char *fixed_var;
 
         (void)ncvarinq(ncid, varid, var.name, &var.type, &var.ndims, var.dims, &var.natts);
-        fixed_var = fixstr(var.name, specp->fix_str);
+        fixed_var = sanitize_string(var.name, specp->fix_str);
 
         if (fixed_var == NULL) {
             (void)ncclose(ncid);
@@ -361,7 +359,7 @@ do_ncdump(char *path, struct fspec *specp)
             Printf("(");
 
         for (id = 0; id < var.ndims; id++) {
-            char *fixed_dim = fixstr(dims[var.dims[id]].name, specp->fix_str);
+            char *fixed_dim = sanitize_string(dims[var.dims[id]].name, specp->fix_str);
 
             if (fixed_dim == NULL) {
                 (void)ncclose(ncid);
@@ -380,7 +378,7 @@ do_ncdump(char *path, struct fspec *specp)
             char *fixed_att;
 
             (void)ncattname(ncid, varid, ia, att.name);
-            fixed_att = fixstr(att.name, specp->fix_str);
+            fixed_att = sanitize_string(att.name, specp->fix_str);
 
             if (!fixed_att) {
                 (void)ncclose(ncid);
@@ -418,7 +416,7 @@ do_ncdump(char *path, struct fspec *specp)
         char *fixed_att;
 
         (void)ncattname(ncid, NC_GLOBAL, ia, att.name);
-        fixed_att = fixstr(att.name, specp->fix_str);
+        fixed_att = sanitize_string(att.name, specp->fix_str);
 
         if (!fixed_att) {
             (void)ncclose(ncid);
@@ -701,5 +699,6 @@ main(int argc, char *argv[])
         if (argc > 0)
             do_ncdump(argv[i], &fspec);
     } while (++i < argc);
+
     return EXIT_SUCCESS;
 }

--- a/mfhdf/ncdump/testncdump.sh.in
+++ b/mfhdf/ncdump/testncdump.sh.in
@@ -66,6 +66,8 @@ TESTING() {
 # Run a test and print PASS or *FAIL*.  If a test fails then increment
 # the `nerrors' global variable
 #
+# XXX: This test is almost worthless since ncdump always returns EXIT_SUCCESS.
+#
 RUN() {
    # Run test.
 

--- a/mfhdf/ncdump/vardata.c
+++ b/mfhdf/ncdump/vardata.c
@@ -23,7 +23,7 @@
  * Function from ncdump.c. "Fixes" variable names to remove spaces and other
  * "illegal" characters.
  */
-extern char *fixstr(char *str, bool fix_str);
+extern char *sanitize_string(char *str, bool fix_str);
 
 static void annotate(struct ncvar *vp, struct fspec *fsp, long cor[], long iel);
 
@@ -505,7 +505,7 @@ vardata(struct ncvar *vp, long vdims[], int ncid, int varid, struct fspec *fsp)
         nels *= vdims[id]; /* total number of values for variable */
     }
 
-    fixed_var = fixstr(vp->name, fsp->fix_str);
+    fixed_var = sanitize_string(vp->name, fsp->fix_str);
 
     if (vrank <= 1) {
         Printf("\n %s = ", fixed_var);


### PR DESCRIPTION
Fundamentally, this is due to strdup() returning a pointer to invalid memory. Unclear why this is the case (perhaps the POSIX level is incorrect?), but using the library's HDstrdup() replacement works.