### PR TITLE
Correct getopt detection w/ Autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -911,7 +911,7 @@ esac
 AC_MSG_CHECKING([for math library support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[sinh(37.927)]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]); LIBS="$LIBS -lm"])
 
-AC_CHECK_FUNCS([fork system vfork wait])
+AC_CHECK_FUNCS([getopt fork system vfork wait])
 
 
 ## ======================================================================

--- a/mfhdf/libsrc/getopt.h
+++ b/mfhdf/libsrc/getopt.h
@@ -26,8 +26,8 @@
 
 #include "h4config.h"
 
-#if H4_HAVE_GETOPT
-#if H4_HAVE_UNISTD_H
+#ifdef H4_HAVE_GETOPT
+#ifdef H4_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #else

--- a/mfhdf/util/getopt.h
+++ b/mfhdf/util/getopt.h
@@ -26,8 +26,8 @@
 
 #include "h4config.h"
 
-#if H4_HAVE_GETOPT
-#if H4_HAVE_UNISTD_H
+#ifdef H4_HAVE_GETOPT
+#ifdef H4_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #else


### PR DESCRIPTION
* Use #ifdef instead of #if in preprocessor logic
* Detect getopt in configure.ac