### PR TITLE
Drop support for MacFS

### DIFF
--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -62,7 +62,6 @@
 /* I/O library constants */
 #define UNIXUNBUFIO 1
 #define UNIXBUFIO   2
-#define MACIO       3
 
 /* The library always uses UNIXBUFIO */
 #define FILELIB UNIXBUFIO

--- a/hdf/src/hfile.h
+++ b/hdf/src/hfile.h
@@ -70,7 +70,7 @@
 
 #ifndef FILELIB
 #define FILELIB UNIXBUFIO /* UNIX buffered I/O is the default */
-#endif                    /* FILELIB */
+#endif
 
 #if (FILELIB == UNIXBUFIO)
 /* using C buffered file I/O routines to access files */
@@ -103,21 +103,6 @@ typedef int hdf_file_t;
 #define HI_TELL(f)        (lseek((f), (off_t)0, SEEK_CUR))
 #define OPENERR(f)        (f < 0)
 #endif /* FILELIB == UNIXUNBUFIO */
-
-#if (FILELIB == MACIO)
-/* using special routines to redirect to Mac Toolkit I/O */
-typedef short hdf_file_t;
-#define HI_OPEN(x, y)     mopen(x, y)
-#define HI_CREATE(name)   mopen(name, DFACC_CREATE)
-#define HI_CLOSE(x)       (((x = ((mclose(x) == 0) ? NULL : x)) == NULL) ? SUCCEED : FAIL)
-#define HI_FLUSH(a)       (SUCCEED)
-#define HI_READ(a, b, c)  mread(a, (char *)b, (int32)c)
-#define HI_WRITE(a, b, c) mwrite(a, (char *)b, (int32)c)
-#define HI_SEEK(x, y)     mlseek(x, (int32)y, 0)
-#define HI_SEEKEND(x)     mlseek(x, 0L, 2)
-#define HI_TELL(x)        mlseek(x, 0L, 1)
-#define OPENERR(f)        (f < 0)
-#endif /* FILELIB == MACIO */
 
 /* ----------------------- Internal Data Structures ----------------------- */
 /* The internal structure used to keep track of the files opened: an

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -71,7 +71,7 @@ New features and changes
       might be interesting to profile that vs C stdio.h calls.
 
       This change will have *NO IMPACT* on modern Macs. Files created using
-      MacFS in the 90s and early 2000s can be accessed using C stanadard
+      MacFS in the 90s and early 2000s can be accessed using C standard
       library I/O.
 
 Support for new platforms and compilers

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -58,20 +58,19 @@ New features and changes
       volumes on MacOS 9 and earlier (publication CMU-CS-98-145 can be
       found via an internet search).
 
-      HDF4 allows a library builder to manually hard-code the FILELIB symbol
+      HDF4 allows a library builder to manually specify the FILELIB symbol
       found in hdfi.h to use C standard library buffered I/O (fopen, etc.),
       POSIX unbuffered I/O (open, etc.), or MacFS I/O (mopen, etc.). The
-      library default is to use C buffered I/O and there is no build-time
-      or run-time option to change that. Only manual editing is possible.
-      The FILELIB value is then used to map HI_OPEN, etc. to appropriate
-      I/O calls.
+      library default is to use C buffered I/O and there is no obvious
+      build-time or run-time option to change that. The FILELIB value is
+      then used to map HI_OPEN, etc. to appropriate I/O calls.
 
-      The "altnernative" I/O schemes (POSIX unbuffered and MacFS) are not
+      The "alternative" I/O schemes (POSIX unbuffered and MacFS) are not
       tested. Due to its age and obscurity, MacFS support is being dropped.
       The POSIX unbuffered I/O scheme will remain in place for now since it
       might be interesting to profile that vs C stdio.h calls.
 
-      This change will have NO IMPACT on modern Macs. Files created using
+      This change will have *NO IMPACT* on modern Macs. Files created using
       MacFS in the 90s and early 2000s can be accessed using C stanadard
       library I/O.
 

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -52,6 +52,29 @@ New features and changes
       * dfi.h - Declared private, unused, undocumented in UG/RM/DG, has been
                 removed from the library entirely.
 
+    - Dropped support for MacFS I/O
+
+      MacFS was an obscure I/O system from the late 90s used to access HFS
+      volumes on MacOS 9 and earlier (publication CMU-CS-98-145 can be
+      found via an internet search).
+
+      HDF4 allows a library builder to manually hard-code the FILELIB symbol
+      found in hdfi.h to use C standard library buffered I/O (fopen, etc.),
+      POSIX unbuffered I/O (open, etc.), or MacFS I/O (mopen, etc.). The
+      library default is to use C buffered I/O and there is no build-time
+      or run-time option to change that. Only manual editing is possible.
+      The FILELIB value is then used to map HI_OPEN, etc. to appropriate
+      I/O calls.
+
+      The "altnernative" I/O schemes (POSIX unbuffered and MacFS) are not
+      tested. Due to its age and obscurity, MacFS support is being dropped.
+      The POSIX unbuffered I/O scheme will remain in place for now since it
+      might be interesting to profile that vs C stdio.h calls.
+
+      This change will have NO IMPACT on modern Macs. Files created using
+      MacFS in the 90s and early 2000s can be accessed using C stanadard
+      library I/O.
+
 Support for new platforms and compilers
 =======================================
 


### PR DESCRIPTION
This is an ancient and obscure I/O system that provided a POSIX-like I/O interface for MacOS 9 and earlier w/ HFS volumes. It has nothing to do with modern Macs.