### PR TITLE
Fix spelling errors.

### DIFF
--- a/mfhdf/ncdump/ncdump.1
+++ b/mfhdf/ncdump/ncdump.1
@@ -96,7 +96,7 @@ this name from the last component of the pathname of the input netCDF file
 by stripping off any extension it has.  Use the \fB-n\fP option to specify a
 different name.  Although the output file name used by \fBncgen -b\fP can be
 specified, it may be wise to have \fIncdump\fP change the default name to
-avoid inadvertantly overwriting a valuable netCDF file when using
+avoid inadvertently overwriting a valuable netCDF file when using
 \fBncdump\fP, editing the resulting CDL file, and using \fBncgen -b\fP to
 generate a new netCDF file from the edited CDL file.
 .IP "\fB-d\fP \fIfloat_digits[,double_digits]\fP"


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * inadvertantly -> inadvertently