### PR TITLE
Fix H4_DFI_H endif.

### DIFF
--- a/hdf/src/dfi.h
+++ b/hdf/src/dfi.h
@@ -40,60 +40,6 @@
 #undef DF_STRUCTOK /* leave it this way - hdfsh expects it */
 
 /*--------------------------------------------------------------------------*/
-/*                      Machine dependencies                                */
-/*--------------------------------------------------------------------------*/
-
-#ifdef APOLLO
-#include <sys/file.h> /* for unbuffered i/o stuff */
-#define int8                    char
-#define uint8                   unsigned char
-#define int16                   short int
-#define uint16                  unsigned short int
-#define int32                   long int
-#define uint32                  unsigned long int
-#define float32                 float
-#define DFmovmem(from, to, len) memcpy(to, from, len)
-#ifndef DF_STRUCTOK
-#define UINT16READ(p, x)                                                                                     \
-    {                                                                                                        \
-        x = ((*p++) & 255) << 8;                                                                             \
-        x |= (*p++) & 255;                                                                                   \
-    }
-#define INT16READ(p, x)                                                                                      \
-    {                                                                                                        \
-        x = (*p++) << 8;                                                                                     \
-        x |= (*p++) & 255;                                                                                   \
-    }
-#define INT32READ(p, x)                                                                                      \
-    {                                                                                                        \
-        x = (*p++) << 24;                                                                                    \
-        x |= ((*p++) & 255) << 16;                                                                           \
-        x |= ((*p++) & 255) << 8;                                                                            \
-        x |= (*p++) & 255;                                                                                   \
-    }
-#define UINT16WRITE(p, x)                                                                                    \
-    {                                                                                                        \
-        *p++ = (x >> 8) & 255;                                                                               \
-        *p++ = x & 255;                                                                                      \
-    }
-#define INT16WRITE(p, x)                                                                                     \
-    {                                                                                                        \
-        *p++ = (x >> 8) & 255;                                                                               \
-        *p++ = x & 255;                                                                                      \
-    }
-#define INT32WRITE(p, x)                                                                                     \
-    {                                                                                                        \
-        *p++ = (x >> 24) & 255;                                                                              \
-        *p++ = (x >> 16) & 255;                                                                              \
-        *p++ = (x >> 8) & 255;                                                                               \
-        *p++ = x & 255;                                                                                      \
-    }
-#endif /*DF_STRUCTOK */
-#define DF_CREAT(name, prot) creat(name, prot)
-#define DF_MT                DFMT_APOLLO
-#endif /*APOLLO */
-
-/*--------------------------------------------------------------------------*/
 /*                      Flexibility parameters                              */
 #ifdef DF_BUFFIO /* set all calls to do buffered I/O */
 #define DF_OPEN(x, y)        fopen(x, y)

--- a/hdf/src/dfi.h
+++ b/hdf/src/dfi.h
@@ -43,6 +43,7 @@
 /*                      Machine dependencies                                */
 /*--------------------------------------------------------------------------*/
 
+#ifdef APOLLO
 #include <sys/file.h> /* for unbuffered i/o stuff */
 #define int8                    char
 #define uint8                   unsigned char


### PR DESCRIPTION
NCL failed to build with hdf4 4.2.16:
```
/usr/include/hdf/dfi.h:128:2: error: #endif without #if
  128 | #endif /* H4_DFI_H */
      |  ^~~~~
```
When the `endif` for `APOLLO` is removed to not close `#ifndef H4_DFI_H` too soon a different error occurs:
```
 /usr/include/hdf/dfi.h:53:33: error: two or more data types in declaration specifiers
    53 | #define float32                 float
       |                                 ^~~~~
 /usr/include/hdf/hdfi.h:121:16: note: in expansion of macro 'float32'
   121 | typedef float  float32;
       |                ^~~~~~~
 /usr/include/hdf/hdfi.h:121:1: warning: useless type name in empty declaration
   121 | typedef float  float32;
       | ^~~~~~~
```
Re-instating `#ifdef APOLLO` resolves the issue.