### PR TITLE
Remove lex/yacc checks in Autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,17 +352,6 @@ AR_FLAGS=cr
 ## correctly.
 export AR
 
-
-AC_CHECK_PROGS([YACC], ['bison -y' byacc yacc], [none], [])
-if test "$YACC" = "none"; then
-  AC_MSG_ERROR([cannot find bison/yacc utility])
-fi
-
-AC_CHECK_PROGS([LEX], [flex lex], [none], [])
-if test "$LEX" = "none"; then
-  AC_MSG_ERROR([cannot find flex/lex utility])
-fi
-
 AC_CHECK_PROG([DIFF],     [diff],     [diff -w])
 AC_CHECK_PROG([MAKEINFO], [makeinfo], [makeinfo])
 AC_CHECK_PROG([NEQN],     [neqn],     [neqn])

--- a/mfhdf/ncgen/Makefile.am
+++ b/mfhdf/ncgen/Makefile.am
@@ -48,16 +48,6 @@ ctest0_DEPENDENCIES = $(LIBMFHDF) $(LIBHDF) $(XDRLIB)
 
 ftest0_SOURCES=
 
-## Recipe for building the ncgentab.c file
-##ncgentab.c ncgentab.h: ncgen.h ncgen.y ncgenyy.c
-##	$(YACC) -d $(srcdir)/ncgen.y
-##	mv y.tab.c ncgentab.c
-##	mv y.tab.h ncgentab.h
-
-##ncgenyy.c: ncgen.l
-##	$(LEX) $(srcdir)/ncgen.l
-##	mv lex.yy.c ncgenyy.c
-
 #############################################################################
 ##                            Documentation                                ##
 #############################################################################

--- a/release_notes/INSTALL
+++ b/release_notes/INSTALL
@@ -187,7 +187,9 @@ without using CMake should consult the USING_HDF4_VS.txt file.
 
 Additional Third-party Software Requirements:
 
-   1)  Flex and Bison programs are required to regenerate the ncgen utility input files.
+   1)  Flex and Bison programs are required to regenerate the ncgen parsers.
+       This is not required to build the library and is only necessary if you
+       change the input files.
    
    2)  The Win flex-bison project, a port of Flex & Bison tools 
        to the Windows platform, is recommended. Download from:


### PR DESCRIPTION
There is no need to check for flex/lex or bison/yacc at configure time. The programs are not invoked in any Makefile and are instead run directly via bin/genparser.