### PR TITLE
Remove the -ansi flag from clang compile options

### DIFF
--- a/config/clang-flags
+++ b/config/clang-flags
@@ -43,7 +43,7 @@ if test "X-clang" = "X-$cc_vendor" -o "X-Apple LLVM" = "X-$cc_vendor"; then
     echo "compiler '$CC' is $cc_vendor-$cc_version"
 
     CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
-    CFLAGS="$CFLAGS -std=c99 -ansi -Wall -pedantic"
+    CFLAGS="$CFLAGS -std=c99 -Wall -pedantic"
 
     DEBUG_CFLAGS="$CFLAGS -g"
     DEBUG_CPPFLAGS=


### PR DESCRIPTION
This sets C89 mode and overrides -std=c99, generating a ton of warnings.