### PR TITLE
Fix gfortran version check in Autotools

### DIFF
--- a/config/gnu-fflags
+++ b/config/gnu-fflags
@@ -63,7 +63,7 @@
 
 case $F77_BASENAME in
   gfortran)
-    if test $fc_vers_major -ge 10; then
+    if test $cc_vers_major -ge 10; then
         FFLAGS="$FFLAGS -fallow-argument-mismatch"
     else
         FFLAGS="$FFLAGS"

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -53,8 +53,16 @@ Support for new platforms and compilers
 =======================================
 
 
-Bugs fixed since HDF 4.2.15
+Bugs fixed since HDF 4.2.16
 ===========================
+    - Build fortran with -fallow-argument-mismatch w/ gcc 10+
+
+      The gfortran configuration checks checked the version via a variable that
+      was never set, preventing -fallow-argument-mismatch from being set w/
+      gcc 10+, which would prevent building the fortran interface.
+
+      Fixes HDFFR-1582
+
     - JNI SDSreaddata functions for float and double used mismatched buffer macros
 
       The SDreaddata_double and SDreaddata_float function created data buffers with


### PR DESCRIPTION
The config/gnu-flags code checked for the gfortran version using a variable that was never set, so -fallow-argument-mismatch was never set for gcc 10+, which prevents building the Fortran libraries.

Fixes HDFFR-1582