### PR TITLE
Fix Windows directory API call issues

### DIFF
--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -105,6 +105,7 @@
 /* Windows headers */
 #ifdef H4_HAVE_WIN32_API
 #include <windows.h>
+#include <direct.h>
 #include <io.h>
 #include <process.h>
 #endif

--- a/mfhdf/libsrc/mfhdf.h
+++ b/mfhdf/libsrc/mfhdf.h
@@ -20,8 +20,6 @@
 
 #include "H4api_adpt.h"
 
-/* change this back if it causes problems on other machines than the Alhpa-QAK */
-/* Reverse back to the previous way. AKC */
 #include "hdf.h"
 #ifdef H4_HAVE_NETCDF
 #include "netcdf.h"

--- a/mfhdf/test/texternal.c
+++ b/mfhdf/test/texternal.c
@@ -729,11 +729,11 @@ test_change_extdir(void)
         strcpy(temp_dir, TMP_DIR);
 
 #if defined H4_HAVE_WIN32_API
-        command_ret = _mkdir(temp_dir);
+        command_ret = mkdir(temp_dir);
 #else
         command_ret = mkdir(temp_dir, 0755);
 #endif
-        CHECK(command_ret, FAIL, "mkdir");
+        CHECK(command_ret, (-1), "mkdir temp_dir");
         strcat(dir_name, temp_dir);
     }
 
@@ -836,7 +836,7 @@ test_change_extdir(void)
     /* Remove temporary directory used in case no src_dir */
     if (temp_dir) {
         command_ret = rmdir(temp_dir);
-        CHECK(command_ret, FAIL, "remove temp_dir");
+        CHECK(command_ret, (-1), "remove temp_dir");
         free(temp_dir);
     }
 


### PR DESCRIPTION
Recent changes added POSIX(-like) directory manipulation API calls that require including direct.h when building with some compilers.