### PR TITLE
Correct type usage in ncgen/generate.c

### DIFF
--- a/mfhdf/ncgen/genlib.c
+++ b/mfhdf/ncgen/genlib.c
@@ -52,36 +52,36 @@ va_dcl                                      /* variable number of error args, if
 }
 
 void *
-emalloc(int size) /* check return from malloc */
+emalloc(size_t size)
 {
-    void *p;
+    void *p = NULL;
 
-    if (size < 0) {
-        derror("negative arg to emalloc: %d", size);
-        return 0;
-    }
-    p = (void *)malloc((unsigned)size);
-    if (p == 0) {
+    if (size == 0)
+        return NULL;
+
+    p = (void *)malloc(size);
+    if (p == NULL) {
         derror("out of memory\n");
         exit(3);
     }
+
     return p;
 }
 
+/* Check return from realloc
+ *
+ * NOTE: realloc(NULL, 0) behavior is implementation-defined
+ */
 void *
-erealloc(void *ptr, int size) /* check return from realloc */
+erealloc(void *ptr, size_t size)
 {
-    void *p;
+    void *p = NULL;
 
-    if (size < 0) {
-        derror("negative arg to realloc");
-        return 0;
-    }
-    p = (void *)realloc((char *)ptr, (unsigned)size);
-
-    if (p == 0) {
+    p = (void *)realloc(ptr, size);
+    if (p == NULL) {
         derror("out of memory");
         exit(3);
     }
+
     return p;
 }

--- a/mfhdf/ncgen/genlib.h
+++ b/mfhdf/ncgen/genlib.h
@@ -26,8 +26,8 @@ extern void	derror		(
                                        );
 */
 
-extern void *emalloc(int size);
-extern void *erealloc(void *ptr, int size);
+extern void *emalloc(size_t size);
+extern void *erealloc(void *ptr, size_t size);
 extern void  usage(void);
 
 extern void yyerror(char *);
@@ -41,8 +41,8 @@ void        cline(const char *stmnt);
 void        fline(const char *stmnt);
 const char *nctype(nc_type);
 const char *ncctype(nc_type);
-char       *cstrstr(char *, long);
-char       *fstrstr(char *, long);
+char       *cstrstr(char *, size_t);
+char       *fstrstr(char *, size_t);
 char       *fstring(nc_type, void *, int);
 void        define_netcdf(char *netcdfname);
 


### PR DESCRIPTION
Addresses warnings in generate.c and related, mostly due to not using size_t appropriately.