### PR TITLE
Fix bad preprocessor logic in fortest.c

### DIFF
--- a/hdf/test/fortest.c
+++ b/hdf/test/fortest.c
@@ -84,7 +84,7 @@ main(int argc, char *argv[])
    the size of C pointer; this happens on all 64-bit platforms.
    We need a better fix; see HDFFR-191.
 */
-#if defined _WIN64 || H4_HAVE_LP64
+#if defined(_WIN64) || defined(H4_HAVE_LP64)
     printf("   Skipping stubs\n");
 #else
     num_tests = InitTest("stubs", "tstubsf", "");


### PR DESCRIPTION
Adds a missing 'defined' in '#if defined a || b'
Windows code in hdf/test/fortest.c.