### PR TITLE
Remove vfork detection

### DIFF
--- a/config/cmake/h4config.h.in
+++ b/config/cmake/h4config.h.in
@@ -131,9 +131,6 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine H4_HAVE_UNISTD_H @H4_HAVE_UNISTD_H@
 
-/* Define to 1 if you have the `vfork' function. */
-#cmakedefine H4_HAVE_VFORK @H4_HAVE_VFORK@
-
 /* Define to 1 if you have the `wait' function. */
 #cmakedefine H4_HAVE_WAIT @H4_HAVE_WAIT@
 

--- a/configure.ac
+++ b/configure.ac
@@ -911,7 +911,7 @@ esac
 AC_MSG_CHECKING([for math library support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[sinh(37.927)]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]); LIBS="$LIBS -lm"])
 
-AC_CHECK_FUNCS([getopt fork system vfork wait])
+AC_CHECK_FUNCS([getopt fork system wait])
 
 
 ## ======================================================================


### PR DESCRIPTION
vfork() is not used in HDF4. The Autotools checked for it and CMake had an entry for it in its config file, though CMake did not check for its existence.