### PR TITLE
Fix CFLAGS when using the system RPC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -749,9 +749,9 @@ esac
 
 ## Check headers and add libraries for XDR if the HDF4 XDR library is not used.
 if test "X$BUILD_XDR" != "Xyes"; then
-    ## For Solaris systems, add the -nsl for XDR support
-    ##
-    ## The SunRPC of the glibc has been replaced by a TI-RPC (Transport Independent RPC) library for IPv6 support
+  ## For Solaris systems, add the -nsl for XDR support
+  ##
+  ## The SunRPC of the glibc has been replaced by a TI-RPC (Transport Independent RPC) library for IPv6 support
   ## ======================================================================
   ## Checks for header files
   ## ======================================================================
@@ -760,13 +760,12 @@ if test "X$BUILD_XDR" != "Xyes"; then
   HAVE_TIRPC="yes"
   ## save current settings
   SYSCPPFLAGS="$CPPFLAGS"
+  SYSCFLAGS="$CFLAGS"
   case "$host" in
     *-solaris*)
       LIBS="$LIBS -lnsl"
       ;;
     *-pc-cygwin* | *-linux*)
-      CFLAGS="$SYSCFLAGS"
-      CPPFLAGS="$SYSCPPFLAGS"
       AC_CHECK_HEADER([rpc/rpc.h],[:], [unset HAVE_OLDRPC])
       AC_CHECK_HEADER([tirpc/netconfig.h],[:], [unset HAVE_TIRPC])
       if test -z "$HAVE_OLDRPC" ; then


### PR DESCRIPTION
The TI-RPC, etc. checks unset the CFLAGS variable in the feature tests.