### PR TITLE
Remove getopt checks in Autotools and H4_HAVE_GETOPT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -911,7 +911,7 @@ esac
 AC_MSG_CHECKING([for math library support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[sinh(37.927)]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]); LIBS="$LIBS -lm"])
 
-AC_CHECK_FUNCS([getopt fork system wait])
+AC_CHECK_FUNCS([fork system wait])
 
 
 ## ======================================================================

--- a/mfhdf/libsrc/getopt.c
+++ b/mfhdf/libsrc/getopt.c
@@ -27,10 +27,13 @@
  * SUCH DAMAGE.
  */
 
-#include "getopt.h"
+
+#ifndef H5_HAVE_UNISTD_H
 
 #include <stdio.h>
 #include <string.h>
+
+#include "getopt.h"
 
 int opterr = 1, /* if error message should be printed */
     optind = 1, /* index into parent argv vector */
@@ -116,3 +119,5 @@ getopt(int argc, char *const argv[], const char *optstring)
     }
     return (optopt); /* return option letter */
 }
+
+#endif /* H4_HAVE_UNISTD_H */

--- a/mfhdf/libsrc/getopt.c
+++ b/mfhdf/libsrc/getopt.c
@@ -27,7 +27,6 @@
  * SUCH DAMAGE.
  */
 
-
 #ifndef H5_HAVE_UNISTD_H
 
 #include <stdio.h>

--- a/mfhdf/libsrc/getopt.h
+++ b/mfhdf/libsrc/getopt.h
@@ -26,10 +26,8 @@
 
 #include "h4config.h"
 
-#ifdef H4_HAVE_GETOPT
 #ifdef H4_HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 #else
 
 int          getopt(int argc, char *const argv[], const char *optstring);

--- a/mfhdf/util/getopt.c
+++ b/mfhdf/util/getopt.c
@@ -119,5 +119,4 @@ getopt(int argc, char *const argv[], const char *optstring)
     return (optopt); /* return option letter */
 }
 
-
 #endif /* H4_HAVE_UNISTD_H */

--- a/mfhdf/util/getopt.c
+++ b/mfhdf/util/getopt.c
@@ -27,9 +27,12 @@
  * SUCH DAMAGE.
  */
 
-#include "getopt.h"
+#ifndef H5_HAVE_UNISTD_H
+
 #include <stdio.h>
 #include <string.h>
+
+#include "getopt.h"
 
 int opterr = 1, /* if error message should be printed */
     optind = 1, /* index into parent argv vector */
@@ -115,3 +118,6 @@ getopt(int argc, char *const argv[], const char *optstring)
     }
     return (optopt); /* return option letter */
 }
+
+
+#endif /* H4_HAVE_UNISTD_H */

--- a/mfhdf/util/getopt.h
+++ b/mfhdf/util/getopt.h
@@ -26,10 +26,8 @@
 
 #include "h4config.h"
 
-#ifdef H4_HAVE_GETOPT
 #ifdef H4_HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 #else
 
 int          getopt(int argc, char *const argv[], const char *optstring);


### PR DESCRIPTION
The Autotools build files do not build getopt.c (either of two duplicated versions). There is also no need to check for getopt in the list of functions - current POSIX systems have getopt (via unistd.h) and Windows does not. Checking for unistd.h should be enough.