### PR TITLE
Clean up emalloc code

### DIFF
--- a/mfhdf/nctest/emalloc.c
+++ b/mfhdf/nctest/emalloc.c
@@ -5,55 +5,42 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "error.h"
 #include "emalloc.h"
-#ifdef HDF
-#include "hdf.h"
-#endif
 
-/* check return from malloc */
+/* Check return from malloc */
 void *
-emalloc(int size)
+emalloc(size_t size)
 {
-    void *p;
+    void *p = NULL;
 
-    if (size < 0) {
-        error("negative arg to emalloc: %d", size);
-        return 0;
-    }
     if (size == 0)
-        return 0;
-#ifdef HDF
-    p = (void *)malloc((uint32)size);
-#else
-    p = (void *)malloc((unsigned)size);
-#endif
-    if (p == 0) {
+        return NULL;
+
+    p = (void *)malloc(size);
+    if (p == NULL) {
         error("out of memory\n");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
+
     return p;
 }
 
-/* check return from realloc */
+/* Check return from realloc
+ *
+ * NOTE: realloc(NULL, 0) behavior is implementation-defined
+ */
 void *
-erealloc(void *ptr, int size)
+erealloc(void *ptr, size_t size)
 {
-    void *p;
+    void *p = NULL;
 
-    if (size < 0) {
-        error("negative arg to realloc");
-        return 0;
-    }
-#ifdef HDF
-    p = (void *)realloc((void *)ptr, (uint32)size);
-#else
-    p = (void *)realloc((char *)ptr, (unsigned)size);
-#endif
-
-    if (p == 0) {
+    p = (void *)realloc(ptr, size);
+    if (p == NULL) {
         error("out of memory");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
+
     return p;
 }

--- a/mfhdf/nctest/emalloc.h
+++ b/mfhdf/nctest/emalloc.h
@@ -10,9 +10,9 @@
 extern "C" {
 #endif
 
-extern void *emalloc(int size);
+extern void *emalloc(size_t size);
 
-extern void *erealloc(void *ptr, int size);
+extern void *erealloc(void *ptr, size_t size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Use size_t for size instead of int
* Remove now pointless negative size checks
* Remove HDF-specific ifdefs
* exit(EXIT_FAILURE) on failure
* Use NULL instead of 0
* Initialize pointers