### PR TITLE
Restore HD-prefixed memory call macros

### DIFF
--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -330,10 +330,10 @@ typedef intptr_t hdf_pint_t;
  * only kept here to avoid breakage in programs that unwisely used
  * them.
  */
-#define HDmalloc(s)    malloc(s)
-#define HDcalloc(a,b)  calloc(a,b)
-#define HDfree(p)      free(p)
-#define HDrealloc(p,s) realloc(p,s)
+#define HDmalloc(s)     malloc(s)
+#define HDcalloc(a, b)  calloc(a, b)
+#define HDfree(p)       free(p)
+#define HDrealloc(p, s) realloc(p, s)
 
 /* Macro to free space and clear pointer to NULL */
 #define HDfreenclear(p)                                                                                      \

--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -324,6 +324,17 @@ typedef intptr_t hdf_pint_t;
  *  Memory functions
  **************************************************************************/
 
+/* DO NOT USE THESE MACROS */
+
+/* These will be removed from a future version of the library and are
+ * only kept here to avoid breakage in programs that unwisely used
+ * them.
+ */
+#define HDmalloc(s)    malloc(s)
+#define HDcalloc(a,b)  calloc(a,b)
+#define HDfree(p)      free(p)
+#define HDrealloc(p,s) realloc(p,s)
+
 /* Macro to free space and clear pointer to NULL */
 #define HDfreenclear(p)                                                                                      \
     {                                                                                                        \


### PR DESCRIPTION
Some external software uses the HDmalloc, etc. macros provided in hdfi.h. These macros are no longer used in the library and are only provided to avoid breaking software that relies on them.