### PR TITLE
Fix getrusage in mcache.c

### DIFF
--- a/config/cmake/h4config.h.in
+++ b/config/cmake/h4config.h.in
@@ -35,6 +35,9 @@
 /* Define to 1 if you have the `fork' function. */
 #cmakedefine H4_HAVE_FORK @H4_HAVE_FORK@
 
+/* Define to 1 if you have the `getrusage' function. */
+#cmakedefine H4_HAVE_GETRUSAGE @H4_HAVE_GETRUSAGE@
+
 /* Define to 1 if you have the <winsock2.h> header file. */
 #cmakedefine H4_HAVE_WINSOCK2_H @H4_HAVE_WINSOCK2_H@
 

--- a/configure.ac
+++ b/configure.ac
@@ -904,7 +904,7 @@ esac
 AC_MSG_CHECKING([for math library support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[sinh(37.927)]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]); LIBS="$LIBS -lm"])
 
-AC_CHECK_FUNCS([fork system wait])
+AC_CHECK_FUNCS([fork getrusage system wait])
 
 
 ## ======================================================================

--- a/hdf/src/mcache.c
+++ b/hdf/src/mcache.c
@@ -55,7 +55,6 @@
 #define STATISTICS
 */
 
-#define __MCACHEINTERFACE_PRIVATE
 #include "hdf.h"    /* number types ..etc */
 #include "hqueue.h" /* Circular queue functions(Macros) */
 #include "mcache.h"
@@ -843,7 +842,7 @@ done:
 } /* mcache_look() */
 
 #ifdef STATISTICS
-#ifdef HAVE_GETRUSAGE
+#ifdef H4_HAVE_GETRUSAGE
 /******************************************************************************
 NAME
    myrusage - print some process usage statistics
@@ -868,7 +867,7 @@ myrusage()
     fprintf(stderr, "       block_in=%d,block_out=%d,nioch=%d\n", r.ru_inblock, r.ru_oublock, r.ru_ioch);
     fprintf(stderr, "       mesgs=%d,mesgr=%d,nsignals=%d\n", r.ru_msgsnd, r.ru_msgrcv, r.ru_nsignals);
 }
-#endif /* HAVE_GETRUSAGE */
+#endif /* H4_HAVE_GETRUSAGE */
 
 /******************************************************************************
 NAME
@@ -891,7 +890,7 @@ mcache_stat(MCACHE *mp /* IN: MCACHE cookie */)
     intn          cnt;
     intn          hitcnt;
 
-#ifdef HAVE_GETRUSAGE
+#ifdef H4_HAVE_GETRUSAGE
     myrusage();
 #endif
 

--- a/hdf/src/mcache.c
+++ b/hdf/src/mcache.c
@@ -51,9 +51,7 @@
 /*
 #define MCACHE_DEBUG
 */
-/*
 #define STATISTICS
-*/
 
 #include "hdf.h"    /* number types ..etc */
 #include "hqueue.h" /* Circular queue functions(Macros) */
@@ -843,6 +841,9 @@ done:
 
 #ifdef STATISTICS
 #ifdef H4_HAVE_GETRUSAGE
+
+#include <sys/resource.h>
+
 /******************************************************************************
 NAME
    myrusage - print some process usage statistics
@@ -862,10 +863,10 @@ myrusage()
     double        timespent();
 
     getrusage(RUSAGE_SELF, &r);
-    fprintf(stderr, "USAGE: shmem=%d,unshdata=%d,unshstack=%d\n", r.ru_ixrss, r.ru_idrss, r.ru_isrss);
-    fprintf(stderr, "       pager=%d,pagef=%d,nswap=%d\n", r.ru_minflt, r.ru_majflt, r.ru_nswap);
-    fprintf(stderr, "       block_in=%d,block_out=%d,nioch=%d\n", r.ru_inblock, r.ru_oublock, r.ru_ioch);
-    fprintf(stderr, "       mesgs=%d,mesgr=%d,nsignals=%d\n", r.ru_msgsnd, r.ru_msgrcv, r.ru_nsignals);
+    fprintf(stderr, "USAGE: shmem=%ld, unshdata=%ld, unshstack=%ld\n", r.ru_ixrss, r.ru_idrss, r.ru_isrss);
+    fprintf(stderr, "       pager=%ld, pagef=%ld, nswap=%ld\n", r.ru_minflt, r.ru_majflt, r.ru_nswap);
+    fprintf(stderr, "       block_in=%ld, block_out=%ld\n", r.ru_inblock, r.ru_oublock);
+    fprintf(stderr, "       mesgs=%ld, mesgr=%ld, nsignals=%ld\n", r.ru_msgsnd, r.ru_msgrcv, r.ru_nsignals);
 }
 #endif /* H4_HAVE_GETRUSAGE */
 
@@ -908,7 +909,7 @@ mcache_stat(MCACHE *mp /* IN: MCACHE cookie */)
                           mp->cachemiss);
         (void)fprintf(stderr, "%u page reads, %u page writes\n", mp->pageread, mp->pagewrite);
         (void)fprintf(stderr, "%u listhits, %u listallocs\n", mp->listhit, mp->listalloc);
-        (void)fprintf(stderr, "sizeof(MCACHE)=%d, sizeof(BKT)=%d, sizeof(L_ELEM)=%d\n", sizeof(MCACHE),
+        (void)fprintf(stderr, "sizeof(MCACHE)=%zu, sizeof(BKT)=%zu, sizeof(L_ELEM)=%zu\n", sizeof(MCACHE),
                       sizeof(BKT), sizeof(L_ELEM));
         (void)fprintf(stderr, "memory pool used %u bytes\n",
                       (int32)(sizeof(MCACHE) + (sizeof(BKT) + mp->pagesize) * mp->curcache +

--- a/hdf/src/mcache.c
+++ b/hdf/src/mcache.c
@@ -51,7 +51,9 @@
 /*
 #define MCACHE_DEBUG
 */
+/*
 #define STATISTICS
+*/
 
 #include "hdf.h"    /* number types ..etc */
 #include "hqueue.h" /* Circular queue functions(Macros) */


### PR DESCRIPTION
getrusage(2) is used in the mcache statistics code, however:

* Checked in cmake, but not added to h4config.h
* Unchecked in Autotools
* ifdef symbol in mcache.c was missing the H4_ prefix
* Missing include
* Format specifiers generate warnings
* non-existent rusage struct member used