### PR TITLE
Yet another fix for missing getopt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,6 +305,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --${{ matrix.build_mode.autotools }} --${{ matrix.xdr }}-hdf4-xdr --${{ matrix.netcdf.enabled }}-netcdf --${{ matrix.java }}-java --${{ matrix.shared }}-shared
+          cat ./hdf/src/h4config.h
         shell: bash
         if: (matrix.generator == 'autogen')
 
@@ -317,6 +318,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake ${{ matrix.cacheinit }} ${{ matrix.generator }} --log-level=VERBOSE -DCMAKE_BUILD_TYPE=${{ matrix.build_mode.cmake }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} -DHDF4_BUILD_EXAMPLES=ON -DBUILD_JPEG_WITH_PIC:BOOL=ON -DHDF4_BUILD_XDR_LIB:BOOL=${{ matrix.xdr }} -DHDF4_ENABLE_NETCDF:BOOL=${{ matrix.netcdf.cmake }} -DHDF4_BUILD_JAVA=${{ matrix.java }} -DBUILD_JPEG_WITH_FETCHCONTENT=${{ matrix.jpegfc }} -DBUILD_SZIP_WITH_FETCHCONTENT=${{ matrix.libaecfc }} -DBUILD_ZLIB_WITH_FETCHCONTENT=${{ matrix.zlibfc }} $GITHUB_WORKSPACE
+          cat ./h4config.h
         shell: bash
         if: (matrix.generator != 'autogen') && ! ((matrix.name == 'Ubuntu mingw CMake') && (matrix.build_mode.cmake == 'Debug'))
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,6 +305,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --${{ matrix.build_mode.autotools }} --${{ matrix.xdr }}-hdf4-xdr --${{ matrix.netcdf.enabled }}-netcdf --${{ matrix.java }}-java --${{ matrix.shared }}-shared
+          echo "\n *** h4config.h ***\n"
           cat ./hdf/src/h4config.h
         shell: bash
         if: (matrix.generator == 'autogen')
@@ -318,6 +319,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake ${{ matrix.cacheinit }} ${{ matrix.generator }} --log-level=VERBOSE -DCMAKE_BUILD_TYPE=${{ matrix.build_mode.cmake }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} -DHDF4_BUILD_EXAMPLES=ON -DBUILD_JPEG_WITH_PIC:BOOL=ON -DHDF4_BUILD_XDR_LIB:BOOL=${{ matrix.xdr }} -DHDF4_ENABLE_NETCDF:BOOL=${{ matrix.netcdf.cmake }} -DHDF4_BUILD_JAVA=${{ matrix.java }} -DBUILD_JPEG_WITH_FETCHCONTENT=${{ matrix.jpegfc }} -DBUILD_SZIP_WITH_FETCHCONTENT=${{ matrix.libaecfc }} -DBUILD_ZLIB_WITH_FETCHCONTENT=${{ matrix.zlibfc }} $GITHUB_WORKSPACE
+          echo "\n *** h4config.h ***\n"
           cat ./h4config.h
         shell: bash
         if: (matrix.generator != 'autogen') && ! ((matrix.name == 'Ubuntu mingw CMake') && (matrix.build_mode.cmake == 'Debug'))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,7 +305,9 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --${{ matrix.build_mode.autotools }} --${{ matrix.xdr }}-hdf4-xdr --${{ matrix.netcdf.enabled }}-netcdf --${{ matrix.java }}-java --${{ matrix.shared }}-shared
-          echo "\n *** h4config.h ***\n"
+          echo
+          echo "*** h4config.h ***"
+          echo
           cat ./hdf/src/h4config.h
         shell: bash
         if: (matrix.generator == 'autogen')
@@ -319,7 +321,9 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake ${{ matrix.cacheinit }} ${{ matrix.generator }} --log-level=VERBOSE -DCMAKE_BUILD_TYPE=${{ matrix.build_mode.cmake }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} -DHDF4_BUILD_EXAMPLES=ON -DBUILD_JPEG_WITH_PIC:BOOL=ON -DHDF4_BUILD_XDR_LIB:BOOL=${{ matrix.xdr }} -DHDF4_ENABLE_NETCDF:BOOL=${{ matrix.netcdf.cmake }} -DHDF4_BUILD_JAVA=${{ matrix.java }} -DBUILD_JPEG_WITH_FETCHCONTENT=${{ matrix.jpegfc }} -DBUILD_SZIP_WITH_FETCHCONTENT=${{ matrix.libaecfc }} -DBUILD_ZLIB_WITH_FETCHCONTENT=${{ matrix.zlibfc }} $GITHUB_WORKSPACE
-          echo "\n *** h4config.h ***\n"
+          echo
+          echo "*** h4config.h ***"
+          echo
           cat ./h4config.h
         shell: bash
         if: (matrix.generator != 'autogen') && ! ((matrix.name == 'Ubuntu mingw CMake') && (matrix.build_mode.cmake == 'Debug'))

--- a/configure.ac
+++ b/configure.ac
@@ -911,7 +911,7 @@ esac
 AC_MSG_CHECKING([for math library support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[sinh(37.927)]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]); LIBS="$LIBS -lm"])
 
-AC_CHECK_FUNCS([getopt fork system wait])
+AC_CHECK_FUNCS([fork system wait])
 
 
 ## ======================================================================

--- a/mfhdf/libsrc/getopt.h
+++ b/mfhdf/libsrc/getopt.h
@@ -26,11 +26,11 @@
 
 #include "h4config.h"
 
-#ifdef H4_HAVE_UNISTD_H
+#if defined(H4_HAVE_UNISTD_H) && !(defined(__MINGW32__) || defined(__MINGW64__))
 #include <unistd.h>
 #else
 
-/* Alternative implementation for Windows */
+/* Alternative implementation for Windows, including MinGW */
 
 int          getopt(int argc, char *const argv[], const char *optstring);
 extern char *optarg;

--- a/mfhdf/libsrc/getopt.h
+++ b/mfhdf/libsrc/getopt.h
@@ -26,11 +26,11 @@
 
 #include "h4config.h"
 
-#ifdef H4_HAVE_GETOPT
 #ifdef H4_HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 #else
+
+/* Alternative implementation for Windows */
 
 int          getopt(int argc, char *const argv[], const char *optstring);
 extern char *optarg;

--- a/mfhdf/util/getopt.h
+++ b/mfhdf/util/getopt.h
@@ -26,11 +26,11 @@
 
 #include "h4config.h"
 
-#ifdef H4_HAVE_UNISTD_H
+#if defined(H4_HAVE_UNISTD_H) && !(defined(__MINGW32__) || defined(__MINGW64__))
 #include <unistd.h>
 #else
 
-/* Alternative implementation for Windows */
+/* Alternative implementation for Windows, including MinGW */
 
 int          getopt(int argc, char *const argv[], const char *optstring);
 extern char *optarg;

--- a/mfhdf/util/getopt.h
+++ b/mfhdf/util/getopt.h
@@ -26,11 +26,11 @@
 
 #include "h4config.h"
 
-#ifdef H4_HAVE_GETOPT
 #ifdef H4_HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 #else
+
+/* Alternative implementation for Windows */
 
 int          getopt(int argc, char *const argv[], const char *optstring);
 extern char *optarg;


### PR DESCRIPTION
* Removes detection of getopt in the Autotools
* If you have unistd.h, we use that and assume it contains getopt
* If not, you are probably Windows and we use the HDF4 getopt