### PR TITLE
Fix manpage-has-errors-from-man lintian issue.

### DIFF
--- a/mfhdf/ncgen/ncgen.1
+++ b/mfhdf/ncgen/ncgen.1
@@ -326,7 +326,7 @@ are all acceptable \fIfloat\fP constants:
 -2.0f
 3.14159265358979f	// will be truncated to less precision
 1.f
-.1f
+\[char46]1f
 .fi
 .RE
 .LP


### PR DESCRIPTION
The Debian package contains this patch to fix the manpage-has-errors-from-man lintian issue:
```
warning: macro `1f' not defined
```
From the lintian tag description:
>   A manual page provoked warnings or errors from the man program. Here are some common ones:
>   
>   "cannot adjust" or "can't break" are issues with paragraph filling. They are usually related to long lines. Justifying text on the left hand side can help with adjustments. Hyphenation can help with breaks.
>   
>   For more information, please see "Manipulating Filling and Adjusting" and "Manipulating Hyphenation" in the Groff manual (see `info groff`).
>   
>   "can't find numbered character" usually means that the input was in a national legacy encoding. The warning means that some characters were dropped. Please use escapes such as `\[:a]` as described on the groff_char manual page.
>   
>   Other common warnings are formatting typos. String arguments to `.IP` require quotes. Usually, some text is lost or mangled. See the groff_man (or groff_mdoc if using mdoc) manual page for details on macros.
>   
>   The check for manual pages uses the `--warnings` option to man to catch common problems, like a `.` or a `'` at the beginning of a line as literal text. They are interpreted as Groff commands. Just reformat the paragraph so the characters are not at the beginning of a line. You can also add a zero-width space (`\&`) in front of them.
>   
>   Aside from overrides, warnings can be disabled with the `.warn` directive. Please see "Debugging" in the Groff manual.
>   
>   You can see the warnings yourself by running the command used by Lintian:
>   
>       LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
>           man --warnings -E UTF-8 -l -Tutf8 -Z <file> >/dev/null
> 
>   Please refer to the [groff_man(7)](https://manpages.debian.org/unstable/groff/groff_man.7.en.html) manual page and the [groff_mdoc(7)](https://manpages.debian.org/unstable/groff/groff_mdoc.7.en.html) manual page for details.
