### PR TITLE
Use int main(void) when argc/argv not used

### DIFF
--- a/hdf/test/gentest.c
+++ b/hdf/test/gentest.c
@@ -183,13 +183,10 @@ gen_nbit_test(void)
 } /* end gen_nbit_test() */
 
 int
-main(int argc, char *argv[])
+main(void)
 {
-    (void)argc;
-    (void)argv;
-
     gen_bitio_test();
     gen_nbit_test();
 
-    return (0);
+    return EXIT_SUCCESS;
 } /* end main() */

--- a/hdf/util/fptest.c
+++ b/hdf/util/fptest.c
@@ -48,7 +48,7 @@
  *      data element value = row value + column value [+ plane value, if rank=3]
  */
 int
-main(int argc, char *argv[])
+main(void)
 {
     int   nrow = 3, ncol = 4, npln = 5, ione = 1;
     int   i, j, k;
@@ -69,9 +69,6 @@ main(int argc, char *argv[])
     const char *text = "TEXT";
     const char *fp32 = "FP32";
     const char *fp64 = "FP64";
-
-    (void)argv;
-    (void)argc;
 
     /*
      * initialize the row, column, and plane vectors
@@ -256,5 +253,6 @@ main(int argc, char *argv[])
             for (j = 0; j < ncol; j++)
                 (void)fwrite((char *)&b64r3[k][i][j], sizeof(float64), 1, sp);
     (void)fclose(sp);
-    return (0);
+
+    return EXIT_SUCCESS;
 }

--- a/mfhdf/hdfimport/hdfimporttest.c
+++ b/mfhdf/hdfimport/hdfimporttest.c
@@ -35,7 +35,7 @@
  *      data element value = row value + column value [+ plane value, if rank=3]
  */
 int
-main(int argc, char *argv[])
+main(void)
 {
     int   nrow = 3, ncol = 4, npln = 5, ione = 1;
     int   i, j, k;
@@ -77,9 +77,6 @@ main(int argc, char *argv[])
     const char *in32 = "IN32";
     const char *in16 = "IN16";
     const char *in8  = "IN08";
-
-    (void)argv;
-    (void)argc;
 
     /*
      * initialize the row, column, and plane vectors
@@ -441,5 +438,6 @@ main(int argc, char *argv[])
             for (j = 0; j < ncol; j++)
                 (void)fwrite((char *)&b64r3[k][i][j], sizeof(float64), 1, sp);
     (void)fclose(sp);
-    return (0);
+
+    return EXIT_SUCCESS;
 }

--- a/mfhdf/test/hdfnctest.c
+++ b/mfhdf/test/hdfnctest.c
@@ -20,13 +20,10 @@ extern int test_ncunlim();
 extern int test_ncvargetfill();
 
 int
-main(int argc, char *argv[])
+main(void)
 {
     intn status;       /* status flag */
     int  num_errs = 0; /* number of errors so far */
-
-    (void)argc;
-    (void)argv;
 
     /* Tests reading/writing datasets with unlimited dimension via HDF API */
     status   = test_unlim(); /* in tunlim.c */
@@ -40,9 +37,12 @@ main(int argc, char *argv[])
     status   = test_ncvargetfill(); /* in tncvargetfill.c */
     num_errs = num_errs + status;
 
-    if (num_errs == 0)
+    if (num_errs == 0) {
         printf("*** HDF-nc test passes ***\n");
-    else
+        return EXIT_SUCCESS;
+    }
+    else {
         printf("*** HDF-nc test fails ***\n");
-    return num_errs;
+        return EXIT_FAILURE;
+    }
 }

--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -65,7 +65,7 @@ extern int test_external();
 extern int test_att_ann_datainfo();
 
 int
-main(int argc, char *argv[])
+main(void)
 {
     int32   f1, f2, fnbit;            /* File handles */
     int32   nt;                       /* Number type */
@@ -97,9 +97,6 @@ main(int argc, char *argv[])
     float32 data[1000], max, min, imax, imin;
     float64 cal, cale, ioff, ioffe;
     int     num_errs = 0; /* number of errors so far */
-
-    (void)argc;
-    (void)argv;
 
     ncopts = NC_VERBOSE;
 
@@ -1339,12 +1336,14 @@ main(int argc, char *argv[])
     /* status = test_sd(); */
     /* num_errs = num_errs + status; */
 
-    if (num_errs == 0)
+    if (num_errs == 0) {
         printf("*** HDF-SD test passes ***\n");
-    else
+        return EXIT_SUCCESS;
+    }
+    else {
         printf("*** HDF-SD test fails ***\n");
-
-    return num_errs;
+        return EXIT_FAILURE;
+    }
 }
 
 #endif /* HDF */


### PR DESCRIPTION
* Use alternative main() signature when args not used
* Return EXIT_SUCCESS/EXIT_FAILURE
* Delete noise casts