### PR TITLE
Verify usage of access_rec->special_info struct

### DIFF
--- a/hdf/src/hchunks.c
+++ b/hdf/src/hchunks.c
@@ -833,16 +833,16 @@ HMCIstaccess(accrec_t *access_rec, /* IN: access record to fill in */
             /* free old info from Chunk tables ..etc*/
 
             /* Sync chunk cache */
-            mcache_sync(info->chk_cache);
+            mcache_sync(tmpinfo->chk_cache);
 
             /* close/free chunk cache */
-            mcache_close(info->chk_cache);
+            mcache_close(tmpinfo->chk_cache);
 
             /* Use Vxxx interface to free Vdata info */
-            VSdetach(info->aid);
+            VSdetach(tmpinfo->aid);
 
             /* free chunk tree */
-            tbbtdfree(info->chk_tree, chkdestroynode, chkfreekey);
+            tbbtdfree(tmpinfo->chk_tree, chkdestroynode, chkfreekey);
 
             /* free up stuff in special info */
             free(tmpinfo->ddims);
@@ -1749,6 +1749,8 @@ done:
             free(info->minfo);
 
             free(info); /* free special info last */
+
+            access_rec->special_info = NULL;
         }
 
         /* free access record */

--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -786,6 +786,8 @@ done:
         if (access_rec != NULL)
             HIrelease_accrec_node(access_rec);
         free(info);
+
+        access_rec->special_info = NULL;
     }
     free(buf);
 
@@ -1055,6 +1057,8 @@ HCIstaccess(accrec_t *access_rec, int16 acc_mode)
 done:
     if (ret_value == FAIL) { /* Error condition cleanup */
         free(info);
+
+        access_rec->special_info = NULL;
     }
 
     return ret_value;

--- a/hdf/src/hcompri.c
+++ b/hdf/src/hcompri.c
@@ -152,10 +152,10 @@ HRPconvert(int32 fid, uint16 tag, uint16 ref, int32 xdim, int32 ydim, int16 sche
 
 done:
     if (ret_value == FAIL) { /* Error condition cleanup */
-        free (info);
+        free(info);
 
         access_rec->special_info = NULL;
-    }                        /* end if */
+    } /* end if */
 
     return ret_value;
 } /* HRPconvert */

--- a/hdf/src/hcompri.c
+++ b/hdf/src/hcompri.c
@@ -98,8 +98,8 @@ HRPconvert(int32 fid, uint16 tag, uint16 ref, int32 xdim, int32 ydim, int16 sche
 {
     filerec_t *file_rec;          /* file record */
     accrec_t  *access_rec = NULL; /* access element record */
-    crinfo_t  *info;              /* information for the compressed raster element */
-    int32      ret_value = SUCCEED;
+    crinfo_t  *info       = NULL; /* information for the compressed raster element */
+    int32      ret_value  = SUCCEED;
 
     HEclear();
 
@@ -152,6 +152,9 @@ HRPconvert(int32 fid, uint16 tag, uint16 ref, int32 xdim, int32 ydim, int16 sche
 
 done:
     if (ret_value == FAIL) { /* Error condition cleanup */
+        free (info);
+
+        access_rec->special_info = NULL;
     }                        /* end if */
 
     return ret_value;

--- a/hdf/src/hextelt.c
+++ b/hdf/src/hextelt.c
@@ -344,6 +344,8 @@ done:
         if (info != NULL) {
             free(info->extern_file_name);
             free(info);
+
+            access_rec->special_info = NULL;
         }
         free(fname);
         if (data_id != FAIL)
@@ -458,8 +460,7 @@ HXIstaccess(accrec_t *access_rec, int16 acc_mode)
     /* get the special info record */
     access_rec->special_info = HIgetspinfo(access_rec);
     if (access_rec->special_info) { /* found it from other access records */
-        info = (extinfo_t *)access_rec->special_info;
-        info->attached++;
+        ((extinfo_t *)access_rec->special_info)->attached++;
     }
     else { /* look for information in the file */
         if (HPseek(file_rec, data_off + 2) == FAIL)
@@ -501,6 +502,8 @@ done:
         if (info != NULL) { /* free file name first */
             free(info->extern_file_name);
             free(info);
+            /* info will only be null if creating a new special_info struct */
+            access_rec->special_info = NULL;
         }
     }
 
@@ -1028,10 +1031,8 @@ HXPreset(accrec_t *access_rec, sp_info_block_t *info_block)
 
 done:
     if (ret_value == FAIL) { /* Error condition cleanup */
-        if (info != NULL) {
-            free(info->extern_file_name);
-            free(info);
-        }
+        /* info changes are not reversible and
+            access_rec->special_info was not created here */
     }
 
     return ret_value;


### PR DESCRIPTION
Except for the HLIstaccess function in hblocks.c; All instances of the special_info and malloc were verified and fixed where identified.