### PR TITLE
Restore VOID and VOIDP

### DIFF
--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -139,6 +139,13 @@ typedef uint32_t uint32;
 typedef int          intn;
 typedef unsigned int uintn;
 
+/* These are no longer used in the library, but other software uses them */
+#ifndef VOID
+/* winnt.h defines VOID to `void` via a macro */
+typedef void VOID;
+#endif
+typedef void *VOIDP;
+
 /*-------------------------------------------------------------------------
  * Is this an LP64 system?
  *-------------------------------------------------------------------------*/


### PR DESCRIPTION
The VOID and VOIDP typedefs are used by external software, even though they are located in an internal header file. Although no longer in use in the HDF4 library, they have been re-added to the hdfi.h header for the time being.