### PR TITLE
Enabled unsafe Fortran mode.  Bug fix for Fortran compiler flags.  Us…

### DIFF
--- a/config/gnu-fflags
+++ b/config/gnu-fflags
@@ -69,7 +69,7 @@ case $F77_BASENAME in
         FFLAGS="$FFLAGS"
     fi
     DEBUG_FFLAGS="-g"
-    PROD_FFLAGS="-O"
+    PROD_FFLAGS="-O3"
     PROFILE_FFLAGS="-pg"
     ;;
 

--- a/config/linux-gnu
+++ b/config/linux-gnu
@@ -67,9 +67,6 @@ else
     esac
 fi
 
-# Figure out GNU FC compiler flags
-. $srcdir/config/gnu-fflags
-
 # compiler version strings
 
 # check if the compiler_version_info is already set
@@ -160,6 +157,9 @@ if test X != "X$fc_version"; then
     # Get the compiler version numbers
     fc_vers_major=`echo $fc_version | cut -f1 -d.`
 fi
+
+# Figure out GNU FC compiler flags
+. $srcdir/config/gnu-fflags
 
 # Overriding Configure Tests
 # --------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -263,8 +263,8 @@ AC_PROG_CPP
 AC_ARG_ENABLE([fortran],
               [AS_HELP_STRING([--enable-fortran],
                               [Build Fortran into library. This interface
-                               is unsafe on 64-bit systems. [default=no]])],,
-              [enableval="no"])
+                               is unsafe on 64-bit systems. [default=yes]])],,
+              [enableval="yes"])
 
 case "$enableval" in
   yes)

--- a/mfhdf/libsrc/local_nc.h
+++ b/mfhdf/libsrc/local_nc.h
@@ -33,7 +33,8 @@
 /* Do we have system XDR files */
 #ifndef H4_NO_SYS_XDR_INC
 
-#ifdef __CYGWIN__
+#include <rpc/types.h>
+#include <rpc/xdr.h>
 #ifndef __u_char_defined
 typedef unsigned char u_char;
 #define __u_char_defined
@@ -50,13 +51,12 @@ typedef unsigned int u_int;
 typedef unsigned long u_long;
 #define __u_long_defined
 #endif
-#endif /* __CYGWIN__ */
 
-#include <rpc/types.h>
-#include <rpc/xdr.h>
 #else /* H4_NO_SYS_XDR_INC */
+
 #include "types.h"
 #include "xdr.h"
+
 #endif /* H4_NO_SYS_XDR_INC */
 
 #ifdef H4_HAVE_NETCDF


### PR DESCRIPTION
…es O3 for fortran production mode.  Small change in mfhdf code to define u_int so it can work with old MAC OS.