### PR TITLE
Remove work-arounds for no stdarg.h

### DIFF
--- a/mfhdf/libsrc/error.h
+++ b/mfhdf/libsrc/error.h
@@ -19,12 +19,7 @@
 
 #include "H4api_adpt.h"
 
-#ifndef NO_STDARG
 HDFLIBAPI void nc_serror(const char *fmt, ...);
 HDFLIBAPI void NCadvise(int err, const char *fmt, ...);
-#else
-HDFLIBAPI void nc_serror();
-HDFLIBAPI void NCadvise();
-#endif /* NO_STDARG */
 
 #endif /* MFH4_ERROR_H */

--- a/mfhdf/ncdump/dumplib.c
+++ b/mfhdf/ncdump/dumplib.c
@@ -3,15 +3,11 @@
  *   See netcdf/README file for copying and redistribution conditions.
  *********************************************************************/
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef NO_STDARG
-#include <stdarg.h>
-#else
-#include <varargs.h>
-#endif
 
 #include "h4config.h"
 #ifdef H4_HAVE_NETCDF
@@ -25,24 +21,14 @@
 /*
  * Print error message to stderr, don't exit
  */
-#ifndef NO_STDARG
 void
 error(const char *fmt, ...)
-#else
-/*VARARGS1*/
-void error(fmt, va_alist) const char *fmt;
-va_dcl
-#endif
 {
     va_list args;
 
     (void)fprintf(stderr, "*** %s: ", progname);
 
-#ifndef NO_STDARG
     va_start(args, fmt);
-#else
-    va_start(args);
-#endif
     (void)vfprintf(stderr, fmt, args);
     va_end(args);
 

--- a/mfhdf/ncdump/dumplib.c
+++ b/mfhdf/ncdump/dumplib.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 #include "h4config.h"
 #ifdef H4_HAVE_NETCDF
 #include "netcdf.h"

--- a/mfhdf/ncdump/dumplib.h
+++ b/mfhdf/ncdump/dumplib.h
@@ -8,28 +8,12 @@
 
 extern char *progname; /* for error messages */
 
-#ifndef EXIT_FAILURE
-#define EXIT_SUCCESS 0
-#define EXIT_FAILURE 1
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Print error message to stderr, don't exit */
-#ifndef NO_STDARG
 extern void error(const char *fmt, ...);
-#else
-extern void error();
-#endif
-
-/*
-extern void	error		(
-                                       char *fmt,
-                                       ...
-                                       );
-*/
 
 /* set position in line before lput() calls */
 extern void set_indent(int indent);

--- a/mfhdf/ncgen/genlib.c
+++ b/mfhdf/ncgen/genlib.c
@@ -5,12 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef NO_STDARG
 #include <stdarg.h>
-#else
-/* try varargs instead */
-#include <varargs.h>
-#endif /* !NO_STDARG */
 
 #include "ncgen.h"
 #include "genlib.h"
@@ -21,14 +16,8 @@ int derror_count = 0;
 /*
  * For logging error conditions.
  */
-#ifndef NO_STDARG
 void
 derror(const char *fmt, ...)
-#else
-/*VARARGS1*/
-void derror(fmt, va_alist) const char *fmt; /* error-message printf-style format */
-va_dcl                                      /* variable number of error args, if any */
-#endif /* !NO_STDARG */
 {
     va_list args;
 
@@ -37,11 +26,7 @@ va_dcl                                      /* variable number of error args, if
     else
         (void)fprintf(stderr, "%s: %s line %d: ", progname, cdlname, lineno);
 
-#ifndef NO_STDARG
     va_start(args, fmt);
-#else
-    va_start(args);
-#endif /* !NO_STDARG */
 
     (void)vfprintf(stderr, fmt, args);
     va_end(args);

--- a/mfhdf/ncgen/genlib.h
+++ b/mfhdf/ncgen/genlib.h
@@ -13,26 +13,13 @@ extern char *cdlname;  /* for error messages */
 extern "C" {
 #endif
 
-#ifndef NO_STDARG
-extern void derror(const char *fmt, ...);
-#else
-extern void derror();
-#endif
-
-/*
-extern void	derror		(
-                                       char *fmt,
-                                       ...
-                                       );
-*/
-
+extern void  derror(const char *fmt, ...);
 extern void *emalloc(size_t size);
 extern void *erealloc(void *ptr, size_t size);
 extern void  usage(void);
 
 extern void yyerror(char *);
-
-extern int yyparse(void);
+extern int  yyparse(void);
 
 extern void put_variable(void *);
 

--- a/mfhdf/nctest/error.c
+++ b/mfhdf/nctest/error.c
@@ -5,11 +5,7 @@
 
 #include <stdio.h>
 
-#ifndef NO_STDARG
 #include <stdarg.h>
-#else
-#include <varargs.h>
-#endif
 
 #include "h4config.h"
 #ifdef H4_HAVE_NETCDF

--- a/mfhdf/nctest/error.h
+++ b/mfhdf/nctest/error.h
@@ -15,17 +15,8 @@ extern "C" {
 #endif
 
 /* Print error message to stderr, don't exit */
-#ifndef NO_STRARG
 extern void derror(const char *fmt, ...);
-#else
-extern void derror();
-#endif
-
-#ifndef NO_STDARG
 extern void error(const char *fmt, ...);
-#else /* VARARGS1 */
-extern void error(const char *fmt, va_dcl);
-#endif
 
 /*
  * Turn off netCDF library handling of errors.  Caller must check all error


### PR DESCRIPTION
Removes some old pre-ANSI work-arounds that use varargs.h instead of stdarg.h.