### PR TITLE
Correct NDEBUG and -g in Autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -871,8 +871,7 @@ AC_SUBST([CONFIG_MODE])
 
 AC_C_BIGENDIAN
 
-## Are we building this in debug or production mode? (Remove the -g flag
-## in production mode.)
+## Are we building this in debug or production mode?
 AC_MSG_CHECKING([for build mode])
 AC_ARG_ENABLE([production],
               [AS_HELP_STRING([--enable-production],
@@ -882,37 +881,16 @@ case "X-$enable_production" in
   X-|X-yes)
     AC_MSG_RESULT([production])
     CONFIG_MODE=production
-    ## Remove the "-g" flag from compile line if it's in there.
-    CFLAGS_temp=""
-    if test -n "$CFLAGS"; then
-      for d in $CFLAGS ; do
-        if test "X$d" != "X-g"; then
-          CFLAGS_temp="$CFLAGS_temp $d"
-        fi
-      done
-      CFLAGS=$CFLAGS_temp
-    fi
-
-    FFLAGS_temp=""
-    if test -n "$FFLAGS"; then
-      for d in $FFLAGS ; do
-        if test "X$d" != "X-g"; then
-          FFLAGS_temp="$FFLAGS_temp $d"
-        fi
-      done
-      FFLAGS=$FFLAGS_temp
-    fi
-
     CFLAGS="$CFLAGS $PROD_CFLAGS"
     FFLAGS="$FFLAGS $PROD_FFLAGS"
-    CPPFLAGS="$CPPFLAGS $PROD_CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS -DNDEBUG $PROD_CPPFLAGS"
     ;;
   X-no)
     AC_MSG_RESULT([development])
     CONFIG_MODE=development
     CFLAGS="$CFLAGS $DEBUG_CFLAGS"
     FFLAGS="$FFLAGS $DEBUG_FFLAGS"
-    CPPFLAGS="$CPPFLAGS $DEBUG_CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS -UNDEBUG $DEBUG_CPPFLAGS"
     ;;
   *)
     AC_MSG_RESULT([user-defined])

--- a/hdf/examples/Makefile.am
+++ b/hdf/examples/Makefile.am
@@ -4,7 +4,7 @@
 
 include $(top_srcdir)/config/commence.am
 
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 
 #############################################################################
 ##                          Programs to build                              ##

--- a/hdf/fortran/examples/Makefile.am
+++ b/hdf/fortran/examples/Makefile.am
@@ -4,7 +4,7 @@
 
 include $(top_srcdir)/config/commence.am
 
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 
 #############################################################################
 ##                          Programs to build                              ##

--- a/java/src/jni/Makefile.am
+++ b/java/src/jni/Makefile.am
@@ -6,7 +6,7 @@ include $(top_srcdir)/config/commence.am
 
 # Mark this directory as part of the JNI API
 JAVA_API=yes
-AM_CFLAGS=-DNDEBUG -fPIC
+AM_CFLAGS=-fPIC
 
 # Include src directory and JNI flags
 AM_CPPFLAGS=-I$(top_srcdir)/hdf/src        \

--- a/mfhdf/dumper/Makefile.am
+++ b/mfhdf/dumper/Makefile.am
@@ -7,7 +7,7 @@ include $(top_srcdir)/config/commence.am
 hdp_INCLUDES=-I$(top_srcdir)/hdf/src        \
          -I$(top_srcdir)/mfhdf/libsrc   \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(hdp_INCLUDES) $(XDRINC) $(DEFINES)
 
 ## Add hdp specific linker flags here

--- a/mfhdf/examples/Makefile.am
+++ b/mfhdf/examples/Makefile.am
@@ -4,7 +4,7 @@
 
 include $(top_srcdir)/config/commence.am
 
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 
 #############################################################################
 ##                          Programs to build                              ##

--- a/mfhdf/fortran/Makefile.am
+++ b/mfhdf/fortran/Makefile.am
@@ -8,7 +8,7 @@ fort_INCLUDES=-I$(top_srcdir)/hdf/src     \
          -I$(top_srcdir)/hdf/test         \
          -I$(top_srcdir)/mfhdf/libsrc     \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(fort_INCLUDES) $(XDRINC) $(DEFINES)
 
 DIST_SUBDIRS = examples

--- a/mfhdf/fortran/examples/Makefile.am
+++ b/mfhdf/fortran/examples/Makefile.am
@@ -4,7 +4,7 @@
 
 include $(top_srcdir)/config/commence.am
 
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 
 #############################################################################
 ##                          Programs to build                              ##

--- a/mfhdf/hdfimport/Makefile.am
+++ b/mfhdf/hdfimport/Makefile.am
@@ -8,7 +8,7 @@ include $(top_srcdir)/config/commence.am
 hdfimport_INCLUDES=-I$(top_srcdir)/hdf/src   \
          -I$(top_srcdir)/mfhdf/libsrc        \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(hdfimport_INCLUDES) $(XDRINC) $(DEFINES)
 
 ## Add hdfimport specific linker flags here

--- a/mfhdf/hdiff/Makefile.am
+++ b/mfhdf/hdiff/Makefile.am
@@ -9,7 +9,7 @@ hdiff_INCLUDES=-I$(top_srcdir)/hdf/src   \
          -I$(top_srcdir)/mfhdf/libsrc    \
          -I$(top_srcdir)/mfhdf/util      \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(hdiff_INCLUDES) $(XDRINC) $(DEFINES)
 
 ## Add hdiff specific linker flags here

--- a/mfhdf/hrepack/Makefile.am
+++ b/mfhdf/hrepack/Makefile.am
@@ -9,7 +9,7 @@ hrepack_INCLUDES=-I$(top_srcdir)/hdf/src   \
          -I$(top_srcdir)/mfhdf/hdiff       \
          -I$(top_srcdir)/mfhdf/libsrc      \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(hrepack_INCLUDES) $(XDRINC) $(DEFINES)
 
 ## Add hrepack specific linker flags here

--- a/mfhdf/libsrc/Makefile.am
+++ b/mfhdf/libsrc/Makefile.am
@@ -7,7 +7,7 @@ include $(top_srcdir)/config/commence.am
 ## Setup the different includes and preprocessor #defines we need.
 lib_INCLUDES = -I$(top_srcdir)/hdf/src        \
                -I$(top_srcdir)/mfhdf/libsrc
-DEFINES = -DNDEBUG -DHDF
+DEFINES = -DHDF
 AM_CPPFLAGS = $(lib_INCLUDES) $(XDRINC) $(DEFINES)
 
 #############################################################################

--- a/mfhdf/ncdump/Makefile.am
+++ b/mfhdf/ncdump/Makefile.am
@@ -9,7 +9,7 @@ ncdump_INCLUDES=-I$(top_srcdir)/hdf/src   \
          -I$(top_srcdir)/mfhdf/libsrc     \
          -I$(top_srcdir)/mfhdf/util       \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(ncdump_INCLUDES) $(XDRINC) $(DEFINES)
 
 ## Add ncdump specific linker flags here

--- a/mfhdf/ncgen/Makefile.am
+++ b/mfhdf/ncgen/Makefile.am
@@ -15,7 +15,7 @@ ncgen_INCLUDES=-I$(top_srcdir)/hdf/src   \
          -I$(top_srcdir)/mfhdf/libsrc    \
          -I$(top_srcdir)/mfhdf/util      \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(ncgen_INCLUDES) $(XDRINC) $(DEFINES)
 
 ## Add ncgen specific linker flags here

--- a/mfhdf/nctest/Makefile.am
+++ b/mfhdf/nctest/Makefile.am
@@ -8,7 +8,7 @@ include $(top_srcdir)/config/commence.am
 nctest_INCLUDES=-I$(top_srcdir)/hdf/src  \
          -I$(top_srcdir)/mfhdf/libsrc    \
          -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(nctest_INCLUDES) $(XDRINC) $(DEFINES)
 
 #############################################################################

--- a/mfhdf/test/Makefile.am
+++ b/mfhdf/test/Makefile.am
@@ -8,7 +8,7 @@ include $(top_srcdir)/config/commence.am
 test_INCLUDES=-I$(top_srcdir)/hdf/src         \
               -I$(top_srcdir)/mfhdf/libsrc    \
               -I$(top_builddir)/mfhdf/libsrc
-DEFINES=-DNDEBUG -DHDF
+DEFINES=-DHDF
 AM_CPPFLAGS=$(test_INCLUDES) $(XDRINC) $(DEFINES)
 
 if HDF_BUILD_XDR

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -38,6 +38,21 @@ New features and changes
 ========================
     Configuration:
     -------------
+    - The Autotools no longer strip -g from production CFLAGS
+
+      configure would strip -g from CFLAGS when --enable-production was
+      specified. This is no longer the case.
+
+      (DER - 2023/03/01)
+
+    - The Autotools now set -DNDEBUG/-UNDEBUG via build mode
+
+      Several makefiles set -DNDEBUG for all build modes. This is now set
+      via the build mode configure options. Production sets -DNDEBUG and
+      development sets -UNDEBUG.
+
+      (DER - 2023/03/01)
+
     - Tools are now built by default in CMake
 
       The option to build and test the HDF4 tools hdiff, hrepack, hdfimport,


### PR DESCRIPTION
* Define NDEBUG or not in configure
* Remove hard-coded -DNDEBUG from Makefile.am files
* Don't strip -g in production mode