### PR TITLE
Remove unnecessary `return;` statement at the end of two functions.

### DIFF
--- a/hdf/src/mfan.c
+++ b/hdf/src/mfan.c
@@ -137,7 +137,6 @@ dumpentryKey(void *key, void *data)
     }
     else
         printf("(NULL)\n");
-    return;
 } /* dumpentryKey() */
 #endif /* AN_DEBUG */
 

--- a/hdf/src/tbbt.c
+++ b/hdf/src/tbbt.c
@@ -821,7 +821,6 @@ tbbt_dump(TBBT_TREE *ptree, void (*key_dump)(void *, void *), intn method)
     printf("capacity = %ld\n", (long)tree->count);
     printf("\n");
     tbbt_dumpNode(tree->root, key_dump, method);
-    return;
 }
 
 /* Always returns NULL */


### PR DESCRIPTION
These two functions have a different style than the rest of the code base. This change is trivial. It's just me trying to slowly move the code base towards better consistency one little bit at a time.