### PR TITLE
hdf/{src,test}/*.c: Remove extra parens from returns.

### DIFF
--- a/hdf/src/atom.c
+++ b/hdf/src/atom.c
@@ -605,5 +605,5 @@ HAshutdown(void)
             free(atom_group_list[i]);
             atom_group_list[i] = NULL;
         } /* end if */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HAshutdown() */

--- a/hdf/src/cdeflate.c
+++ b/hdf/src/cdeflate.c
@@ -95,7 +95,7 @@ HCIcdeflate_init(compinfo_t *info)
     deflate_info->deflate_context.opaque    = NULL;
     deflate_info->deflate_context.data_type = Z_BINARY;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcdeflate_init() */
 
 /*--------------------------------------------------------------------------
@@ -161,7 +161,7 @@ HCIcdeflate_decode(compinfo_t *info, int32 length, uint8 *buf)
     bytes_read = (int32)length - (int32)deflate_info->deflate_context.avail_out;
     deflate_info->offset += bytes_read;
 
-    return (bytes_read);
+    return bytes_read;
 } /* end HCIcdeflate_decode() */
 
 /*--------------------------------------------------------------------------
@@ -214,7 +214,7 @@ HCIcdeflate_encode(compinfo_t *info, int32 length, void *buf)
     }                               /* end while */
     deflate_info->offset += length; /* incr. abs. offset into the file */
 
-    return (length);
+    return length;
 } /* end HCIcdeflate_encode() */
 
 /*--------------------------------------------------------------------------
@@ -284,7 +284,7 @@ HCIcdeflate_term(compinfo_t *info, uint32 acc_mode)
     deflate_info->acc_init = 0; /* second stage of initializing not performed */
     deflate_info->acc_mode = 0; /* init access mode to illegal value */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcdeflate_term() */
 
 /*--------------------------------------------------------------------------
@@ -340,7 +340,7 @@ HCIcdeflate_staccess(accrec_t *access_rec, int16 acc_mode)
     if ((deflate_info->io_buf = malloc(DEFLATE_BUF_SIZE)) == NULL)
         HRETURN_ERROR(DFE_NOSPACE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcdeflate_staccess() */
 
 /*--------------------------------------------------------------------------
@@ -399,7 +399,7 @@ HCIcdeflate_staccess2(accrec_t *access_rec, int16 acc_mode)
     /* set flag to indicate second stage of initialization is finished */
     deflate_info->acc_init = acc_mode;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcdeflate_staccess2() */
 
 /*--------------------------------------------------------------------------
@@ -427,7 +427,7 @@ HCPcdeflate_stread(accrec_t *access_rec)
     if (HCIcdeflate_staccess(access_rec, DFACC_READ) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcdeflate_stread() */
 
 /*--------------------------------------------------------------------------
@@ -455,7 +455,7 @@ HCPcdeflate_stwrite(accrec_t *access_rec)
     if (HCIcdeflate_staccess(access_rec, DFACC_WRITE) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcdeflate_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -589,7 +589,7 @@ HCPcdeflate_read(accrec_t *access_rec, int32 length, void *data)
     if ((length = HCIcdeflate_decode(info, length, data)) == FAIL)
         HRETURN_ERROR(DFE_CDECODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcdeflate_read() */
 
 /*--------------------------------------------------------------------------
@@ -646,7 +646,7 @@ HCPcdeflate_write(accrec_t *access_rec, int32 length, const void *data)
     if ((length = HCIcdeflate_encode(info, length, (void *)data)) == FAIL)
         HRETURN_ERROR(DFE_CENCODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcdeflate_write() */
 
 /*--------------------------------------------------------------------------
@@ -692,7 +692,7 @@ HCPcdeflate_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 
     (void)paccess;
     (void)pspecial;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcdeflate_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -734,5 +734,5 @@ HCPcdeflate_endaccess(accrec_t *access_rec)
     if (Hendaccess(info->aid) == FAIL)
         HRETURN_ERROR(DFE_CANTCLOSE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcdeflate_endaccess() */

--- a/hdf/src/cnbit.c
+++ b/hdf/src/cnbit.c
@@ -164,7 +164,7 @@ HCIcnbit_init(accrec_t *access_rec)
             nbit_info->mask_buf[i] &= ~(nbit_info->mask_info[i].mask);
     } /* end if */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcnbit_init() */
 
 /*--------------------------------------------------------------------------
@@ -283,7 +283,7 @@ HCIcnbit_decode(compinfo_t *info, int32 length, uint8 *buf)
     } /* end for */
 
     nbit_info->offset += orig_length; /* incr. abs. offset into the file */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcnbit_decode() */
 
 /*--------------------------------------------------------------------------
@@ -339,7 +339,7 @@ HCIcnbit_encode(compinfo_t *info, int32 length, const uint8 *buf)
     }                                                 /* end for */
 
     nbit_info->offset += orig_length; /* incr. abs. offset into the file */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcnbit_encode() */
 
 /*--------------------------------------------------------------------------
@@ -366,7 +366,7 @@ HCIcnbit_term(compinfo_t *info)
 {
     (void)info;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcnbit_term() */
 
 /*--------------------------------------------------------------------------
@@ -405,7 +405,7 @@ HCIcnbit_staccess(accrec_t *access_rec, int16 acc_mode)
         HRETURN_ERROR(DFE_DENIED, FAIL);
     if ((acc_mode & DFACC_WRITE) && Hbitappendable(info->aid) == FAIL)
         HRETURN_ERROR(DFE_DENIED, FAIL);
-    return (HCIcnbit_init(access_rec)); /* initialize the N-bit info */
+    return HCIcnbit_init(access_rec); /* initialize the N-bit info */
 } /* end HCIcnbit_staccess() */
 
 /*--------------------------------------------------------------------------
@@ -434,7 +434,7 @@ HCPcnbit_stread(accrec_t *access_rec)
 
     if ((ret = HCIcnbit_staccess(access_rec, DFACC_READ)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcnbit_stread() */
 
 /*--------------------------------------------------------------------------
@@ -463,7 +463,7 @@ HCPcnbit_stwrite(accrec_t *access_rec)
 
     if ((ret = HCIcnbit_staccess(access_rec, DFACC_WRITE)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcnbit_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -515,7 +515,7 @@ HCPcnbit_seek(accrec_t *access_rec, int32 offset, int origin)
     nbit_info->nt_pos  = 0;             /* start at the first byte of the mask */
     nbit_info->offset  = offset;        /* set abs. offset into the file */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcnbit_seek() */
 
 /*--------------------------------------------------------------------------
@@ -583,7 +583,7 @@ HCPcnbit_write(accrec_t *access_rec, int32 length, const void *data)
     if (HCIcnbit_encode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CENCODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcnbit_write() */
 
 /*--------------------------------------------------------------------------
@@ -629,7 +629,7 @@ HCPcnbit_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pr
     (void)paccess;
     (void)pspecial;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcnbit_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -667,5 +667,5 @@ HCPcnbit_endaccess(accrec_t *access_rec)
     if (Hendbitaccess(info->aid, 0) == FAIL)
         HRETURN_ERROR(DFE_CANTCLOSE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcnbit_endaccess() */

--- a/hdf/src/cnone.c
+++ b/hdf/src/cnone.c
@@ -89,7 +89,7 @@ HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode)
         HRETURN_ERROR(DFE_DENIED, FAIL);
     if ((acc_mode & DFACC_WRITE) && Happendable(info->aid) == FAIL)
         HRETURN_ERROR(DFE_DENIED, FAIL);
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcnone_staccess() */
 
 /*--------------------------------------------------------------------------
@@ -118,7 +118,7 @@ HCPcnone_stread(accrec_t *access_rec)
 
     if ((ret = HCIcnone_staccess(access_rec, DFACC_READ)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcnone_stread() */
 
 /*--------------------------------------------------------------------------
@@ -147,7 +147,7 @@ HCPcnone_stwrite(accrec_t *access_rec)
 
     if ((ret = HCIcnone_staccess(access_rec, DFACC_WRITE)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcnone_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -184,7 +184,7 @@ HCPcnone_seek(accrec_t *access_rec, int32 offset, int origin)
     if (Hseek(info->aid, offset, origin) == FAIL)
         HRETURN_ERROR(DFE_CSEEK, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcnone_seek() */
 
 /*--------------------------------------------------------------------------
@@ -218,7 +218,7 @@ HCPcnone_read(accrec_t *access_rec, int32 length, void *data)
     if (Hread(info->aid, length, data) == FAIL)
         HRETURN_ERROR(DFE_CDECODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcnone_read() */
 
 /*--------------------------------------------------------------------------
@@ -252,7 +252,7 @@ HCPcnone_write(accrec_t *access_rec, int32 length, const void *data)
     if (Hwrite(info->aid, length, data) == FAIL)
         HRETURN_ERROR(DFE_CENCODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcnone_write() */
 
 /*--------------------------------------------------------------------------
@@ -298,7 +298,7 @@ HCPcnone_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pr
     (void)paccess;
     (void)pspecial;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcnone_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -331,5 +331,5 @@ HCPcnone_endaccess(accrec_t *access_rec)
     if (Hendaccess(info->aid) == FAIL)
         HRETURN_ERROR(DFE_CANTCLOSE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcnone_endaccess() */

--- a/hdf/src/crle.c
+++ b/hdf/src/crle.c
@@ -103,7 +103,7 @@ HCIcrle_init(accrec_t *access_rec)
     rle_info->second_byte = (uintn)RLE_NIL; /* start with no code here too */
     rle_info->offset      = 0;              /* offset into the file */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcrle_init() */
 
 /*--------------------------------------------------------------------------
@@ -178,7 +178,7 @@ HCIcrle_decode(compinfo_t *info, int32 length, uint8 *buf)
     }                                       /* end while */
 
     rle_info->offset += orig_length; /* incr. abs. offset into the file */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcrle_decode() */
 
 /*--------------------------------------------------------------------------
@@ -290,7 +290,7 @@ HCIcrle_encode(compinfo_t *info, int32 length, const uint8 *buf)
     }     /* end while */
 
     rle_info->offset += orig_length; /* incr. abs. offset into the file */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcrle_encode() */
 
 /*--------------------------------------------------------------------------
@@ -342,7 +342,7 @@ HCIcrle_term(compinfo_t *info)
     rle_info->rle_state   = RLE_INIT;
     rle_info->second_byte = rle_info->last_byte = (uintn)RLE_NIL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcrle_term() */
 
 /*--------------------------------------------------------------------------
@@ -380,7 +380,7 @@ HCIcrle_staccess(accrec_t *access_rec, int16 acc_mode)
 
     if (info->aid == FAIL)
         HRETURN_ERROR(DFE_DENIED, FAIL);
-    return (HCIcrle_init(access_rec)); /* initialize the RLE info */
+    return HCIcrle_init(access_rec); /* initialize the RLE info */
 } /* end HCIcrle_staccess() */
 
 /*--------------------------------------------------------------------------
@@ -409,7 +409,7 @@ HCPcrle_stread(accrec_t *access_rec)
 
     if ((ret = HCIcrle_staccess(access_rec, DFACC_READ)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcrle_stread() */
 
 /*--------------------------------------------------------------------------
@@ -438,7 +438,7 @@ HCPcrle_stwrite(accrec_t *access_rec)
 
     if ((ret = HCIcrle_staccess(access_rec, DFACC_WRITE)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcrle_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -500,7 +500,7 @@ HCPcrle_seek(accrec_t *access_rec, int32 offset, int origin)
         }
 
     free(tmp_buf);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcrle_seek() */
 
 /*--------------------------------------------------------------------------
@@ -534,7 +534,7 @@ HCPcrle_read(accrec_t *access_rec, int32 length, void *data)
     if (HCIcrle_decode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CDECODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcrle_read() */
 
 /*--------------------------------------------------------------------------
@@ -577,7 +577,7 @@ HCPcrle_write(accrec_t *access_rec, int32 length, const void *data)
     if (HCIcrle_encode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CENCODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcrle_write() */
 
 /*--------------------------------------------------------------------------
@@ -623,7 +623,7 @@ HCPcrle_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pre
     (void)paccess;
     (void)pspecial;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcrle_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -663,5 +663,5 @@ HCPcrle_endaccess(accrec_t *access_rec)
     if (Hendaccess(info->aid) == FAIL)
         HRETURN_ERROR(DFE_CANTCLOSE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcrle_endaccess() */

--- a/hdf/src/cskphuff.c
+++ b/hdf/src/cskphuff.c
@@ -195,7 +195,7 @@ HCIcskphuff_init(accrec_t *access_rec, uintn alloc_buf)
         } /* end for */
     }     /* end for */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcskphuff_init() */
 
 /*--------------------------------------------------------------------------
@@ -248,7 +248,7 @@ HCIcskphuff_decode(compinfo_t *info, int32 length, uint8 *buf)
         length--;
     }                                    /* end while */
     skphuff_info->offset += orig_length; /* incr. abs. offset into the file */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcskphuff_decode() */
 
 /*--------------------------------------------------------------------------
@@ -323,7 +323,7 @@ HCIcskphuff_encode(compinfo_t *info, int32 length, const uint8 *buf)
     } /* end while */
 
     skphuff_info->offset += orig_length; /* incr. abs. offset into the file */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcskphuff_encode() */
 
 /*--------------------------------------------------------------------------
@@ -368,7 +368,7 @@ HCIcskphuff_term(compinfo_t *info)
     free(skphuff_info->right);
     free(skphuff_info->up);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIcskphuff_term() */
 
 /*--------------------------------------------------------------------------
@@ -411,7 +411,7 @@ HCIcskphuff_staccess(accrec_t *access_rec, int16 acc_mode)
         HRETURN_ERROR(DFE_DENIED, FAIL);
     if ((acc_mode & DFACC_WRITE) && Hbitappendable(info->aid) == FAIL)
         HRETURN_ERROR(DFE_DENIED, FAIL);
-    return (HCIcskphuff_init(access_rec, TRUE)); /* initialize the skip-Huffman info */
+    return HCIcskphuff_init(access_rec, TRUE); /* initialize the skip-Huffman info */
 } /* end HCIcskphuff_staccess() */
 
 /*--------------------------------------------------------------------------
@@ -441,7 +441,7 @@ HCPcskphuff_stread(accrec_t *access_rec)
 
     if ((ret = HCIcskphuff_staccess(access_rec, DFACC_READ)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcskphuff_stread() */
 
 /*--------------------------------------------------------------------------
@@ -471,7 +471,7 @@ HCPcskphuff_stwrite(accrec_t *access_rec)
 
     if ((ret = HCIcskphuff_staccess(access_rec, DFACC_WRITE)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcskphuff_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -530,7 +530,7 @@ HCPcskphuff_seek(accrec_t *access_rec, int32 offset, int origin)
         }
 
     free(tmp_buf);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcskphuff_seek() */
 
 /*--------------------------------------------------------------------------
@@ -564,7 +564,7 @@ HCPcskphuff_read(accrec_t *access_rec, int32 length, void *data)
     if (HCIcskphuff_decode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CDECODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcskphuff_read() */
 
 /*--------------------------------------------------------------------------
@@ -606,7 +606,7 @@ HCPcskphuff_write(accrec_t *access_rec, int32 length, const void *data)
     if (HCIcskphuff_encode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CENCODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcskphuff_write() */
 
 /*--------------------------------------------------------------------------
@@ -652,7 +652,7 @@ HCPcskphuff_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 
     (void)paccess;
     (void)pspecial;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcskphuff_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -689,5 +689,5 @@ HCPcskphuff_endaccess(accrec_t *access_rec)
     if (Hendbitaccess(info->aid, 0) == FAIL)
         HRETURN_ERROR(DFE_CANTCLOSE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcskphuff_endaccess() */

--- a/hdf/src/cszip.c
+++ b/hdf/src/cszip.c
@@ -103,7 +103,7 @@ HCIcszip_init(accrec_t *access_rec)
     szip_info->szip_dirty = SZIP_CLEAN;
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end HCIcszip_init() */
 
 /*--------------------------------------------------------------------------
@@ -265,7 +265,7 @@ HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
                 free(szip_info->buffer);
                 szip_info->buffer = NULL;
             }
-            return (SUCCEED);
+            return SUCCEED;
         }
 
         /* Decompress the data */
@@ -302,7 +302,7 @@ HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
         /*  can't happen?? panic?? */
         free(szip_info->buffer);
         szip_info->buffer = NULL;
-        return (FAIL);
+        return FAIL;
     }
 
     memcpy(buf, szip_info->buffer + szip_info->buffer_pos, length);
@@ -315,7 +315,7 @@ HCIcszip_decode(compinfo_t *info, int32 length, uint8 *buf)
         szip_info->buffer = NULL;
     }
 
-    return (SUCCEED);
+    return SUCCEED;
 
 #else  /* ifdef H4_HAVE_LIBSZ */
     (void)info;
@@ -382,7 +382,7 @@ HCIcszip_encode(compinfo_t *info, int32 length, const uint8 *buf)
     szip_info->offset     = szip_info->buffer_pos;
     szip_info->szip_dirty = SZIP_DIRTY;
 
-    return (SUCCEED);
+    return SUCCEED;
 
 #else  /* ifdef H4_HAVE_SZIP_ENCODER */
     (void)info;
@@ -434,7 +434,7 @@ HCIcszip_term(compinfo_t *info)
 
     szip_info = &(info->cinfo.coder_info.szip_info);
     if (szip_info->szip_state != SZIP_RUN)
-        return (SUCCEED); /* nothing to do */
+        return SUCCEED; /* nothing to do */
 
     if (szip_info->szip_dirty != SZIP_DIRTY) /* Should never happen?? */
     {
@@ -442,7 +442,7 @@ HCIcszip_term(compinfo_t *info)
             free(szip_info->buffer);
             szip_info->buffer = NULL;
         }
-        return (SUCCEED);
+        return SUCCEED;
     }
 
     szip_info->szip_state = SZIP_TERM;
@@ -516,7 +516,7 @@ HCIcszip_term(compinfo_t *info)
                 free(szip_info->buffer);
                 szip_info->buffer = NULL;
             }
-            return (SUCCEED);
+            return SUCCEED;
         }
 
         /* compress failed, return error */
@@ -549,7 +549,7 @@ HCIcszip_term(compinfo_t *info)
             free(szip_info->buffer);
             szip_info->buffer = NULL;
         }
-        return (SUCCEED);
+        return SUCCEED;
     }
 
     if ((current_size > 0) && (((int32)size_out + 5) < current_size)) {
@@ -572,7 +572,7 @@ HCIcszip_term(compinfo_t *info)
             free(szip_info->buffer);
             szip_info->buffer = NULL;
         }
-        return (SUCCEED);
+        return SUCCEED;
     }
 
     /* Finally!  Write the compressed data. Byte 0 is '0' */
@@ -589,7 +589,7 @@ HCIcszip_term(compinfo_t *info)
     }
     free(out_buffer);
 
-    return (SUCCEED);
+    return SUCCEED;
 
 #else  /* H4_HAVE_SZIP_ENCODER */
     (void)info;
@@ -642,7 +642,7 @@ HCIcszip_staccess(accrec_t *access_rec, int16 acc_mode)
     if (info->aid == FAIL)
         HRETURN_ERROR(DFE_DENIED, FAIL);
 
-    return (HCIcszip_init(access_rec)); /* initialize the SZIP info */
+    return HCIcszip_init(access_rec); /* initialize the SZIP info */
 } /* end HCIcszip_staccess() */
 
 /*--------------------------------------------------------------------------
@@ -671,7 +671,7 @@ HCPcszip_stread(accrec_t *access_rec)
 
     if ((ret = HCIcszip_staccess(access_rec, DFACC_READ)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcszip_stread() */
 
 /*--------------------------------------------------------------------------
@@ -700,7 +700,7 @@ HCPcszip_stwrite(accrec_t *access_rec)
 
     if ((ret = HCIcszip_staccess(access_rec, DFACC_WRITE)) == FAIL)
         HRETURN_ERROR(DFE_CINIT, FAIL);
-    return (ret);
+    return ret;
 } /* HCPcszip_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -769,7 +769,7 @@ HCPcszip_seek(accrec_t *access_rec, int32 offset, int origin)
     }
 
     free(tmp_buf);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcszip_seek() */
 
 /*--------------------------------------------------------------------------
@@ -803,7 +803,7 @@ HCPcszip_read(accrec_t *access_rec, int32 length, void *data)
     if (HCIcszip_decode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CDECODE, FAIL);
 
-    return (length);
+    return length;
 } /* HCPcszip_read() */
 
 /*--------------------------------------------------------------------------
@@ -848,7 +848,7 @@ HCPcszip_write(accrec_t *access_rec, int32 length, const void *data)
     if (HCIcszip_encode(info, length, data) == FAIL)
         HRETURN_ERROR(DFE_CENCODE, FAIL);
 
-    return (length);
+    return length;
 #else /* ifdef H4_HAVE_SZIP_ENCODER */
     (void)access_rec;
     (void)length;
@@ -902,7 +902,7 @@ HCPcszip_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pr
     (void)paccess;
     (void)pspecial;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcszip_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -943,7 +943,7 @@ HCPcszip_endaccess(accrec_t *access_rec)
     if (Hendaccess(info->aid) == FAIL)
         HRETURN_ERROR(DFE_CANTCLOSE, FAIL);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPcszip_endaccess() */
 
 /*--------------------------------------------------------------------------
@@ -1046,7 +1046,7 @@ HCPsetup_szip_parms(comp_info *c_info, int32 nt, int32 ncomp, int32 ndims, int32
     c_info->szip.bits_per_pixel = sz * 8;
 
 done:
-    return (ret_value);
+    return ret_value;
 #else
     /* szip not enabled */
     (void)c_info;
@@ -1056,6 +1056,6 @@ done:
     (void)dims;
     (void)cdims;
 
-    return (FAIL);
+    return FAIL;
 #endif
 }

--- a/hdf/src/df24f.c
+++ b/hdf/src/df24f.c
@@ -59,7 +59,7 @@ static int dimsset = 0;
 FRETVAL(intf)
 nd2reqil(intf *il)
 {
-    return (DFGRIreqil((intn)*il, (intn)IMAGE));
+    return DFGRIreqil((intn)*il, (intn)IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -77,7 +77,7 @@ FRETVAL(intf)
 nd2sdims(intf *xdim, intf *ydim)
 {
     dimsset = 1;
-    return (DFGRIsetdims(*xdim, *ydim, 3, IMAGE));
+    return DFGRIsetdims(*xdim, *ydim, 3, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -102,10 +102,10 @@ nd2igdim(_fcd filename, intf *pxdim, intf *pydim, intf *pil, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DF24getdims(fn, (int32 *)pxdim, (int32 *)pydim, (intn *)pil);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -129,10 +129,10 @@ nd2igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DF24getimage(fn, (void *)_fcdtocp(image), *xdim, *ydim);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -156,14 +156,14 @@ nd2iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen, intf *n
 
     if (!dimsset)
         if (DFGRIsetdims(*xdim, *ydim, 3, IMAGE) < 0)
-            return (-1);
+            return -1;
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFGRIaddimlut(fn, (void *)_fcdtocp(image), *xdim, *ydim, IMAGE, 1, (intn)*newfile);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -179,7 +179,7 @@ nd2iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen, intf *n
 FRETVAL(intf)
 nd2setil(intf *il)
 {
-    return (DFGRIsetil((intn)*il, IMAGE));
+    return DFGRIsetil((intn)*il, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -195,7 +195,7 @@ nd2setil(intf *il)
 FRETVAL(intf)
 nd2first(void)
 {
-    return (DFGRIrestart());
+    return DFGRIrestart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -211,7 +211,7 @@ nd2first(void)
 FRETVAL(intf)
 nd2lref(void)
 {
-    return ((intf)DFGRIlastref());
+    return (intf)DFGRIlastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -236,7 +236,7 @@ nd2scomp(intf *scheme)
         cinfo.jpeg.quality        = 75;
         cinfo.jpeg.force_baseline = 1;
     } /* end if */
-    return (DF24setcompress((int32)*scheme, &cinfo));
+    return DF24setcompress((int32)*scheme, &cinfo);
 } /* end d2scomp() */
 
 /*-----------------------------------------------------------------------------
@@ -258,7 +258,7 @@ nd2sjpeg(intf *quality, intf *force_baseline)
 
     cinfo.jpeg.quality        = (intn)*quality;
     cinfo.jpeg.force_baseline = (intn)*force_baseline;
-    return (DF24setcompress((int32)COMP_JPEG, &cinfo));
+    return DF24setcompress((int32)COMP_JPEG, &cinfo);
 } /* end d2sjpeg() */
 
 /*-----------------------------------------------------------------------------
@@ -274,7 +274,7 @@ nd2sjpeg(intf *quality, intf *force_baseline)
 FRETVAL(intf)
 ndf24reqil(intf *il)
 {
-    return (DFGRIreqil((intn)*il, IMAGE));
+    return DFGRIreqil((intn)*il, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -292,7 +292,7 @@ FRETVAL(intf)
 ndf24setdims(intf *xdim, intf *ydim)
 {
     dimsset = 1;
-    return (DFGRIsetdims(*xdim, *ydim, 3, IMAGE));
+    return DFGRIsetdims(*xdim, *ydim, 3, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -308,7 +308,7 @@ ndf24setdims(intf *xdim, intf *ydim)
 FRETVAL(intf)
 ndf24setil(intf *il)
 {
-    return (DFGRIsetil((intn)*il, IMAGE));
+    return DFGRIsetil((intn)*il, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -324,7 +324,7 @@ ndf24setil(intf *il)
 FRETVAL(intf)
 ndf24restart(void)
 {
-    return (DFGRIrestart());
+    return DFGRIrestart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -349,7 +349,7 @@ ndf24scompress(intf *scheme)
         cinfo.jpeg.quality        = 75;
         cinfo.jpeg.force_baseline = 1;
     } /* end if */
-    return (DF24setcompress((int32)*scheme, &cinfo));
+    return DF24setcompress((int32)*scheme, &cinfo);
 } /* end df24setcompress() */
 
 /*-----------------------------------------------------------------------------
@@ -371,7 +371,7 @@ ndf24sjpeg(intf *quality, intf *force_baseline)
 
     cinfo.jpeg.quality        = (intn)*quality;
     cinfo.jpeg.force_baseline = (intn)*force_baseline;
-    return (DF24setcompress((int32)COMP_JPEG, &cinfo));
+    return DF24setcompress((int32)COMP_JPEG, &cinfo);
 } /* end df24setjpeg() */
 
 /*-----------------------------------------------------------------------------
@@ -394,10 +394,10 @@ nd2irref(_fcd filename, intf *ref, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFGRreadref(fn, (uint16)*ref);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -419,8 +419,8 @@ nd2inimg(_fcd filename, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DF24nimages(fn);
     free(fn);
-    return (ret);
+    return ret;
 } /* end nd2inimg */

--- a/hdf/src/dfan.c
+++ b/hdf/src/dfan.c
@@ -1551,7 +1551,7 @@ DFANIstart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end DFANIstart() */
 
 /*--------------------------------------------------------------------------

--- a/hdf/src/dfanf.c
+++ b/hdf/src/dfanf.c
@@ -73,7 +73,7 @@
 FRETVAL(intf)
 ndaclear(void)
 {
-    return (DFANIclear());
+    return DFANIclear();
 }
 
 /*-----------------------------------------------------------------------------
@@ -96,11 +96,11 @@ ndaiganl(_fcd filename, intf *tag, intf *ref, intf *type, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFANIgetannlen(fn, (uint16)*tag, (uint16)*ref, (intn)*type);
     free(fn);
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -125,12 +125,12 @@ ndaigann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *maxlen, int
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFANIgetann(fn, (uint16)*tag, (uint16)*ref, (uint8 *)_fcdtocp(annotation), (int32)*maxlen,
                       (intn)*type, 1);
     free(fn);
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -155,11 +155,11 @@ ndaipann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *annlen, int
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFANIputann(fn, (uint16)*tag, (uint16)*ref, (uint8 *)_fcdtocp(annotation), (int32)*annlen,
                       (intn)*type);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -192,7 +192,7 @@ ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsiz
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
 
     /* create reflist with true uint16s to maintain compatibility
      ** with machines that allocate more than 16 bits per uint16.
@@ -211,7 +211,7 @@ ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsiz
     free(fn);
     free(tempreflist);
 
-    return (nrefs);
+    return nrefs;
 }
 
 /*-----------------------------------------------------------------------------
@@ -228,7 +228,7 @@ ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsiz
 FRETVAL(intf)
 ndalref(void)
 {
-    return ((intf)DFANlastref());
+    return (intf)DFANlastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -245,7 +245,7 @@ ndalref(void)
 FRETVAL(intf)
 ndfanlastref(void)
 {
-    return ((intf)DFANlastref());
+    return (intf)DFANlastref();
 }
 
 /*---------------------------------------------------------------------------
@@ -266,7 +266,7 @@ ndfanlastref(void)
 FRETVAL(intf)
 ndfanaddfds(intf *dfile, _fcd desc, intf *desclen)
 {
-    return (DFANIaddfann(*dfile, _fcdtocp(desc), *desclen, DFAN_DESC));
+    return DFANIaddfann(*dfile, _fcdtocp(desc), *desclen, DFAN_DESC);
 }
 
 /*-----------------------------------------------------------------------------
@@ -282,7 +282,7 @@ ndfanaddfds(intf *dfile, _fcd desc, intf *desclen)
 FRETVAL(intf)
 ndfangetfidlen(intf *dfile, intf *isfirst)
 {
-    return (DFANIgetfannlen(*dfile, DFAN_LABEL, (intn)*isfirst));
+    return DFANIgetfannlen(*dfile, DFAN_LABEL, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -298,7 +298,7 @@ ndfangetfidlen(intf *dfile, intf *isfirst)
 FRETVAL(intf)
 ndfangetfdslen(intf *dfile, intf *isfirst)
 {
-    return (DFANIgetfannlen(*dfile, DFAN_DESC, (intn)*isfirst));
+    return DFANIgetfannlen(*dfile, DFAN_DESC, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -315,7 +315,7 @@ ndfangetfdslen(intf *dfile, intf *isfirst)
 FRETVAL(intf)
 ndfangetfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
-    return (DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_LABEL, (intn)*isfirst));
+    return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_LABEL, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -332,7 +332,7 @@ ndfangetfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 FRETVAL(intf)
 ndfangetfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
-    return (DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_DESC, (intn)*isfirst));
+    return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_DESC, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -353,7 +353,7 @@ ndfangetfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 FRETVAL(intf)
 ndaafds(intf *dfile, _fcd desc, intf *desclen)
 {
-    return (DFANIaddfann(*dfile, _fcdtocp(desc), *desclen, DFAN_DESC));
+    return DFANIaddfann(*dfile, _fcdtocp(desc), *desclen, DFAN_DESC);
 }
 
 /*-----------------------------------------------------------------------------
@@ -369,7 +369,7 @@ ndaafds(intf *dfile, _fcd desc, intf *desclen)
 FRETVAL(intf)
 ndagfidl(intf *dfile, intf *isfirst)
 {
-    return (DFANIgetfannlen(*dfile, DFAN_LABEL, (intn)*isfirst));
+    return DFANIgetfannlen(*dfile, DFAN_LABEL, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -385,7 +385,7 @@ ndagfidl(intf *dfile, intf *isfirst)
 FRETVAL(intf)
 ndagfdsl(intf *dfile, intf *isfirst)
 {
-    return (DFANIgetfannlen(*dfile, DFAN_DESC, (intn)*isfirst));
+    return DFANIgetfannlen(*dfile, DFAN_DESC, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -402,7 +402,7 @@ ndagfdsl(intf *dfile, intf *isfirst)
 FRETVAL(intf)
 ndagfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
-    return (DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_LABEL, (intn)*isfirst));
+    return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_LABEL, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -420,7 +420,7 @@ ndagfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 FRETVAL(intf)
 ndagfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
-    return (DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_DESC, (intn)*isfirst));
+    return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_DESC, (intn)*isfirst);
 }
 
 /*-----------------------------------------------------------------------------
@@ -441,5 +441,5 @@ ndagfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 FRETVAL(intf)
 ndaiafid(intf *dfile, _fcd id, intf *idlen)
 {
-    return (DFANIaddfann(*dfile, _fcdtocp(id), *idlen, DFAN_LABEL));
+    return DFANIaddfann(*dfile, _fcdtocp(id), *idlen, DFAN_LABEL);
 }

--- a/hdf/src/dfcomp.c
+++ b/hdf/src/dfcomp.c
@@ -154,7 +154,7 @@ DFputcomp(int32 file_id, uint16 tag, uint16 ref, const uint8 *image, int32 xdim,
         default: /* unknown compression scheme */
             HRETURN_ERROR(DFE_BADSCHEME, FAIL);
     }
-    return ((intn)ret);
+    return (intn)ret;
 } /* end DFputcomp() */
 
 /*-----------------------------------------------------------------------------
@@ -194,7 +194,7 @@ DFgetcomp(int32 file_id, uint16 tag, uint16 ref, uint8 *image, int32 xdim, int32
     /* code easier to follow */
     if (scheme == DFTAG_JPEG5 || scheme == DFTAG_GREYJPEG5 || scheme == DFTAG_JPEG ||
         scheme == DFTAG_GREYJPEG)
-        return (DFCIunjpeg(file_id, tag, ref, (void *)image, xdim, ydim, (int16)scheme));
+        return DFCIunjpeg(file_id, tag, ref, (void *)image, xdim, ydim, (int16)scheme);
 
     /* Only do this stuff for non-JPEG compressed images */
     aid = Hstartread(file_id, tag, ref);

--- a/hdf/src/dfconv.c
+++ b/hdf/src/dfconv.c
@@ -138,55 +138,55 @@ DFKNTsize(int32 number_type)
     switch (number_type & (~DFNT_LITEND)) {
         /* native types */
         case DFNT_NUCHAR:
-            return (SIZE_NUCHAR);
+            return SIZE_NUCHAR;
         case DFNT_NCHAR:
-            return (SIZE_NCHAR);
+            return SIZE_NCHAR;
         case DFNT_NINT8:
-            return (SIZE_NINT8);
+            return SIZE_NINT8;
         case DFNT_NUINT8:
-            return (SIZE_NUINT8);
+            return SIZE_NUINT8;
 
         case DFNT_NINT16:
-            return (SIZE_NINT16);
+            return SIZE_NINT16;
         case DFNT_NUINT16:
-            return (SIZE_NUINT16);
+            return SIZE_NUINT16;
 
         case DFNT_NINT32:
-            return (SIZE_NINT32);
+            return SIZE_NINT32;
         case DFNT_NUINT32:
-            return (SIZE_NUINT32);
+            return SIZE_NUINT32;
 
         case DFNT_NFLOAT32:
-            return (SIZE_NFLOAT32);
+            return SIZE_NFLOAT32;
 
         case DFNT_NFLOAT64:
-            return (SIZE_NFLOAT64);
+            return SIZE_NFLOAT64;
 
         /* HDF types */
         case DFNT_UCHAR:
-            return (SIZE_UCHAR);
+            return SIZE_UCHAR;
         case DFNT_CHAR:
-            return (SIZE_CHAR);
+            return SIZE_CHAR;
         case DFNT_INT8:
-            return (SIZE_INT8);
+            return SIZE_INT8;
         case DFNT_UINT8:
-            return (SIZE_UINT8);
+            return SIZE_UINT8;
 
         case DFNT_INT16:
-            return (SIZE_INT16);
+            return SIZE_INT16;
         case DFNT_UINT16:
-            return (SIZE_UINT16);
+            return SIZE_UINT16;
 
         case DFNT_INT32:
-            return (SIZE_INT32);
+            return SIZE_INT32;
         case DFNT_UINT32:
-            return (SIZE_UINT32);
+            return SIZE_UINT32;
 
         case DFNT_FLOAT32:
-            return (SIZE_FLOAT32);
+            return SIZE_FLOAT32;
 
         case DFNT_FLOAT64:
-            return (SIZE_FLOAT64);
+            return SIZE_FLOAT64;
 
         /* Unknown types */
         default:
@@ -354,7 +354,7 @@ DFKsetcustom(int (*DFKcustin)(void * /* source */, void * /* dest */, uint32 /* 
 int32
 DFKisnativeNT(int32 numbertype)
 {
-    return ((DFNT_NATIVE & numbertype) > 0 ? 1 : 0);
+    return (DFNT_NATIVE & numbertype) > 0 ? 1 : 0;
 }
 
 /*------------------------------------------------------------------
@@ -370,7 +370,7 @@ DFKisnativeNT(int32 numbertype)
 int32
 DFKislitendNT(int32 numbertype)
 {
-    return ((DFNT_LITEND & numbertype) > 0 ? 1 : 0);
+    return (DFNT_LITEND & numbertype) > 0 ? 1 : 0;
 }
 
 /************************************************************
@@ -492,14 +492,14 @@ DFKconvert(void *source, void *dest, int32 ntype, int32 num_elm, int16 acc_mode,
 
     /* Check args (minimally) */
     if (source == NULL || dest == NULL)
-        return (-1);
+        return -1;
 
     DFKsetNT(ntype);
     if (acc_mode == DFACC_READ)
         ret = DFKnumin(source, dest, (uint32)num_elm, (uint32)source_stride, (uint32)dest_stride);
     else
         ret = DFKnumout(source, dest, (uint32)num_elm, (uint32)source_stride, (uint32)dest_stride);
-    return (ret);
+    return ret;
 }
 
 /*****************************************************************************

--- a/hdf/src/dff.c
+++ b/hdf/src/dff.c
@@ -66,7 +66,7 @@ ndfiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
     /* For compiler warning, see note above. */
     ret = (intf)DFopen(fn, (intn)*acc_mode, (intn)*defdds);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -81,7 +81,7 @@ ndfiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 FRETVAL(intf)
 ndfclose(intf *dfile)
 {
-    return (DFclose((DF *)*dfile));
+    return DFclose((DF *)*dfile);
 }
 
 /*-----------------------------------------------------------------------------
@@ -117,7 +117,7 @@ ndfdesc(intf *dfile, intf ptr[][4], intf *begin, intf *num)
 
     free(ptr1);
 
-    return (num_desc);
+    return num_desc;
 }
 
 /*-----------------------------------------------------------------------------
@@ -134,7 +134,7 @@ ndfdesc(intf *dfile, intf ptr[][4], intf *begin, intf *num)
 FRETVAL(intf)
 ndfdup(intf *dfile, intf *tag, intf *ref, intf *otag, intf *oref)
 {
-    return (DFdup((DF *)*dfile, (uint16)*tag, (uint16)*ref, (uint16)*otag, (uint16)*oref));
+    return DFdup((DF *)*dfile, (uint16)*tag, (uint16)*ref, (uint16)*otag, (uint16)*oref);
 }
 
 /*-----------------------------------------------------------------------------
@@ -150,7 +150,7 @@ ndfdup(intf *dfile, intf *tag, intf *ref, intf *otag, intf *oref)
 FRETVAL(intf)
 ndfdel(intf *dfile, intf *tag, intf *ref)
 {
-    return (DFdel((DF *)*dfile, (uint16)*tag, (uint16)*ref));
+    return DFdel((DF *)*dfile, (uint16)*tag, (uint16)*ref);
 }
 
 /*-----------------------------------------------------------------------------
@@ -173,7 +173,7 @@ ndfiaccess(intf *dfile, intf *tag, intf *ref, _fcd acc_mode, intf *acclen)
     acc = DFIf2cstring(acc_mode, (intn)*acclen);
     ret = (intf)DFaccess((DF *)*dfile, (uint16)*tag, (uint16)*ref, acc);
     free(acc);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -190,7 +190,7 @@ ndfiaccess(intf *dfile, intf *tag, intf *ref, _fcd acc_mode, intf *acclen)
 FRETVAL(intf)
 ndfread(intf *dfile, _fcd ptr, intf *len)
 {
-    return (DFread((DF *)*dfile, (char *)_fcdtocp(ptr), *len));
+    return DFread((DF *)*dfile, (char *)_fcdtocp(ptr), *len);
 }
 
 /*-----------------------------------------------------------------------------
@@ -206,7 +206,7 @@ ndfread(intf *dfile, _fcd ptr, intf *len)
 FRETVAL(intf)
 ndfseek(intf *dfile, intf *offset)
 {
-    return (DFseek((DF *)*dfile, *offset));
+    return DFseek((DF *)*dfile, *offset);
 }
 
 /*-----------------------------------------------------------------------------
@@ -223,7 +223,7 @@ ndfseek(intf *dfile, intf *offset)
 FRETVAL(intf)
 ndfwrite(intf *dfile, _fcd ptr, intf *len)
 {
-    return (DFwrite((DF *)*dfile, (char *)_fcdtocp(ptr), *len));
+    return DFwrite((DF *)*dfile, (char *)_fcdtocp(ptr), *len);
 }
 
 /*-----------------------------------------------------------------------------
@@ -238,7 +238,7 @@ ndfwrite(intf *dfile, _fcd ptr, intf *len)
 FRETVAL(intf)
 ndfupdate(intf *dfile)
 {
-    return (DFupdate((DF *)*dfile));
+    return DFupdate((DF *)*dfile);
 }
 
 /*-----------------------------------------------------------------------------
@@ -255,7 +255,7 @@ ndfupdate(intf *dfile)
 FRETVAL(intf)
 ndfget(intf *dfile, intf *tag, intf *ref, _fcd ptr)
 {
-    return (DFgetelement((DF *)*dfile, (uint16)*tag, (uint16)*ref, (char *)_fcdtocp(ptr)));
+    return DFgetelement((DF *)*dfile, (uint16)*tag, (uint16)*ref, (char *)_fcdtocp(ptr));
 }
 
 /*-----------------------------------------------------------------------------
@@ -273,7 +273,7 @@ ndfget(intf *dfile, intf *tag, intf *ref, _fcd ptr)
 FRETVAL(intf)
 ndfput(intf *dfile, intf *tag, intf *ref, _fcd ptr, intf *len)
 {
-    return (DFputelement((DF *)*dfile, (uint16)*tag, (uint16)*ref, (char *)_fcdtocp(ptr), *len));
+    return DFputelement((DF *)*dfile, (uint16)*tag, (uint16)*ref, (char *)_fcdtocp(ptr), *len);
 }
 
 /*-----------------------------------------------------------------------------
@@ -289,7 +289,7 @@ ndfput(intf *dfile, intf *tag, intf *ref, _fcd ptr, intf *len)
 FRETVAL(intf)
 ndfsfind(intf *dfile, intf *tag, intf *ref)
 {
-    return (DFsetfind((DF *)*dfile, (uint16)*tag, (uint16)*ref));
+    return DFsetfind((DF *)*dfile, (uint16)*tag, (uint16)*ref);
 }
 
 /*-----------------------------------------------------------------------------
@@ -320,7 +320,7 @@ ndffind(intf *dfile, intf *itag, intf *iref, intf *len)
 
     free(ptr1);
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -335,7 +335,7 @@ ndffind(intf *dfile, intf *itag, intf *iref, intf *len)
 FRETVAL(intf)
 ndferrno(void)
 {
-    return (DFerrno());
+    return DFerrno();
 }
 
 /*-----------------------------------------------------------------------------
@@ -350,7 +350,7 @@ ndferrno(void)
 FRETVAL(intf)
 ndfnewref(intf *dfile)
 {
-    return ((intf)DFnewref((DF *)*dfile));
+    return (intf)DFnewref((DF *)*dfile);
 }
 
 /*-----------------------------------------------------------------------------
@@ -366,7 +366,7 @@ ndfnewref(intf *dfile)
 FRETVAL(intf)
 ndfnumber(intf *dfile, intf *tag)
 {
-    return (DFnumber((DF *)*dfile, (uint16)*tag));
+    return DFnumber((DF *)*dfile, (uint16)*tag);
 }
 
 /*-----------------------------------------------------------------------------
@@ -382,7 +382,7 @@ ndfnumber(intf *dfile, intf *tag)
 FRETVAL(intf)
 ndfstat(intf *dfile, DFdata *dfinfo)
 {
-    return (DFstat((DF *)*dfile, dfinfo));
+    return DFstat((DF *)*dfile, dfinfo);
 }
 
 /*-----------------------------------------------------------------------------
@@ -404,5 +404,5 @@ ndfiishdf(_fcd name, intf *namelen)
     fn  = DFIf2cstring(name, (intn)*namelen);
     ret = DFishdf(fn);
     free(fn);
-    return (ret);
+    return ret;
 }

--- a/hdf/src/dfgr.c
+++ b/hdf/src/dfgr.c
@@ -156,7 +156,7 @@ static intn DFGRIstart(void);
 int
 DFGRgetlutdims(const char *filename, int32 *pxdim, int32 *pydim, int *pncomps, int *pil)
 {
-    return (DFGRIgetdims(filename, pxdim, pydim, pncomps, pil, LUT));
+    return DFGRIgetdims(filename, pxdim, pydim, pncomps, pil, LUT);
 }
 
 /*-----------------------------------------------------------------------------
@@ -172,7 +172,7 @@ DFGRgetlutdims(const char *filename, int32 *pxdim, int32 *pydim, int *pncomps, i
 int
 DFGRreqlutil(int il)
 {
-    return (DFGRIreqil(il, LUT));
+    return DFGRIreqil(il, LUT);
 }
 
 /*-----------------------------------------------------------------------------
@@ -193,7 +193,7 @@ DFGRgetlut(const char *filename, void *lut, int32 xdim, int32 ydim)
     int    compressed, has_pal;
     uint16 compr_type;
     /* 0 == C */
-    return (DFGRIgetimlut(filename, lut, xdim, ydim, LUT, 0, &compressed, &compr_type, &has_pal));
+    return DFGRIgetimlut(filename, lut, xdim, ydim, LUT, 0, &compressed, &compr_type, &has_pal);
 }
 
 /*-----------------------------------------------------------------------------
@@ -213,7 +213,7 @@ DFGRgetlut(const char *filename, void *lut, int32 xdim, int32 ydim)
 int
 DFGRgetimdims(const char *filename, int32 *pxdim, int32 *pydim, int *pncomps, int *pil)
 {
-    return (DFGRIgetdims(filename, pxdim, pydim, pncomps, pil, IMAGE));
+    return DFGRIgetdims(filename, pxdim, pydim, pncomps, pil, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -229,7 +229,7 @@ DFGRgetimdims(const char *filename, int32 *pxdim, int32 *pydim, int *pncomps, in
 int
 DFGRreqimil(int il)
 {
-    return (DFGRIreqil(il, IMAGE));
+    return DFGRIreqil(il, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -250,7 +250,7 @@ DFGRgetimage(const char *filename, void *image, int32 xdim, int32 ydim)
     int    compressed, has_pal;
     uint16 compr_type;
     /* 0 == C */
-    return (DFGRIgetimlut(filename, image, xdim, ydim, IMAGE, 0, &compressed, &compr_type, &has_pal));
+    return DFGRIgetimlut(filename, image, xdim, ydim, IMAGE, 0, &compressed, &compr_type, &has_pal);
 }
 
 /*-----------------------------------------------------------------------------
@@ -312,7 +312,7 @@ DFGRsetlutdims(int32 xdim, int32 ydim, int ncomps, int il)
 {
     if (DFGRIsetil(il, LUT) < 0)
         return FAIL;
-    return (DFGRIsetdims(xdim, ydim, ncomps, LUT));
+    return DFGRIsetdims(xdim, ydim, ncomps, LUT);
 }
 
 /*-----------------------------------------------------------------------------
@@ -330,7 +330,7 @@ int
 DFGRsetlut(void *lut, int32 xdim, int32 ydim)
 {
     /* 0 == C, 0 == no newfile */
-    return (DFGRIaddimlut((const char *)NULL, lut, xdim, ydim, LUT, 0, 0));
+    return DFGRIaddimlut((const char *)NULL, lut, xdim, ydim, LUT, 0, 0);
 }
 
 /*-----------------------------------------------------------------------------
@@ -349,7 +349,7 @@ int
 DFGRaddlut(const char *filename, void *lut, int32 xdim, int32 ydim)
 {
     /* 0 == C, 0 == no new file */
-    return (DFGRIaddimlut(filename, lut, xdim, ydim, LUT, 0, 0));
+    return DFGRIaddimlut(filename, lut, xdim, ydim, LUT, 0, 0);
 }
 
 /*-----------------------------------------------------------------------------
@@ -369,7 +369,7 @@ DFGRsetimdims(int32 xdim, int32 ydim, int ncomps, int il)
 {
     if (DFGRIsetil(il, IMAGE) < 0)
         return FAIL;
-    return (DFGRIsetdims(xdim, ydim, ncomps, IMAGE));
+    return DFGRIsetdims(xdim, ydim, ncomps, IMAGE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -388,14 +388,14 @@ int
 DFGRaddimage(const char *filename, void *image, int32 xdim, int32 ydim)
 {
     /* 0 == C, 0 == not new file */
-    return (DFGRIaddimlut(filename, image, xdim, ydim, IMAGE, 0, 0));
+    return DFGRIaddimlut(filename, image, xdim, ydim, IMAGE, 0, 0);
 }
 
 int
 DFGRputimage(const char *filename, void *image, int32 xdim, int32 ydim)
 {
     /* 0 == C, 1 == new file */
-    return (DFGRIaddimlut(filename, image, xdim, ydim, IMAGE, 0, 1));
+    return DFGRIaddimlut(filename, image, xdim, ydim, IMAGE, 0, 1);
 }
 
 /*-----------------------------------------------------------------------------
@@ -1361,7 +1361,7 @@ done:
 uint16
 DFGRIlastref(void)
 {
-    return ((uint16)Grlastref);
+    return (uint16)Grlastref;
 }
 
 /*--------------------------------------------------------------------------
@@ -1393,7 +1393,7 @@ DFGRIstart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end DFGRIstart() */
 
 /*--------------------------------------------------------------------------
@@ -1419,5 +1419,5 @@ DFGRPshutdown(void)
     free(Grlastfile);
     Grlastfile = NULL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end DFGRPshutdown() */

--- a/hdf/src/dfgroup.c
+++ b/hdf/src/dfgroup.c
@@ -172,7 +172,7 @@ DFdinobj(int32 list)
     if (!list_rec)
         HRETURN_ERROR(DFE_ARGS, FAIL);
 
-    return (list_rec->num);
+    return list_rec->num;
 } /* DFdinobj() */
 
 /*-----------------------------------------------------------------------------

--- a/hdf/src/dfimcomp.c
+++ b/hdf/src/dfimcomp.c
@@ -479,7 +479,7 @@ nearest_color(uint8 r, uint8 g, uint8 b)
 static uint32
 sqr(int16 x)
 {
-    return ((uint32)x * (uint32)x);
+    return (uint32)x * (uint32)x;
 }
 
 /************************************************************************/
@@ -773,7 +773,7 @@ find_box(void)
             temp = temp->right;
 
     if (max == NULL) {
-        return (NULL); /* punt! */
+        return NULL; /* punt! */
     }
 
     return max;

--- a/hdf/src/dfjpeg.c
+++ b/hdf/src/dfjpeg.c
@@ -189,7 +189,7 @@ jpeg_HDF_dest(struct jpeg_compress_struct *cinfo_ptr, int32 file_id, uint16 tag,
     dest->ydim    = ydim;
     dest->scheme  = scheme;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end jpeg_HDF_dest() */
 
 /*-----------------------------------------------------------------------------
@@ -208,7 +208,7 @@ jpeg_HDF_dest_term(struct jpeg_compress_struct *cinfo_ptr)
     /* all we need to do for now is to free up the dest. mgr structure */
     free(cinfo_ptr->dest);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end jpeg_HDF_dest_term() */
 
 /***********************************************************************/
@@ -308,5 +308,5 @@ DFCIjpeg(int32 file_id, uint16 tag, uint16 ref, int32 xdim, int32 ydim, const vo
     free(jerr_ptr);
     free(cinfo_ptr);
 
-    return (SUCCEED); /* we must be ok... */
+    return SUCCEED; /* we must be ok... */
 } /* end DFCIjpeg() */

--- a/hdf/src/dfpf.c
+++ b/hdf/src/dfpf.c
@@ -49,10 +49,10 @@ ndpigpal(_fcd filename, _fcd pal, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFPgetpal(fn, (void *)_fcdtocp(pal));
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -80,10 +80,10 @@ ndpippal(_fcd filename, _fcd pal, intf *overwrite, _fcd filemode, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFPputpal(fn, (void *)_fcdtocp(pal), (intn)*overwrite, (char *)_fcdtocp(filemode));
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -103,10 +103,10 @@ ndpinpal(_fcd filename, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFPnpals(fn);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -128,10 +128,10 @@ ndpirref(_fcd filename, intf *ref, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFPreadref(fn, (uint16)*ref);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -154,10 +154,10 @@ ndpiwref(_fcd filename, intf *ref, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFPreadref(fn, (uint16)*ref);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -172,8 +172,7 @@ ndpiwref(_fcd filename, intf *ref, intf *fnlen)
 FRETVAL(intf)
 ndprest(void)
 {
-
-    return (DFPrestart());
+    return DFPrestart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -190,8 +189,7 @@ ndprest(void)
 FRETVAL(intf)
 ndplref(void)
 {
-
-    return ((intf)DFPlastref());
+    return (intf)DFPlastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -206,8 +204,7 @@ ndplref(void)
 FRETVAL(intf)
 ndfprestart(void)
 {
-
-    return (DFPrestart());
+    return DFPrestart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -224,6 +221,5 @@ ndfprestart(void)
 FRETVAL(intf)
 ndfplastref(void)
 {
-
-    return ((intf)DFPlastref());
+    return (intf)DFPlastref();
 }

--- a/hdf/src/dfr8.c
+++ b/hdf/src/dfr8.c
@@ -1430,7 +1430,7 @@ DFR8Istart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end DFR8Istart() */
 
 /*--------------------------------------------------------------------------

--- a/hdf/src/dfr8f.c
+++ b/hdf/src/dfr8f.c
@@ -47,7 +47,7 @@
 FRETVAL(intf)
 nd8spal(_fcd pal)
 {
-    return (DFR8setpalette((uint8 *)_fcdtocp(pal)));
+    return DFR8setpalette((uint8 *)_fcdtocp(pal));
 }
 
 /*-----------------------------------------------------------------------------
@@ -62,7 +62,7 @@ nd8spal(_fcd pal)
 FRETVAL(intf)
 nd8first(void)
 {
-    return (DFR8restart());
+    return DFR8restart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -87,7 +87,7 @@ nd8igdim(_fcd filename, intf *xdim, intf *ydim, intf *ispal, intf *lenfn)
 
     fn = HDf2cstring(filename, (intn)*lenfn);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFR8getdims(fn, &txdim, &tydim, &tispal);
     if (ret != FAIL) {
         *xdim  = txdim;
@@ -95,7 +95,7 @@ nd8igdim(_fcd filename, intf *xdim, intf *ydim, intf *ispal, intf *lenfn)
         *ispal = tispal;
     }
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -119,10 +119,10 @@ nd8igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, _fcd pal, intf *lenf
 
     fn = HDf2cstring(filename, (intn)*lenfn);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFR8getimage(fn, (uint8 *)_fcdtocp(image), *xdim, *ydim, (uint8 *)_fcdtocp(pal));
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -146,10 +146,10 @@ nd8ipimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf
 
     fn = HDf2cstring(filename, (intn)*lenfn);
     if (!fn)
-        return (-1);
+        return -1;
     ret = (intf)DFR8putimage(fn, (void *)_fcdtocp(image), (int32)*xdim, (int32)*ydim, (uint16)*compress);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -173,10 +173,10 @@ nd8iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf
 
     fn = HDf2cstring(filename, (intn)*lenfn);
     if (!fn)
-        return (-1);
+        return -1;
     ret = (intf)DFR8addimage(fn, (void *)_fcdtocp(image), (int32)*xdim, (int32)*ydim, (uint16)*compress);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -229,10 +229,10 @@ nd8iwref(_fcd filename, intf *ref, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFR8writeref(fn, Ref);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -254,10 +254,10 @@ nd8inims(_fcd filename, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFR8nimages(fn);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -272,7 +272,7 @@ nd8inims(_fcd filename, intf *fnlen)
 FRETVAL(intf)
 nd8lref(void)
 {
-    return ((intf)DFR8lastref());
+    return (intf)DFR8lastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -297,7 +297,7 @@ nd8scomp(intf *scheme)
         cinfo.jpeg.quality        = 75;
         cinfo.jpeg.force_baseline = 1;
     } /* end if */
-    return (DFR8setcompress((int32)*scheme, &cinfo));
+    return DFR8setcompress((int32)*scheme, &cinfo);
 } /* end d8scomp() */
 
 /*-----------------------------------------------------------------------------
@@ -319,7 +319,7 @@ nd8sjpeg(intf *quality, intf *force_baseline)
 
     cinfo.jpeg.quality        = (intn)*quality;
     cinfo.jpeg.force_baseline = (intn)*force_baseline;
-    return (DFR8setcompress((int32)COMP_JPEG, &cinfo));
+    return DFR8setcompress((int32)COMP_JPEG, &cinfo);
 } /* end d8sjpeg() */
 
 /*-----------------------------------------------------------------------------
@@ -335,7 +335,7 @@ nd8sjpeg(intf *quality, intf *force_baseline)
 FRETVAL(intf)
 ndfr8lastref(void)
 {
-    return ((intf)DFR8lastref());
+    return (intf)DFR8lastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -350,8 +350,7 @@ ndfr8lastref(void)
 FRETVAL(intf)
 ndfr8setpalette(_fcd pal)
 {
-
-    return (DFR8setpalette((uint8 *)_fcdtocp(pal)));
+    return DFR8setpalette((uint8 *)_fcdtocp(pal));
 }
 
 /*-----------------------------------------------------------------------------
@@ -366,8 +365,7 @@ ndfr8setpalette(_fcd pal)
 FRETVAL(intf)
 ndfr8restart(void)
 {
-
-    return (DFR8restart());
+    return DFR8restart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -392,7 +390,7 @@ ndfr8scompress(intf *scheme)
         cinfo.jpeg.quality        = 75;
         cinfo.jpeg.force_baseline = 1;
     } /* end if */
-    return (DFR8setcompress((int32)*scheme, &cinfo));
+    return DFR8setcompress((int32)*scheme, &cinfo);
 } /* end dfr8setcompress() */
 
 /*-----------------------------------------------------------------------------
@@ -414,5 +412,5 @@ ndfr8sjpeg(intf *quality, intf *force_baseline)
 
     cinfo.jpeg.quality        = (intn)*quality;
     cinfo.jpeg.force_baseline = (intn)*force_baseline;
-    return (DFR8setcompress((int32)COMP_JPEG, &cinfo));
+    return DFR8setcompress((int32)COMP_JPEG, &cinfo);
 } /* end dfr8setjpeg() */

--- a/hdf/src/dfrle.c
+++ b/hdf/src/dfrle.c
@@ -89,7 +89,7 @@ DFCIrle(const void *buf, void *bufto, int32 len)
     else
         clead--; /* don't need count position */
 
-    return ((int32)((uint8 *)clead - (uint8 *)bufto)); /* how many encoded */
+    return (int32)((uint8 *)clead - (uint8 *)bufto); /* how many encoded */
 }
 
 /*-----------------------------------------------------------------------------
@@ -148,5 +148,5 @@ DFCIunrle(uint8 *buf, uint8 *bufto, int32 outlen, int resetsave)
             p++; /* skip that character */
         }
     }
-    return ((int32)(p - buf));
+    return (int32)(p - buf);
 }

--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -5006,7 +5006,7 @@ DFSDIstart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end DFSDIstart() */
 
 /*--------------------------------------------------------------------------
@@ -5057,5 +5057,5 @@ DFSDPshutdown(void)
     free(Lastfile);
     Lastfile = NULL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end DFSDPshutdown() */

--- a/hdf/src/dfsdf.c
+++ b/hdf/src/dfsdf.c
@@ -99,7 +99,7 @@ ndsgdisc(intf *dim, intf *maxsize, void *scale)
     else
         cdim = (intn)*dim;
 
-    return (DFSDgetdimscale(cdim, *maxsize, scale));
+    return DFSDgetdimscale(cdim, *maxsize, scale);
 }
 
 /*-----------------------------------------------------------------------------
@@ -115,7 +115,7 @@ ndsgdisc(intf *dim, intf *maxsize, void *scale)
 FRETVAL(intf)
 ndsgrang(void *pmax, void *pmin)
 {
-    return (DFSDgetrange(pmax, pmin));
+    return DFSDgetrange(pmax, pmin);
 }
 
 /*-----------------------------------------------------------------------------
@@ -145,7 +145,7 @@ ndssdims(intf *rank, intf dimsizes[])
 
     ret = DFSDsetdims((intn)*rank, cdims);
     free(cdims);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -170,7 +170,7 @@ ndssdisc(intf *dim, intf *dimsize, void *scale)
         return FAIL;
     cdim = rank - (intn)*dim + 1;
 
-    return (DFSDsetdimscale(cdim, *dimsize, scale));
+    return DFSDsetdimscale(cdim, *dimsize, scale);
 }
 
 /*-----------------------------------------------------------------------------
@@ -186,7 +186,7 @@ ndssdisc(intf *dim, intf *dimsize, void *scale)
 FRETVAL(intf)
 ndssrang(void *max, void *min)
 {
-    return (DFSDsetrange(max, min));
+    return DFSDsetrange(max, min);
 }
 
 /*-----------------------------------------------------------------------------
@@ -201,7 +201,7 @@ ndssrang(void *max, void *min)
 FRETVAL(intf)
 ndsclear(void)
 {
-    return (DFSDclear());
+    return DFSDclear();
 }
 
 /*-----------------------------------------------------------------------------
@@ -254,7 +254,7 @@ ndsgdiln(intf *dim, intf *llabel, intf *lunit, intf *lformat)
         *lunit   = clunit;
         *lformat = clformat;
     } /* end if */
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -279,7 +279,7 @@ ndsgdaln(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
         *lformat   = clformat;
         *lcoordsys = clcoordsys;
     } /* end if */
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -294,7 +294,7 @@ FRETVAL(intf)
 ndsfirst(void)
 {
 
-    return (DFSDrestart());
+    return DFSDrestart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -336,7 +336,7 @@ ndspslc(intf windims[], void *data, intf dims[])
     ret = DFSDIputslice(cwindims, data, cdims, 1);
     free(cdims);
     free(cwindims);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -352,7 +352,7 @@ FRETVAL(intf)
 ndseslc(void)
 {
 
-    return (DFSDIendslice(1));
+    return DFSDIendslice(1);
 }
 
 /*-----------------------------------------------------------------------------
@@ -369,7 +369,7 @@ ndseslc(void)
 FRETVAL(intf)
 ndssnt(intf *numbertype)
 {
-    return (DFSDsetNT(*numbertype));
+    return DFSDsetNT(*numbertype);
 }
 
 /*----------------------------------------------------------------------------
@@ -385,7 +385,7 @@ ndssnt(intf *numbertype)
 FRETVAL(intf)
 ndsgnt(intf *pnumbertype)
 {
-    return (DFSDgetNT((int32 *)pnumbertype));
+    return DFSDgetNT((int32 *)pnumbertype);
 }
 
 /*-----------------------------------------------------------------------------
@@ -411,7 +411,7 @@ ndsigdim(_fcd filename, intf *prank, intf sizes[], intf *maxrank, intf *lenfn)
 
     fn = HDf2cstring(filename, (intn)*lenfn);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFSDgetdims(fn, (intn *)prank, (int32 *)sizes, (intn)*maxrank);
     DFSDIisndg(&isndg);
     if (isndg) {
@@ -448,7 +448,7 @@ ndsigdat(_fcd filename, intf *rank, intf maxsizes[], void *data, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     /* if DFSDgetdims has not be called call DFSDIsdginfo to */
     /* refresh Readsdg       */
     if (DFSDIrefresh(fn) < 0)
@@ -504,7 +504,7 @@ ndsipdat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
     }
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
 
     /* 0, 1 specify create mode, called from FORTRAN program */
     /* In HDF3.2 .hdf files, data and dimsizes are in C order  */
@@ -512,7 +512,7 @@ ndsipdat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
     free(fn);
     free(cdims);
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -546,14 +546,14 @@ ndsiadat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
     }
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
 
     /* 1, 1 specify create mode, called from FORTRAN program */
     /* In HDF3.2 .hdf files, data and dimsizes are in C order  */
     ret = DFSDIputdata(fn, (intn)*rank, cdims, data, 1, 1);
     free(fn);
     free(cdims);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -582,7 +582,7 @@ ndsigslc(_fcd filename, intf winst[], intf windims[], void *data, intf dims[], i
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
 
     /* if DFSDgetdims has not be called call DFSDIsdginfo to */
     /* refresh Readsdg       */
@@ -621,7 +621,7 @@ ndsigslc(_fcd filename, intf winst[], intf windims[], void *data, intf dims[], i
     else
         ret = DFSDIgetslice(fn, (int32 *)winst, (int32 *)windims, data, (int32 *)dims, 1);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -642,10 +642,10 @@ ndsisslc(_fcd filename, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFSDstartslice(fn);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -667,10 +667,10 @@ ndsirref(_fcd filename, intf *ref, intf *fnlen)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFSDreadref(fn, (uint16)*ref);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -687,7 +687,7 @@ ndsirref(_fcd filename, intf *ref, intf *fnlen)
 FRETVAL(intf)
 ndslref(void)
 {
-    return ((intf)DFSDlastref());
+    return (intf)DFSDlastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -709,11 +709,11 @@ ndsinum(_fcd filename, intf *len)
 
     cname = HDf2cstring(filename, (intn)*len);
     if (!cname)
-        return (-1);
+        return -1;
     status = DFSDndatasets(cname);
     free(cname);
 
-    return (status);
+    return status;
 }
 
 /*------------------------------------------------------------------------------
@@ -737,11 +737,11 @@ ndsip32s(_fcd filename, intf *ref, intf *ispre32, intf *len)
 
     cname = HDf2cstring(filename, (intn)*len);
     if (!cname)
-        return (-1);
+        return -1;
     status = DFSDpre32sdg(cname, (uint16)*ref, (intn *)ispre32);
 
     free(cname);
-    return (status);
+    return status;
 }
 
 /*-----------------------------------------------------------------------------
@@ -785,7 +785,7 @@ ndfsdgetdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format)
     else
         cdim = (intn)*dim;
 
-    return (DFSDgetdimstrs(cdim, (char *)_fcdtocp(label), (char *)_fcdtocp(unit), (char *)_fcdtocp(format)));
+    return DFSDgetdimstrs(cdim, (char *)_fcdtocp(label), (char *)_fcdtocp(unit), (char *)_fcdtocp(format));
 }
 
 /*-----------------------------------------------------------------------------
@@ -816,7 +816,7 @@ ndfsdgetdimscale(intf *dim, intf *maxsize, void *scale)
     else
         cdim = (intn)*dim;
 
-    return (DFSDgetdimscale(cdim, *maxsize, scale));
+    return DFSDgetdimscale(cdim, *maxsize, scale);
 }
 
 /*-----------------------------------------------------------------------------
@@ -832,7 +832,7 @@ ndfsdgetdimscale(intf *dim, intf *maxsize, void *scale)
 FRETVAL(intf)
 ndfsdgetrange(void *pmax, void *pmin)
 {
-    return (DFSDgetrange(pmax, pmin));
+    return DFSDgetrange(pmax, pmin);
 }
 
 /*-----------------------------------------------------------------------------
@@ -863,7 +863,7 @@ ndfsdsetdims(intf *rank, intf dimsizes[])
 
     ret = DFSDsetdims((intn)*rank, cdims);
     free(cdims);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -887,7 +887,7 @@ ndfsdsetdimscale(intf *dim, intf *dimsize, void *scale)
         return FAIL;
     cdim = rank - (intn)*dim + 1;
 
-    return (DFSDsetdimscale(cdim, *dimsize, scale));
+    return DFSDsetdimscale(cdim, *dimsize, scale);
 }
 
 /*-----------------------------------------------------------------------------
@@ -903,7 +903,7 @@ ndfsdsetdimscale(intf *dim, intf *dimsize, void *scale)
 FRETVAL(intf)
 ndfsdsetrange(void *max, void *min)
 {
-    return (DFSDsetrange(max, min));
+    return DFSDsetrange(max, min);
 }
 
 /*-----------------------------------------------------------------------------
@@ -918,7 +918,7 @@ ndfsdsetrange(void *max, void *min)
 FRETVAL(intf)
 ndfsdclear(void)
 {
-    return (DFSDclear());
+    return DFSDclear();
 }
 
 /*-----------------------------------------------------------------------------
@@ -971,7 +971,7 @@ ndfsdgetdimlen(intf *dim, intf *llabel, intf *lunit, intf *lformat)
         *lunit   = clunit;
         *lformat = clformat;
     } /* end if */
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -996,7 +996,7 @@ ndfsdgetdatalen(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
         *lformat   = clformat;
         *lcoordsys = clcoordsys;
     } /* end if */
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -1011,7 +1011,7 @@ ndfsdgetdatalen(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
 FRETVAL(intf)
 ndfsdrestart(void)
 {
-    return (DFSDrestart());
+    return DFSDrestart();
 }
 
 /*-----------------------------------------------------------------------------
@@ -1052,7 +1052,7 @@ ndfsdputslice(intf windims[], void *data, intf dims[])
     ret = DFSDIputslice(cwindims, data, cdims, 1);
     free(cdims);
     free(cwindims);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -1067,7 +1067,7 @@ ndfsdputslice(intf windims[], void *data, intf dims[])
 FRETVAL(intf)
 ndfsdendslice(void)
 {
-    return (DFSDIendslice(1));
+    return DFSDIendslice(1);
 }
 
 /*-----------------------------------------------------------------------------
@@ -1084,7 +1084,7 @@ ndfsdendslice(void)
 FRETVAL(intf)
 ndfsdsetnt(intf *numbertype)
 {
-    return (DFSDsetNT(*numbertype));
+    return DFSDsetNT(*numbertype);
 }
 
 /*-----------------------------------------------------------------------------
@@ -1100,7 +1100,7 @@ ndfsdsetnt(intf *numbertype)
 FRETVAL(intf)
 ndfsdgetnt(intf *pnumbertype)
 {
-    return (DFSDgetNT((int32 *)pnumbertype));
+    return DFSDgetNT((int32 *)pnumbertype);
 }
 
 /*-----------------------------------------------------------------------------
@@ -1117,7 +1117,7 @@ ndfsdgetnt(intf *pnumbertype)
 FRETVAL(intf)
 ndfsdlastref(void)
 {
-    return ((intf)DFSDlastref());
+    return (intf)DFSDlastref();
 }
 
 /*-----------------------------------------------------------------------------
@@ -1378,10 +1378,10 @@ ndsiwref(_fcd filename, intf *fnlen, intf *ref)
 
     fn = HDf2cstring(filename, (intn)*fnlen);
     if (!fn)
-        return (-1);
+        return -1;
     ret = DFSDwriteref(fn, (uint16)*ref);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -1580,5 +1580,5 @@ ndsirslab(_fcd filename, intf *fnlen, intf start[], intf slab_size[], intf strid
         ret = DFSDreadslab(fn, (int32 *)start, (int32 *)slab_size, (int32 *)stride, buffer,
                            (int32 *)buffer_size);
     free(fn);
-    return (ret);
+    return ret;
 }

--- a/hdf/src/dfstubs.c
+++ b/hdf/src/dfstubs.c
@@ -101,7 +101,7 @@ DFopen(char *name, int acc_mode, int ndds)
 {
     if (DFIcheck(DFlist) == 0) {
         DFerror = DFE_TOOMANY;
-        return (NULL);
+        return NULL;
     }
     else
         DFerror = DFE_NONE;
@@ -111,14 +111,14 @@ DFopen(char *name, int acc_mode, int ndds)
 
     if (DFid == -1) {
         DFerror = (int)HEvalue(1);
-        return (NULL);
+        return NULL;
     }
     else {
         /*
            DFlist = makedf(DFid);
          */
         DFlist = (DF *)&DFid;
-        return (DFlist);
+        return DFlist;
     }
 }
 
@@ -144,7 +144,7 @@ DFclose(DF *dfile)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (FAIL);
+        return FAIL;
     }
     else
         DFerror = DFE_NONE;
@@ -172,7 +172,7 @@ DFclose(DF *dfile)
         DFerror = (int)HEvalue(1);
     }
 
-    return (ret);
+    return ret;
 }
 
 /*
@@ -203,7 +203,7 @@ DFdescriptors(DF *dfile, DFdesc ptr[], int begin, int num)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -212,7 +212,7 @@ DFdescriptors(DF *dfile, DFdesc ptr[], int begin, int num)
 
     if (aid == FAIL) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
 
     for (i = 2; i <= begin; i++) {
@@ -220,7 +220,7 @@ DFdescriptors(DF *dfile, DFdesc ptr[], int begin, int num)
         if (ret == FAIL) {
             Hendaccess(aid);
             DFerror = (int)HEvalue(1);
-            return (-1);
+            return -1;
         }
     }
 
@@ -230,13 +230,13 @@ DFdescriptors(DF *dfile, DFdesc ptr[], int begin, int num)
         ret = Hnextread(aid, DFTAG_WILDCARD, DFREF_WILDCARD, DF_CURRENT);
         if (ret == FAIL) {
             Hendaccess(aid);
-            return (i);
+            return i;
         }
         Hinquire(aid, NULL, &ptr[i].tag, &ptr[i].ref, &ptr[i].length, &ptr[i].offset, NULL, NULL, NULL);
     }
     Hendaccess(aid);
 
-    return (i);
+    return i;
 }
 
 /*
@@ -263,13 +263,13 @@ DFnumber(DF *dfile, uint16 tag)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
     num = Hnumber(DFid, tag);
-    return (num);
+    return num;
 }
 
 /*
@@ -294,7 +294,7 @@ DFsetfind(DF *dfile, uint16 tag, uint16 ref)
 {
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -304,7 +304,7 @@ DFsetfind(DF *dfile, uint16 tag, uint16 ref)
 
     search_stat = DFSRCH_NEW;
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -330,7 +330,7 @@ DFfind(DF *dfile, DFdesc *ptr)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -348,12 +348,12 @@ DFfind(DF *dfile, DFdesc *ptr)
         DFerror  = DFE_NOMATCH;
         ptr->tag = 0;
         ptr->ref = 0;
-        return (-1);
+        return -1;
     }
 
     Hinquire(search_aid, NULL, &ptr->tag, &ptr->ref, &ptr->length, &ptr->offset, NULL, NULL, NULL);
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -390,7 +390,7 @@ DFaccess(DF *dfile, uint16 tag, uint16 ref, char *acc_mode)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -403,19 +403,19 @@ DFaccess(DF *dfile, uint16 tag, uint16 ref, char *acc_mode)
             accmode = DFACC_WRITE;
             if (((DFaccmode & DFACC_WRITE) == 0) && ((DFaccmode & DFACC_CREATE) == 0)) {
                 DFerror = DFE_BADACC;
-                return (-1);
+                return -1;
             }
             break;
         case 'a':
             accmode = DFACC_APPEND;
             if (((DFaccmode & DFACC_WRITE) == 0) && ((DFaccmode & DFACC_CREATE) == 0)) {
                 DFerror = DFE_BADACC;
-                return (-1);
+                return -1;
             }
             break;
         default:
             DFerror = DFE_BADACC;
-            return (-1);
+            return -1;
     }
 
     acc_tag     = tag;
@@ -431,7 +431,7 @@ DFaccess(DF *dfile, uint16 tag, uint16 ref, char *acc_mode)
             if (DFelsize <= 0) {
                 DFIclearacc();
                 DFerror = (int)HEvalue(1);
-                return (-1);
+                return -1;
             }
             break;
             /* _maybe_ treat 'w' and 'a' in the same general 'a'-way */
@@ -448,13 +448,13 @@ DFaccess(DF *dfile, uint16 tag, uint16 ref, char *acc_mode)
             if (DFelsize == FAIL) {
                 DFIclearacc();
                 DFerror = (int)HEvalue(1);
-                return (-1);
+                return -1;
             }
             DFelseekpos = DFelsize;
             break;
     }
 
-    return (0);
+    return 0;
 }
 
 static int
@@ -469,7 +469,7 @@ DFIclearacc(void)
     DFelstat    = DFEL_ABSENT;
     DFelement   = NULL;
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -493,7 +493,7 @@ DFIclearacc(void)
 int
 DFstart(DF *dfile, uint16 tag, uint16 ref, char *acc_mode)
 {
-    return (DFaccess(dfile, tag, ref, acc_mode));
+    return DFaccess(dfile, tag, ref, acc_mode);
 }
 
 /*
@@ -521,7 +521,7 @@ DFread(DF *dfile, char *ptr, int32 len)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -531,7 +531,7 @@ DFread(DF *dfile, char *ptr, int32 len)
     if (ret == FAIL) {
         Hendaccess(DFaid);
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
 
     ret = Hread(DFaid, len, (unsigned char *)ptr);
@@ -539,11 +539,11 @@ DFread(DF *dfile, char *ptr, int32 len)
 
     if (ret == FAIL) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
     else {
         DFelseekpos += ret;
-        return (ret);
+        return ret;
     }
 }
 
@@ -570,7 +570,7 @@ DFseek(DF *dfile, int32 offset)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -579,18 +579,18 @@ DFseek(DF *dfile, int32 offset)
        and writing more data */
     if (offset > DFelsize) {
         DFerror = DFE_BADSEEK;
-        return (-1);
+        return -1;
     }
     else {
         ret = Hseek(DFaid, offset, DF_START);
         if (ret == FAIL) {
             DFerror = (int)HEvalue(1);
-            return (-1);
+            return -1;
         }
         DFelseekpos = offset;
     }
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -623,11 +623,11 @@ DFwrite(DF *dfile, char *ptr, int32 len)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     if ((DFelaccmode != DFACC_WRITE) && (DFelaccmode != DFACC_APPEND)) {
         DFerror = DFE_BADACC;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
@@ -650,7 +650,7 @@ DFwrite(DF *dfile, char *ptr, int32 len)
             else {
                 Hendaccess(DFaid);
                 DFerror = DFE_NOTENOUGH;
-                return (-1);
+                return -1;
             }
         }
     }
@@ -667,7 +667,7 @@ DFwrite(DF *dfile, char *ptr, int32 len)
     DFelsize = size;
     DFelstat = DFEL_RESIDENT;
 
-    return (ret);
+    return ret;
 }
 
 /*
@@ -694,12 +694,12 @@ DFupdate(DF *dfile)
 {
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -727,12 +727,12 @@ DFstat(DF *dfile, DFdata *dfinfo)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -759,17 +759,17 @@ DFgetelement(DF *dfile, uint16 tag, uint16 ref, char *ptr)
 {
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
     if (Hgetelement(DFid, tag, ref, (unsigned char *)ptr) == -1) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
     else
-        return (Hlength(DFid, tag, ref));
+        return Hlength(DFid, tag, ref);
 }
 
 /*
@@ -796,17 +796,17 @@ DFputelement(DF *dfile, uint16 tag, uint16 ref, char *ptr, int32 len)
 {
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
     if (Hputelement(DFid, tag, ref, (unsigned char *)ptr, len) == FAIL) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
     else
-        return (Hlength(DFid, tag, ref));
+        return Hlength(DFid, tag, ref);
 }
 
 /*
@@ -833,17 +833,17 @@ DFdup(DF *dfile, uint16 itag, uint16 iref, uint16 otag, uint16 oref)
 {
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
     if (Hdupdd(DFid, itag, iref, otag, oref) != SUCCEED) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
     else
-        return (0);
+        return 0;
 }
 
 /*
@@ -869,17 +869,17 @@ DFdel(DF *dfile, uint16 tag, uint16 ref)
 {
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (-1);
+        return -1;
     }
     else
         DFerror = DFE_NONE;
 
     if (Hdeldd(DFid, tag, ref) != 0) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
     else
-        return (0);
+        return 0;
 }
 
 /*
@@ -904,7 +904,7 @@ DFnewref(DF *dfile)
 
     if (DFIcheck(dfile) != 0) {
         DFerror = DFE_NOTOPEN;
-        return (0);
+        return 0;
     }
     else
         DFerror = DFE_NONE;
@@ -912,10 +912,10 @@ DFnewref(DF *dfile)
     ret = Hnewref(DFid);
     if (ret == 0xffff) {
         DFerror = (int)HEvalue(1);
-        return (0);
+        return 0;
     }
 
-    return (ret);
+    return ret;
 }
 
 /*
@@ -943,11 +943,11 @@ DFishdf(char *filename)
     dummy = Hopen(filename, DFACC_READ, 0);
     if (dummy == -1) {
         DFerror = (int)HEvalue(1);
-        return (-1);
+        return -1;
     }
     else {
         Hclose(dummy);
-        return (0);
+        return 0;
     }
 }
 
@@ -968,7 +968,7 @@ DFishdf(char *filename)
 int
 DFerrno(void)
 {
-    return (DFerror);
+    return DFerror;
 }
 
 /*-----------------------------------------------------------------------------
@@ -986,15 +986,15 @@ DFIcheck(DF *dfile)
 
     if ((dfile != (DF *)&DFid) || (DFid == 0)) {
         DFerror = DFE_DFNULL;
-        return (-1);
+        return -1;
     }
 
     if ((DFaccmode & DFACC_ALL) != DFaccmode) {
         DFerror = DFE_BADACC;
-        return (-1);
+        return -1;
     }
     else
-        return (0);
+        return 0;
 }
 
 /*-----------------------------------------------------------------------------
@@ -1016,7 +1016,7 @@ DFIerr(DF *dfile)
     if (dfile != NULL)
         (void)DFclose(dfile);
     DFerror = saveerror;
-    return (-1);
+    return -1;
 }
 
 /*-----------------------------------------------------------------------------
@@ -1030,24 +1030,24 @@ DFIgetspace(uint32 qty)
 
     ret     = (void *)malloc(qty);
     DFerror = (int)HEvalue(1);
-    return (ret);
+    return ret;
 }
 
 void *
 DFIfreespace(void *ptr)
 {
     free(ptr);
-    return (NULL);
+    return NULL;
 }
 
 intn
 DFIc2fstr(char *str, int len)
 {
-    return (HDc2fstr(str, len));
+    return HDc2fstr(str, len);
 }
 
 char *
 DFIf2cstring(_fcd fdesc, intn len)
 {
-    return (HDf2cstring(fdesc, len));
+    return HDf2cstring(fdesc, len);
 }

--- a/hdf/src/dfufp2if.c
+++ b/hdf/src/dfufp2if.c
@@ -34,9 +34,9 @@ nduif2i(int32 *hdim, int32 *vdim, float32 *max, float32 *min, float32 hscale[], 
 
     fn = HDf2cstring(outfile, *lenfn);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = DFUfptoimage(*hdim, *vdim, (float32)*max, (float32)*min, hscale, vscale, data,
                        (uint8 *)_fcdtocp(palette), fn, *ct_method, *hres, *vres, *compress);
     free(fn);
-    return (ret);
+    return ret;
 }

--- a/hdf/src/dfunjpeg.c
+++ b/hdf/src/dfunjpeg.c
@@ -264,7 +264,7 @@ jpeg_HDF_src(struct jpeg_decompress_struct *cinfo_ptr, int32 file_id, uint16 tag
     src->pub.bytes_in_buffer = 0;
     src->pub.next_input_byte = NULL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end jpeg_HDF_src() */
 
 /*-----------------------------------------------------------------------------

--- a/hdf/src/dfutil.c
+++ b/hdf/src/dfutil.c
@@ -71,5 +71,5 @@ DFfindnextref(int32 file_id, uint16 tag, uint16 lref)
         return (uint16)FAIL;
 
     Hendaccess(aid);
-    return (newref);
+    return newref;
 }

--- a/hdf/src/dfutilf.c
+++ b/hdf/src/dfutilf.c
@@ -36,7 +36,7 @@
 FRETVAL(intf)
 ndfindnr(intf *dfile, intf *tag, intf *lref)
 {
-    return ((intf)DFfindnextref(*dfile, (uint16)*tag, (uint16)*lref));
+    return (intf)DFfindnextref(*dfile, (uint16)*tag, (uint16)*lref);
 }
 
 /*
@@ -58,5 +58,5 @@ ndfindnr(intf *dfile, intf *tag, intf *lref)
 FRETVAL(intf)
 ndffindnextref(intf *dfile, intf *tag, intf *lref)
 {
-    return ((intf)DFfindnextref(*dfile, (uint16)*tag, (uint16)*lref));
+    return (intf)DFfindnextref(*dfile, (uint16)*tag, (uint16)*lref);
 }

--- a/hdf/src/glist.c
+++ b/hdf/src/glist.c
@@ -816,7 +816,7 @@ HDGLnum_of_objects(Generic_list list)
 intn
 HDGLis_empty(Generic_list list)
 {
-    return (list.info->num_of_elements == 0);
+    return list.info->num_of_elements == 0;
 } /* HDGLis_empty() */
 
 /******************************************************************************
@@ -838,7 +838,7 @@ HDGLis_in_list(Generic_list list, void *pointer)
     while (element != &list.info->post_element && element->pointer != pointer)
         element = element->next;
 
-    return (element != &list.info->post_element);
+    return element != &list.info->post_element;
 } /* HDGLis_in_list() */
 
 /******************************************************************************

--- a/hdf/src/hbitio.c
+++ b/hdf/src/hbitio.c
@@ -127,7 +127,7 @@ Hstartbitread(int32 file_id, uint16 tag, uint16 ref)
 
         read_size = MIN((bitfile_rec->max_offset - bitfile_rec->byte_offset), BITBUF_SIZE);
         if ((n = Hread(bitfile_rec->acc_id, read_size, bitfile_rec->bytea)) == FAIL)
-            return FAIL;                          /* EOF? somebody pulled the rug out from under us! */
+            return FAIL;                            /* EOF? somebody pulled the rug out from under us! */
         bitfile_rec->buf_read = (intn)n;            /* keep track of the number of bytes in buffer */
         bitfile_rec->bytep    = bitfile_rec->bytea; /* set to the beginning of the buffer */
     }                                               /* end if */

--- a/hdf/src/hbitio.c
+++ b/hdf/src/hbitio.c
@@ -127,7 +127,7 @@ Hstartbitread(int32 file_id, uint16 tag, uint16 ref)
 
         read_size = MIN((bitfile_rec->max_offset - bitfile_rec->byte_offset), BITBUF_SIZE);
         if ((n = Hread(bitfile_rec->acc_id, read_size, bitfile_rec->bytea)) == FAIL)
-            return (FAIL);                          /* EOF? somebody pulled the rug out from under us! */
+            return FAIL;                          /* EOF? somebody pulled the rug out from under us! */
         bitfile_rec->buf_read = (intn)n;            /* keep track of the number of bytes in buffer */
         bitfile_rec->bytep    = bitfile_rec->bytea; /* set to the beginning of the buffer */
     }                                               /* end if */
@@ -138,7 +138,7 @@ Hstartbitread(int32 file_id, uint16 tag, uint16 ref)
     bitfile_rec->block_offset = 0;
     bitfile_rec->count        = 0;
 
-    return (ret_value);
+    return ret_value;
 } /* Hstartbitread() */
 
 /*--------------------------------------------------------------------------
@@ -260,7 +260,7 @@ Hbitappendable(int32 bitid)
 
     if (Happendable(bitfile_rec->acc_id) == FAIL)
         HRETURN_ERROR(DFE_NOTENOUGH, FAIL);
-    return (SUCCEED);
+    return SUCCEED;
 } /* end Hbitappendable() */
 
 /*--------------------------------------------------------------------------
@@ -325,7 +325,7 @@ Hbitwrite(int32 bitid, intn count, uint32 data)
     /* merge the new bits into the current bits buffer */
     if (count < bitfile_rec->count) {
         bitfile_rec->bits |= (uint8)(data << (bitfile_rec->count -= count));
-        return (orig_count);
+        return orig_count;
     } /* end if */
 
     /* fill up the current bits buffer and output the byte */
@@ -390,7 +390,7 @@ Hbitwrite(int32 bitid, intn count, uint32 data)
     if (bitfile_rec->byte_offset > bitfile_rec->max_offset)
         bitfile_rec->max_offset = bitfile_rec->byte_offset;
 
-    return (orig_count);
+    return orig_count;
 } /* end Hbitwrite() */
 
 /*--------------------------------------------------------------------------
@@ -454,7 +454,7 @@ Hbitread(int32 bitid, intn count, uint32 *data)
     /* buffered bits then do the shift and return */
     if (count <= bitfile_rec->count) {
         *data = (uint32)((uintn)bitfile_rec->bits >> (bitfile_rec->count -= count)) & (uint32)maskc[count];
-        return (count);
+        return count;
     } /* end if */
 
     /* keep track of the original number of bits to read in */
@@ -474,8 +474,8 @@ Hbitread(int32 bitid, intn count, uint32 *data)
                 bitfile_rec->count =
                     0;     /* make certain that we don't try to access the file->bits information */
                 *data = b; /* assign the bits read in */
-                return (orig_count - count); /* break out now */
-            }                                /* end if */
+                return orig_count - count; /* break out now */
+            }                              /* end if */
             bitfile_rec->block_offset +=
                 bitfile_rec->buf_read; /* keep track of the number of bytes in buffer */
             bitfile_rec->bytez    = n + (bitfile_rec->bytep = bitfile_rec->bytea);
@@ -496,8 +496,8 @@ Hbitread(int32 bitid, intn count, uint32 *data)
                 bitfile_rec->count =
                     0;     /* make certain that we don't try to access the file->bits information */
                 *data = b; /* assign the bits read in */
-                return (orig_count - count); /* return now */
-            }                                /* end if */
+                return orig_count - count; /* return now */
+            }                              /* end if */
             bitfile_rec->block_offset +=
                 bitfile_rec->buf_read; /* keep track of the number of bytes in buffer */
             bitfile_rec->bytez    = n + (bitfile_rec->bytep = bitfile_rec->bytea);
@@ -514,7 +514,7 @@ Hbitread(int32 bitid, intn count, uint32 *data)
         bitfile_rec->count = 0;
 
     *data = b;
-    return (orig_count);
+    return orig_count;
 } /* end Hbitread() */
 
 /*--------------------------------------------------------------------------
@@ -606,7 +606,7 @@ Hbitseek(int32 bitid, int32 byte_offset, intn bit_offset)
         } /* end else */
     }     /* end else */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end Hbitseek() */
 
 /*--------------------------------------------------------------------------
@@ -633,7 +633,7 @@ Hgetbit(int32 bitid)
 
     if (Hbitread(bitid, 1, &data) == FAIL)
         HRETURN_ERROR(DFE_BITREAD, FAIL);
-    return ((intn)data);
+    return (intn)data;
 } /* end Hgetbit() */
 
 /*--------------------------------------------------------------------------
@@ -682,7 +682,7 @@ Hendbitaccess(int32 bitfile_id, intn flushbit)
         HRETURN_ERROR(DFE_CANTENDACCESS, FAIL);
     free(bitfile_rec);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end Hendbitaccess() */
 
 /*--------------------------------------------------------------------------
@@ -714,7 +714,7 @@ HIbitstart(void)
         HGOTO_ERROR(DFE_INTERNAL, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end HIbitstart() */
 
 /*--------------------------------------------------------------------------
@@ -784,7 +784,7 @@ HIbitflush(bitrec_t *bitfile_rec, intn flushbit, intn writeout)
                 HRETURN_ERROR(DFE_WRITEERROR, FAIL);
     } /* end if */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HIbitflush */
 
 /*--------------------------------------------------------------------------
@@ -828,7 +828,7 @@ HIread2write(bitrec_t *bitfile_rec)
     bitfile_rec->mode         = 'w';             /* change to write mode */
     if (Hbitseek(bitfile_rec->bit_id, bitfile_rec->byte_offset, ((intn)BITNUM - bitfile_rec->count)) == FAIL)
         HRETURN_ERROR(DFE_INTERNAL, FAIL);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HIread2write */
 
 /*--------------------------------------------------------------------------
@@ -861,7 +861,7 @@ HIwrite2read(bitrec_t *bitfile_rec)
     bitfile_rec->mode         = 'r';             /* change to read mode */
     if (Hbitseek(bitfile_rec->bit_id, prev_offset, ((intn)BITNUM - prev_count)) == FAIL)
         HRETURN_ERROR(DFE_INTERNAL, FAIL);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HIwrite2read */
 
 /*--------------------------------------------------------------------------
@@ -887,5 +887,5 @@ HPbitshutdown(void)
     /* Shutdown the file ID atom group */
     HAdestroy_group(BITIDGROUP);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HPbitshutdown() */

--- a/hdf/src/hbuffer.c
+++ b/hdf/src/hbuffer.c
@@ -209,7 +209,7 @@ HBPstread(accrec_t *rec)
     (void)rec;
 
     assert(0 && "Should never be called");
-    return (FAIL);
+    return FAIL;
 } /* HBPstread */
 
 /* ------------------------------ HBPstwrite ------------------------------- */
@@ -231,7 +231,7 @@ HBPstwrite(accrec_t *rec)
     (void)rec;
 
     assert(0 && "Should never be called");
-    return (FAIL);
+    return FAIL;
 } /* HBPstwrite */
 
 /* ------------------------------ HBPseek ------------------------------- */
@@ -312,7 +312,7 @@ HBPread(accrec_t *access_rec, int32 length, void *data)
     ret_value = length;
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HBPread */
 
 /* ------------------------------ HBPwrite ------------------------------- */
@@ -378,7 +378,7 @@ HBPwrite(accrec_t *access_rec, int32 length, const void *data)
     ret_value = length; /* return length of bytes written */
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HBPwrite */
 
 /* ------------------------------ HBPinquire ------------------------------ */
@@ -525,7 +525,7 @@ HBPcloseAID(accrec_t *access_rec)
     }
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HBPcloseAID */
 
 /* ------------------------------- HBPinfo -------------------------------- */
@@ -560,5 +560,5 @@ HBPinfo(accrec_t *access_rec, sp_info_block_t *info_block)
     info_block->buf_aid = info->buf_aid;
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HBPinfo */

--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -248,7 +248,7 @@ HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type,
         default:
             HRETURN_ERROR(DFE_BADCODER, FAIL);
     } /* end switch */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIinit_coder() */
 
 /*--------------------------------------------------------------------------
@@ -287,7 +287,7 @@ HCIinit_model(int16 acc_mode, comp_model_info_t *minfo, comp_model_t model_type,
             HRETURN_ERROR(DFE_BADMODEL, FAIL);
     } /* end switch */
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCIinit_model() */
 
 /*--------------------------------------------------------------------------
@@ -1352,7 +1352,7 @@ HCPinquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pref, in
     if (pspecial != NULL)
         *pspecial = (int16)access_rec->special;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HCPinquire() */
 
 /*--------------------------------------------------------------------------
@@ -1442,7 +1442,7 @@ HCPcloseAID(accrec_t *access_rec)
         free(info);
         access_rec->special_info = NULL;
     }
-    return (ret);
+    return ret;
 } /* end HCPcloseAID() */
 
 /* ------------------------------- HCPinfo -------------------------------- */

--- a/hdf/src/hcompri.c
+++ b/hdf/src/hcompri.c
@@ -179,7 +179,7 @@ HRPstread(accrec_t *rec)
     (void)rec;
 
     assert(0 && "Should never be called");
-    return (FAIL);
+    return FAIL;
 } /* HRPstread */
 
 /* ------------------------------ HRPstwrite ------------------------------- */
@@ -201,7 +201,7 @@ HRPstwrite(accrec_t *rec)
     (void)rec;
 
     assert(0 && "Should never be called");
-    return (FAIL);
+    return FAIL;
 } /* HRPstwrite */
 
 /* ------------------------------ HRPseek ------------------------------- */
@@ -273,7 +273,7 @@ HRPread(accrec_t *access_rec, int32 length, void *data)
     ret_value = length;
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HRPread */
 
 /* ------------------------------ HRPwrite ------------------------------- */
@@ -314,7 +314,7 @@ HRPwrite(accrec_t *access_rec, int32 length, const void *data)
     ret_value = length; /* return length of bytes written */
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HRPwrite */
 
 /* ------------------------------ HRPinquire ------------------------------ */
@@ -455,7 +455,7 @@ HRPcloseAID(accrec_t *access_rec)
         access_rec->special_info = NULL;
     }
 
-    return (ret_value);
+    return ret_value;
 } /* HRPcloseAID */
 
 /* ------------------------------- HRPinfo -------------------------------- */
@@ -486,5 +486,5 @@ HRPinfo(accrec_t *access_rec, sp_info_block_t *info_block)
     info_block->key = SPECIAL_COMPRAS;
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HRPinfo */

--- a/hdf/src/hdatainfo.c
+++ b/hdf/src/hdatainfo.c
@@ -923,7 +923,7 @@ GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array)
             HGOTO_ERROR(DFE_INTERNAL, FAIL);
         }
         else
-            return (n_IP8s + n_LUTs);
+            return n_IP8s + n_LUTs;
     }
 
     /* Application requests data info of palettes.  Start checking tags in

--- a/hdf/src/hdfalloc.c
+++ b/hdf/src/hdfalloc.c
@@ -80,7 +80,7 @@ HDmemfill(void *dest, const void *src, uint32 item_size, uint32 num_items)
         if (items_left > 0)  /* if there are any items left to copy */
             memcpy(curr_dest, dest, items_left * item_size);
     } /* end if */
-    return (dest);
+    return dest;
 } /* end HDmemfill() */
 
 /*--------------------------------------------------------------------------
@@ -112,9 +112,9 @@ HIstrncpy(char *dest, const char *source, intn len)
 
     destp = dest;
     if (len == 0)
-        return (destp);
+        return destp;
     for (; (len > 1) && (*source != '\0'); len--)
         *dest++ = *source++;
     *dest = '\0'; /* Force the last byte be '\0'   */
-    return (destp);
+    return destp;
 } /* end HIstrncpy() */

--- a/hdf/src/herrf.c
+++ b/hdf/src/herrf.c
@@ -63,17 +63,17 @@ nheprntc(_fcd filename, intf *print_levels, intf *namelen)
     c_len = *namelen;
     if (c_len == 0) {
         HEprint(stderr, *print_levels);
-        return (ret);
+        return ret;
     }
     c_name = HDf2cstring(filename, c_len);
     if (!c_name)
-        return (FAIL);
+        return FAIL;
     err_file = fopen(c_name, "a");
     if (!err_file)
-        return (FAIL);
+        return FAIL;
     HEprint(err_file, *print_levels);
     fclose(err_file);
-    return (ret);
+    return ret;
 }
 /*-----------------------------------------------------------------------------
  * Name: hestringc

--- a/hdf/src/hextelt.c
+++ b/hdf/src/hextelt.c
@@ -1375,5 +1375,5 @@ HXPshutdown(void)
     HDFEXTCREATEDIR = NULL;
     HDFEXTDIR       = NULL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HXPshutdown() */

--- a/hdf/src/hfile.c
+++ b/hdf/src/hfile.c
@@ -2045,7 +2045,7 @@ HDdont_atexit(void)
     if (install_atexit == TRUE)
         install_atexit = FALSE;
 
-    return (ret_value);
+    return ret_value;
 } /* end HDdont_atexit() */
 
 /*==========================================================================
@@ -2107,7 +2107,7 @@ HIstart(void)
     }
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end HIstart() */
 
 /*--------------------------------------------------------------------------
@@ -2142,7 +2142,7 @@ HPregister_term_func(hdf_termfunc_t term_func)
         HGOTO_ERROR(DFE_INTERNAL, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end HPregister_term_func() */
 
 /*--------------------------------------------------------------------------
@@ -2317,7 +2317,7 @@ HIunlock(filerec_t *file_rec)
     /* unlock the file record */
     file_rec->attach--;
 
-    return (SUCCEED);
+    return SUCCEED;
 }
 
 /* ------------------------- SPECIAL TAG ROUTINES ------------------------- */
@@ -2454,7 +2454,7 @@ Hgetlibversion(uint32 *majorv, uint32 *minorv, uint32 *releasev, char *string)
     *releasev = LIBVER_RELEASE;
     HIstrncpy(string, LIBVER_STRING, LIBVSTR_LEN + 1);
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* HDgetlibversion */
 
 /*--------------------------------------------------------------------------
@@ -2725,7 +2725,7 @@ HPcompare_accrec_tagref(const void *rec1, const void *rec2)
     } /* end if */
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* HPcompare_accrec_tagref */
 
 /*--------------------------------------------------------------------------

--- a/hdf/src/hfiledd.c
+++ b/hdf/src/hfiledd.c
@@ -1873,7 +1873,7 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, uintn *all_cnt,
 
     *all_cnt  = t_all_cnt;
     *real_cnt = t_real_cnt;
-    return (SUCCEED);
+    return SUCCEED;
 } /* HTIcount_dd */
 
 /*--------------------------------------------------------------------------

--- a/hdf/src/hfilef.c
+++ b/hdf/src/hfilef.c
@@ -44,10 +44,10 @@ nhiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 
     fn = HDf2cstring(name, (intn)*namelen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)Hopen(fn, (intn)*acc_mode, (int16)*defdds);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -62,7 +62,7 @@ nhiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 FRETVAL(intf)
 nhclose(intf *file_id)
 {
-    return (Hclose(*file_id));
+    return Hclose(*file_id);
 }
 
 /*-----------------------------------------------------------------------------
@@ -77,7 +77,7 @@ nhclose(intf *file_id)
 FRETVAL(intf)
 nhnumber(intf *file_id, intf *tag)
 {
-    return (Hnumber((int32)*file_id, (uint16)*tag));
+    return Hnumber((int32)*file_id, (uint16)*tag);
 }
 
 /*-----------------------------------------------------------------------------
@@ -98,10 +98,10 @@ nhxisdir(_fcd dir, intf *dirlen)
 
     fn = HDf2cstring(dir, (intn)*dirlen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)HXsetdir(fn);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -122,10 +122,10 @@ nhxiscdir(_fcd dir, intf *dirlen)
 
     fn = HDf2cstring(dir, (intn)*dirlen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)HXsetcreatedir(fn);
     free(fn);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -140,7 +140,7 @@ nhxiscdir(_fcd dir, intf *dirlen)
 FRETVAL(intf)
 nhddontatexit(void)
 {
-    return ((intf)(HDdont_atexit()));
+    return (intf)(HDdont_atexit());
 }
 /*-----------------------------------------------------------------------------
  * Name: hglibverc
@@ -174,7 +174,7 @@ nhglibverc(intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len)
     *minor_v = (intf)cminor_v;
     *release = (intf)crelease;
 
-    return ((intf)status);
+    return (intf)status;
 }
 /*-----------------------------------------------------------------------------
  * Name: hgfilverc
@@ -208,7 +208,7 @@ nhgfilverc(intf *file_id, intf *major_v, intf *minor_v, intf *release, _fcd stri
     *minor_v = (intf)cminor_v;
     *release = (intf)crelease;
 
-    return ((intf)status);
+    return (intf)status;
 }
 /*-----------------------------------------------------------------------------
  * Name:    hiishdf
@@ -228,10 +228,10 @@ nhiishdf(_fcd name, intf *namelen)
 
     fn = HDf2cstring(name, (intn)*namelen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)Hishdf(fn);
     free(fn);
-    return (ret);
+    return ret;
 }
 /*-----------------------------------------------------------------------------
  * Name:    hconfinfc
@@ -254,7 +254,7 @@ nhconfinfc(intf *coder_type, intf *info)
     coder_type_c = (comp_coder_t)*coder_type;
     status       = HCget_config_info(coder_type_c, &info_c);
     if (status == FAIL)
-        return (FAIL);
+        return FAIL;
     *info = (intf)info_c;
-    return (status);
+    return status;
 }

--- a/hdf/src/hkit.c
+++ b/hdf/src/hkit.c
@@ -176,8 +176,8 @@ HDgettagdesc(uint16 tag)
 
     for (i = 0; i < (intn)(sizeof(tag_descriptions) / sizeof(tag_descript_t)); i++)
         if (tag_descriptions[i].tag == tag)
-            return (tag_descriptions[i].desc);
-    return (NULL);
+            return tag_descriptions[i].desc;
+    return NULL;
 } /* HDgettagdesc */
 
 /* ----------------------------- HDgettagsname ----------------------------- */
@@ -221,7 +221,7 @@ HDgettagsname(uint16 tag)
                 ret = t;
             }
         }
-    return (ret);
+    return ret;
 } /* HDgettagsname */
 
 /* ----------------------------- HDgettagnum ------------------------------ */
@@ -244,8 +244,8 @@ HDgettagnum(const char *tag_name)
 
     for (i = 0; i < (intn)(sizeof(tag_descriptions) / sizeof(tag_descript_t)); i++)
         if (0 == strcmp(tag_descriptions[i].name, tag_name))
-            return ((intn)tag_descriptions[i].tag);
-    return (FAIL);
+            return (intn)tag_descriptions[i].tag;
+    return FAIL;
 } /* HDgettagnum */
 
 /* ----------------------------- HDgetNTdesc ----------------------------- */
@@ -294,9 +294,9 @@ HDgetNTdesc(int32 nt)
                 free(ret_desc);
                 ret_desc = t;
             }
-            return (ret_desc);
+            return ret_desc;
         }
-    return (NULL);
+    return NULL;
 } /* end HDgetNTdesc() */
 
 /* ------------------------------- HDfidtoname ------------------------------ */
@@ -322,5 +322,5 @@ HDfidtoname(int32 file_id)
     if ((file_rec = HAatom_object(file_id)) == NULL)
         HRETURN_ERROR(DFE_ARGS, NULL);
 
-    return (file_rec->path);
+    return file_rec->path;
 } /* HDfidtoname */

--- a/hdf/src/linklist.c
+++ b/hdf/src/linklist.c
@@ -425,5 +425,5 @@ HULshutdown(void)
             free(curr);
         }
     }
-    return (SUCCEED);
+    return SUCCEED;
 } /* end HULshutdown() */

--- a/hdf/src/mcache.c
+++ b/hdf/src/mcache.c
@@ -273,7 +273,7 @@ done:
 #endif
 #endif
 
-    return (mp);
+    return mp;
 } /* mcache_open () */
 
 /******************************************************************************
@@ -470,7 +470,7 @@ done:
 #ifdef MCACHE_DEBUG
     fprintf(stderr, "mcache_get: Exiting \n");
 #endif
-    return (bp->page);
+    return bp->page;
 } /* mcache_get() */
 
 /******************************************************************************
@@ -710,7 +710,7 @@ done:
         return NULL;
     }
 
-    return (bp); /* return only the pagesize fragment */
+    return bp; /* return only the pagesize fragment */
 } /* mcache_bkt() */
 
 /******************************************************************************
@@ -838,7 +838,7 @@ mcache_look(MCACHE *mp, /* IN: MCACHE cookie */
     ++mp->cachemiss;
 #endif
 done:
-    return (bp);
+    return bp;
 } /* mcache_look() */
 
 #ifdef STATISTICS

--- a/hdf/src/mfan.c
+++ b/hdf/src/mfan.c
@@ -228,7 +228,7 @@ ANIstart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end ANIstart() */
 
 /* ------------------------------- ANIinit --------------------------------

--- a/hdf/src/mfanf.c
+++ b/hdf/src/mfanf.c
@@ -82,7 +82,7 @@ nafstart(intf *file_id)
 
     ret = ANstart((int32)*file_id);
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -275,7 +275,7 @@ nafwriteann(intf *ann_id, _fcd ann, intf *annlen)
     /* Convert fortran string to C-String */
     iann = HDf2cstring(ann, (intn)*annlen);
     if (!iann)
-        return (FAIL);
+        return FAIL;
 
     status = ANwriteann((int32)*ann_id, (char *)_fcdtocp(ann), (int32)*annlen);
 

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -235,7 +235,7 @@ rigcompare(void *k1, void *k2, intn cmparg)
 {
     (void)cmparg;
 
-    return ((intn)((*(int32 *)k1) - (*(int32 *)k2))); /* valid for integer keys */
+    return (intn)((*(int32 *)k1) - (*(int32 *)k2)); /* valid for integer keys */
 } /* rigcompare */
 
 /* ---------------------------- GRIgrdestroynode ------------------------- */
@@ -334,7 +334,7 @@ Get_grfile(HFILEID f)
     int32  key = (int32)f;
 
     t = (void **)tbbtdfind(gr_tree, &key, NULL);
-    return ((gr_info_t *)(t == NULL ? NULL : *t));
+    return (gr_info_t *)(t == NULL ? NULL : *t);
 } /* end Get_grfile() */
 
 /*--------------------------------------------------------------------------
@@ -427,13 +427,13 @@ New_grfile(HFILEID f)
 
     /* Allocate the gr_info_t structure */
     if (NULL == (g = (gr_info_t *)calloc(1, sizeof(gr_info_t))))
-        return (NULL);
+        return NULL;
 
     /* Assign the file ID & insert into the tree */
     g->hdf_file_id = f;
     tbbtdins(gr_tree, g, NULL); /* insert the vg instance in B-tree */
 
-    return (g);
+    return g;
 } /* end New_grfile() */
 
 /* -------------------------- Store_imginfo ------------------------ */
@@ -3968,7 +3968,7 @@ GRsetup_szip_parms(ri_info_t *ri_ptr, comp_info *c_info, int32 *cdims)
     ret_value = HCPsetup_szip_parms(c_info, nt, ncomp, ndims, xdims, cdims);
 
 done:
-    return (ret_value);
+    return ret_value;
 }
 #endif
 
@@ -4845,7 +4845,7 @@ GRIstart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end GRIstart() */
 
 /*--------------------------------------------------------------------------
@@ -4982,7 +4982,7 @@ GRPshutdown(void)
 
         gr_tree = NULL;
     } /* end if */
-    return (SUCCEED);
+    return SUCCEED;
 } /* end GRPshutdown() */
 
 /*====================== Chunking Routines ================================*/

--- a/hdf/src/mfgrf.c
+++ b/hdf/src/mfgrf.c
@@ -74,7 +74,7 @@
 FRETVAL(intf)
 nmgstart(intf *fid)
 {
-    return ((intf)GRstart((int32)*fid));
+    return (intf)GRstart((int32)*fid);
 } /* end mgstart() */
 
 /*-----------------------------------------------------------------------------
@@ -97,7 +97,7 @@ nmgfinfo(intf *grid, intf *n_datasets, intf *n_attrs)
     ret         = (intf)GRfileinfo((int32)*grid, &n_data, &n_attr);
     *n_datasets = (intf)n_data;
     *n_attrs    = (intf)n_attr;
-    return (ret);
+    return ret;
 } /* end mgfinfo() */
 
 /*-----------------------------------------------------------------------------
@@ -112,7 +112,7 @@ nmgfinfo(intf *grid, intf *n_datasets, intf *n_attrs)
 FRETVAL(intf)
 nmgend(intf *grid)
 {
-    return ((intf)GRend((int32)*grid));
+    return (intf)GRend((int32)*grid);
 } /* end mgend() */
 
 /*-----------------------------------------------------------------------------
@@ -149,7 +149,7 @@ nmgicreat(intf *grid, _fcd name, intf *ncomp, intf *nt, intf *il, intf dimsizes[
     ret         = (intf)GRcreate((int32)*grid, fn, (int32)*ncomp, (int32)*nt, (int32)*il, cdims);
     free(fn);
 
-    return (ret);
+    return ret;
 } /* end mgicreat() */
 
 /*-----------------------------------------------------------------------------
@@ -166,7 +166,7 @@ nmgicreat(intf *grid, _fcd name, intf *ncomp, intf *nt, intf *il, intf dimsizes[
 FRETVAL(intf)
 nmgselct(intf *grid, intf *index)
 {
-    return ((intf)GRselect((int32)*grid, (int32)*index));
+    return (intf)GRselect((int32)*grid, (int32)*index);
 } /* end mgselct() */
 
 /*-----------------------------------------------------------------------------
@@ -196,7 +196,7 @@ nmgin2ndx(intf *grid, _fcd name, intf *nlen)
     ret = (intf)GRnametoindex((int32)*grid, fn);
     free(fn);
 
-    return (ret);
+    return ret;
 } /* end mgin2ndx() */
 
 /*-----------------------------------------------------------------------------
@@ -231,7 +231,7 @@ nmggiinf(intf *riid, _fcd name, intf *ncomp, intf *nt, intf *il, intf *dimsizes,
     dimsizes[YDIM] = t_dimsizes[YDIM];
     *nattr         = (intf)t_nattr;
 
-    return (ret);
+    return ret;
 } /* end mggiinf() */
 
 /*-----------------------------------------------------------------------------
@@ -251,7 +251,7 @@ nmggiinf(intf *riid, _fcd name, intf *ncomp, intf *nt, intf *il, intf *dimsizes,
 FRETVAL(intf)
 nmgwcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data)
 {
-    return (nmgwrimg(riid, start, stride, count, (void *)_fcdtocp(data)));
+    return nmgwrimg(riid, start, stride, count, (void *)_fcdtocp(data));
 } /* end mgwcimg() */
 
 /*-----------------------------------------------------------------------------
@@ -281,7 +281,7 @@ nmgwrimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
     t_count[XDIM]  = (int32)count[XDIM];
     t_count[YDIM]  = (int32)count[YDIM];
 
-    return ((intf)GRwriteimage((int32)*riid, t_start, t_stride, t_count, data));
+    return (intf)GRwriteimage((int32)*riid, t_start, t_stride, t_count, data);
 } /* end mgwrimg() */
 
 /*-----------------------------------------------------------------------------
@@ -301,7 +301,7 @@ nmgwrimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
 FRETVAL(intf)
 nmgrcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data)
 {
-    return (nmgrdimg(riid, start, stride, count, (void *)_fcdtocp(data)));
+    return nmgrdimg(riid, start, stride, count, (void *)_fcdtocp(data));
 } /* end mgrcimg() */
 
 /*-----------------------------------------------------------------------------
@@ -331,7 +331,7 @@ nmgrdimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
     t_count[XDIM]  = (int32)count[XDIM];
     t_count[YDIM]  = (int32)count[YDIM];
 
-    return ((intf)GRreadimage((int32)*riid, t_start, t_stride, t_count, data));
+    return (intf)GRreadimage((int32)*riid, t_start, t_stride, t_count, data);
 } /* end mgrdimg() */
 
 /*-----------------------------------------------------------------------------
@@ -347,7 +347,7 @@ nmgrdimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
 FRETVAL(intf)
 nmgendac(intf *riid)
 {
-    return ((intf)GRendaccess((int32)*riid));
+    return (intf)GRendaccess((int32)*riid);
 } /* end mgendac() */
 
 /*-----------------------------------------------------------------------------
@@ -363,7 +363,7 @@ nmgendac(intf *riid)
 FRETVAL(intf)
 nmgid2rf(intf *riid)
 {
-    return ((intf)GRidtoref((int32)*riid));
+    return (intf)GRidtoref((int32)*riid);
 } /* end mgid2rf() */
 
 /*-----------------------------------------------------------------------------
@@ -380,7 +380,7 @@ nmgid2rf(intf *riid)
 FRETVAL(intf)
 nmgr2idx(intf *grid, intf *ref)
 {
-    return ((intf)GRreftoindex((int32)*grid, (uint16)*ref));
+    return (intf)GRreftoindex((int32)*grid, (uint16)*ref);
 } /* end mgr2idx() */
 
 /*-----------------------------------------------------------------------------
@@ -397,7 +397,7 @@ nmgr2idx(intf *grid, intf *ref)
 FRETVAL(intf)
 nmgrltil(intf *riid, intf *il)
 {
-    return ((intf)GRreqlutil((int32)*riid, (intn)*il));
+    return (intf)GRreqlutil((int32)*riid, (intn)*il);
 } /* end mgrltil() */
 
 /*-----------------------------------------------------------------------------
@@ -414,7 +414,7 @@ nmgrltil(intf *riid, intf *il)
 FRETVAL(intf)
 nmgrimil(intf *riid, intf *il)
 {
-    return ((intf)GRreqimageil((int32)*riid, (intn)*il));
+    return (intf)GRreqimageil((int32)*riid, (intn)*il);
 } /* end mgrimil() */
 
 /*-----------------------------------------------------------------------------
@@ -431,7 +431,7 @@ nmgrimil(intf *riid, intf *il)
 FRETVAL(intf)
 nmggltid(intf *riid, intf *lut_index)
 {
-    return ((intf)GRgetlutid((int32)*riid, (intn)*lut_index));
+    return (intf)GRgetlutid((int32)*riid, (intn)*lut_index);
 } /* end mggltid() */
 
 /*-----------------------------------------------------------------------------
@@ -459,7 +459,7 @@ nmgglinf(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries)
     *nt       = (intf)t_nt;
     *il       = (intf)t_il;
     *nentries = (intf)t_nentries;
-    return (status);
+    return status;
 } /* end mgglinf() */
 
 /*-----------------------------------------------------------------------------
@@ -480,8 +480,8 @@ nmgglinf(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries)
 FRETVAL(intf)
 nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data)
 {
-    return ((intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries,
-                             (void *)_fcdtocp(data)));
+    return (intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries,
+                             (void *)_fcdtocp(data));
 } /* end mgwrlut() */
 
 /*-----------------------------------------------------------------------------
@@ -502,7 +502,7 @@ nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data
 FRETVAL(intf)
 nmgwrlut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, void *data)
 {
-    return ((intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries, data));
+    return (intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries, data);
 } /* end mgwrlut() */
 
 /*-----------------------------------------------------------------------------
@@ -519,7 +519,7 @@ nmgwrlut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, void *dat
 FRETVAL(intf)
 nmgrclut(intf *lutid, _fcd data)
 {
-    return ((intf)GRreadlut((int32)*lutid, (void *)_fcdtocp(data)));
+    return (intf)GRreadlut((int32)*lutid, (void *)_fcdtocp(data));
 } /* end mgrclut() */
 
 /*-----------------------------------------------------------------------------
@@ -536,7 +536,7 @@ nmgrclut(intf *lutid, _fcd data)
 FRETVAL(intf)
 nmgrdlut(intf *lutid, void *data)
 {
-    return ((intf)GRreadlut((int32)*lutid, data));
+    return (intf)GRreadlut((int32)*lutid, data);
 } /* end mgrdlut() */
 
 /*-----------------------------------------------------------------------------
@@ -566,7 +566,7 @@ nmgisxfil(intf *riid, _fcd filename, intf *offset, intf *nlen)
     ret = (intf)GRsetexternalfile((int32)*riid, fn, (int32)*offset);
     free(fn);
 
-    return (ret);
+    return ret;
 } /* end mgisxfil() */
 
 /*-----------------------------------------------------------------------------
@@ -583,7 +583,7 @@ nmgisxfil(intf *riid, _fcd filename, intf *offset, intf *nlen)
 FRETVAL(intf)
 nmgsactp(intf *riid, intf *accesstype)
 {
-    return ((intf)GRsetaccesstype((int32)*riid, (uintn)*accesstype));
+    return (intf)GRsetaccesstype((int32)*riid, (uintn)*accesstype);
 } /* end mgsactp() */
 
 /*-----------------------------------------------------------------------------
@@ -603,7 +603,7 @@ nmgsactp(intf *riid, intf *accesstype)
 FRETVAL(intf)
 nmgiscatt(intf *riid, _fcd name, intf *nt, intf *count, _fcd data, intf *nlen)
 {
-    return (nmgisattr(riid, name, nt, count, (void *)_fcdtocp(data), nlen));
+    return nmgisattr(riid, name, nt, count, (void *)_fcdtocp(data), nlen);
 } /* end mgiscatt() */
 /*-----------------------------------------------------------------------------
  * Name:    mgisattr
@@ -634,7 +634,7 @@ nmgisattr(intf *riid, _fcd name, intf *nt, intf *count, void *data, intf *nlen)
     ret = (intf)GRsetattr((int32)*riid, fn, (int32)*nt, (int32)*count, data);
     free(fn);
 
-    return (ret);
+    return ret;
 } /* end mgisattr() */
 
 /*-----------------------------------------------------------------------------
@@ -661,7 +661,7 @@ nmgatinf(intf *riid, intf *index, _fcd name, intf *nt, intf *count)
     *nt    = (intf)t_nt;
     *count = (intf)t_count;
 
-    return (ret);
+    return ret;
 } /* end mgatinf() */
 
 /*-----------------------------------------------------------------------------
@@ -679,7 +679,7 @@ nmgatinf(intf *riid, intf *index, _fcd name, intf *nt, intf *count)
 FRETVAL(intf)
 nmggcatt(intf *riid, intf *index, _fcd data)
 {
-    return (nmggnatt(riid, index, (void *)_fcdtocp(data)));
+    return nmggnatt(riid, index, (void *)_fcdtocp(data));
 } /* end mggcatt() */
 
 /*-----------------------------------------------------------------------------
@@ -697,7 +697,7 @@ nmggcatt(intf *riid, intf *index, _fcd data)
 FRETVAL(intf)
 nmggnatt(intf *riid, intf *index, void *data)
 {
-    return ((intf)GRgetattr((int32)*riid, (int32)*index, data));
+    return (intf)GRgetattr((int32)*riid, (int32)*index, data);
 } /* end mggnatt() */
 
 /*-----------------------------------------------------------------------------
@@ -716,7 +716,7 @@ nmggnatt(intf *riid, intf *index, void *data)
 FRETVAL(intf)
 nmggattr(intf *riid, intf *index, void *data)
 {
-    return ((intf)GRgetattr((int32)*riid, (int32)*index, data));
+    return (intf)GRgetattr((int32)*riid, (int32)*index, data);
 } /* end mggattr() */
 
 /*-----------------------------------------------------------------------------
@@ -745,7 +745,7 @@ nmgifndat(intf *riid, _fcd name, intf *nlen)
     ret = (intf)GRfindattr((int32)*riid, fn);
     free(fn);
 
-    return (ret);
+    return ret;
 } /* end mgifndat() */
 
 /*-------------------------------------------------------------------------
@@ -785,7 +785,7 @@ nmgcgichnk(intf *id, intf *dim_length, intf *flags)
 
             *flags = -1;
             ret    = 0;
-            return (ret);
+            return ret;
 
         case HDF_CHUNK: /* Chunked, noncompressed GR */
 
@@ -793,7 +793,7 @@ nmgcgichnk(intf *id, intf *dim_length, intf *flags)
             for (i = 0; i < rank; i++)
                 dim_length[rank - i - 1] = chunk_def.chunk_lengths[i];
             ret = 0;
-            return (ret);
+            return ret;
 
         case (HDF_CHUNK | HDF_COMP): /* Chunked and compressed GR */
 
@@ -801,7 +801,7 @@ nmgcgichnk(intf *id, intf *dim_length, intf *flags)
             for (i = 0; i < rank; i++)
                 dim_length[rank - i - 1] = chunk_def.comp.chunk_lengths[i];
             ret = 0;
-            return (ret);
+            return ret;
 
         default:
 
@@ -825,7 +825,7 @@ nmgcrcchnk(intf *id, intf *start, _fcd char_data)
 
     ret = nmgcrchnk(id, start, (void *)_fcdtocp(char_data));
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -867,7 +867,7 @@ nmgcrchnk(intf *id, intf *start, void *num_data)
     /* Free memory */
 
     free(cstart);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -887,7 +887,7 @@ nmgcscchnk(intf *id, intf *maxcache, intf *flags)
 
     ret = GRsetchunkcache(*id, *maxcache, *flags);
 
-    return (ret);
+    return ret;
 }
 
 /*-------------------------------------------------------------------------
@@ -980,7 +980,7 @@ nmgcschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm)
 
     ret = GRsetchunk(riid, chunk_def, cflags);
 
-    return (ret);
+    return ret;
 }
 /*-----------------------------------------------------------------------------
  * Name:     mgcwcchnk
@@ -999,7 +999,7 @@ nmgcwcchnk(intf *id, intf *start, _fcd char_data)
 
     ret = nmgcwchnk(id, start, (void *)_fcdtocp(char_data));
 
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -1042,7 +1042,7 @@ nmgcwchnk(intf *id, intf *start, void *num_data)
 
     free(cstart);
 
-    return (ret);
+    return ret;
 }
 /*-------------------------------------------------------------------------
  * Name:    mgcscompress
@@ -1107,7 +1107,7 @@ nmgcscompress(intf *id, intf *comp_type, intf *comp_prm)
     }
 
     ret = GRsetcompress(riid, c_type, &c_info);
-    return (ret);
+    return ret;
 }
 /*-------------------------------------------------------------------------
  * Name:    mgcgcompress
@@ -1175,7 +1175,7 @@ nmgcgcompress(intf *id, intf *comp_type, intf *comp_prm)
 
         } /*end CASE */
     }     /*end if */
-    return (ret);
+    return ret;
 }
 /*-------------------------------------------------------------------------
  * Name:    mglt2rf
@@ -1191,7 +1191,7 @@ nmglt2rf(intf *id)
     intf ret;
 
     ret = GRluttoref(*id);
-    return (ret);
+    return ret;
 }
 /*-------------------------------------------------------------------------
  * Name:    mgcgnluts
@@ -1209,5 +1209,5 @@ nmgcgnluts(intf *id)
     c_ret = GRgetnluts(*id);
     if (c_ret >= 0)
         ret = c_ret;
-    return (ret);
+    return ret;
 }

--- a/hdf/src/mfgrf.c
+++ b/hdf/src/mfgrf.c
@@ -481,7 +481,7 @@ FRETVAL(intf)
 nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data)
 {
     return (intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries,
-                             (void *)_fcdtocp(data));
+                            (void *)_fcdtocp(data));
 } /* end mgwrlut() */
 
 /*-----------------------------------------------------------------------------

--- a/hdf/src/mstdio.c
+++ b/hdf/src/mstdio.c
@@ -94,7 +94,7 @@ HCPmstdio_stread(accrec_t *access_rec)
 
     if ((*(info->cinfo.coder_funcs.stread))(access_rec) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPmstdio_stread() */
 
 /*--------------------------------------------------------------------------
@@ -129,7 +129,7 @@ HCPmstdio_stwrite(accrec_t *access_rec)
 
     if ((*(info->cinfo.coder_funcs.stwrite))(access_rec) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
-    return (SUCCEED);
+    return SUCCEED;
 } /* HCPmstdio_stwrite() */
 
 /*--------------------------------------------------------------------------
@@ -169,7 +169,7 @@ HCPmstdio_seek(accrec_t *access_rec, int32 offset, int origin)
 
     if ((ret = (*(info->cinfo.coder_funcs.seek))(access_rec, offset, origin)) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
-    return (ret);
+    return ret;
 } /* HCPmstdio_seek() */
 
 /*--------------------------------------------------------------------------
@@ -207,7 +207,7 @@ HCPmstdio_read(accrec_t *access_rec, int32 length, void *data)
 
     if ((ret = (*(info->cinfo.coder_funcs.read))(access_rec, length, data)) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
-    return (ret);
+    return ret;
 } /* HCPmstdio_read() */
 
 /*--------------------------------------------------------------------------
@@ -245,7 +245,7 @@ HCPmstdio_write(accrec_t *access_rec, int32 length, const void *data)
     if ((ret = (*(info->cinfo.coder_funcs.write))(access_rec, length, data)) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
 
-    return (ret);
+    return ret;
 } /* HCPmstdio_write() */
 
 /*--------------------------------------------------------------------------
@@ -288,7 +288,7 @@ HCPmstdio_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *p
     if ((ret = (*(info->cinfo.coder_funcs.inquire))(access_rec, pfile_id, ptag, pref, plength, poffset, pposn,
                                                     paccess, pspecial)) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
-    return (ret);
+    return ret;
 } /* HCPmstdio_inquire() */
 
 /*--------------------------------------------------------------------------
@@ -319,5 +319,5 @@ HCPmstdio_endaccess(accrec_t *access_rec)
     info = (compinfo_t *)access_rec->special_info;
     if ((ret = (*(info->cinfo.coder_funcs.endaccess))(access_rec)) == FAIL)
         HRETURN_ERROR(DFE_CODER, FAIL);
-    return (ret);
+    return ret;
 } /* HCPmstdio_endaccess() */

--- a/hdf/src/tbbt.c
+++ b/hdf/src/tbbt.c
@@ -40,23 +40,23 @@ static TBBT_NODE *
 tbbt_end(TBBT_NODE *root, intn side)
 {
     if (root == NULL)
-        return (NULL);
+        return NULL;
     while (HasChild(root, side)) {
         root = root->link[side];
     }
-    return (root);
+    return root;
 }
 
 TBBT_NODE *
 tbbtfirst(TBBT_NODE *root)
 {
-    return (tbbt_end(root, LEFT));
+    return tbbt_end(root, LEFT);
 }
 
 TBBT_NODE *
 tbbtlast(TBBT_NODE *root)
 {
-    return (tbbt_end(root, RIGHT));
+    return tbbt_end(root, RIGHT);
 }
 
 /* Return address of parent's pointer to neighboring node (to LEFT or RIGHT) **
@@ -79,28 +79,28 @@ tbbt_nbr(TBBT_NODE *ptr, intn side)
     /* return( *tbbt_anbr(ptr,side) ); */
 
     if (!HasChild(ptr, side))
-        return (ptr->link[side]);
-    /*        return(NULL); */
+        return ptr->link[side];
+    /*        return NULL; */
     ptr = ptr->link[side];
     if (ptr == NULL)
-        return (NULL);
+        return NULL;
     while (HasChild(ptr, Other(side)))
         ptr = ptr->link[Other(side)];
-    return (ptr);
+    return ptr;
 }
 
 /* Returns pointer to node with previous key value: */
 TBBT_NODE *
 tbbtnext(TBBT_NODE *node)
 {
-    return (tbbt_nbr(node, RIGHT));
+    return tbbt_nbr(node, RIGHT);
 }
 
 /* Returns pointer to node with next key value: */
 TBBT_NODE *
 tbbtprev(TBBT_NODE *node)
 {
-    return (tbbt_nbr(node, LEFT));
+    return tbbt_nbr(node, LEFT);
 }
 
 /* tbbtfind -- Look up a node in a tree based on a key value */
@@ -126,7 +126,7 @@ tbbtfind(TBBT_NODE *root, void *key, intn (*compar)(void *, void *, intn), intn 
     }
     if (NULL != pp)
         *pp = parent;
-    return ((0 == cmp) ? ptr : NULL);
+    return (0 == cmp) ? ptr : NULL;
 }
 
 /* tbbtffind -- Look up a node in a tree based on a key value */
@@ -154,7 +154,7 @@ tbbtffind(TBBT_NODE *root, void *key, uintn fast_compare, TBBT_NODE **pp)
             }
             if (NULL != pp)
                 *pp = parent;
-            return ((0 == cmp) ? ptr : NULL);
+            return (0 == cmp) ? ptr : NULL;
 
         case TBBT_FAST_INT32_COMPARE:
             if (ptr) {
@@ -170,10 +170,10 @@ tbbtffind(TBBT_NODE *root, void *key, uintn fast_compare, TBBT_NODE **pp)
             }
             if (NULL != pp)
                 *pp = parent;
-            return ((0 == cmp) ? ptr : NULL);
+            return (0 == cmp) ? ptr : NULL;
 
         default:
-            return (NULL);
+            return NULL;
     } /* end switch */
 } /* tbbtffind() */
 
@@ -183,11 +183,11 @@ TBBT_NODE *
 tbbtdfind(TBBT_TREE *tree, void *key, TBBT_NODE **pp)
 {
     if (tree == NULL)
-        return (NULL);
+        return NULL;
     if (tree->fast_compare != 0)
-        return (tbbtffind(tree->root, key, tree->fast_compare, pp));
+        return tbbtffind(tree->root, key, tree->fast_compare, pp);
     else
-        return (tbbtfind(tree->root, key, tree->compar, tree->cmparg, pp));
+        return tbbtfind(tree->root, key, tree->compar, tree->cmparg, pp);
 }
 
 /* tbbtless -- Find a node in a tree which is less than a key, */
@@ -227,7 +227,7 @@ tbbtless(TBBT_NODE *root, void *key, intn (*compar)(void *, void *, intn), intn 
     } /* end if */
     if (NULL != pp)
         *pp = parent;
-    return ((0 == cmp) ? ptr : NULL);
+    return (0 == cmp) ? ptr : NULL;
 }
 
 /* tbbtdless -- Find a node less than a key in a "described" tree */
@@ -236,8 +236,8 @@ TBBT_NODE *
 tbbtdless(TBBT_TREE *tree, void *key, TBBT_NODE **pp)
 {
     if (tree == NULL)
-        return (NULL);
-    return (tbbtless(tree->root, key, tree->compar, tree->cmparg, pp));
+        return NULL;
+    return tbbtless(tree->root, key, tree->compar, tree->cmparg, pp);
 }
 
 /* tbbtindx -- Look up the Nth node (in key order) */
@@ -254,7 +254,7 @@ tbbtindx(TBBT_NODE *root, int32 indx)
 
     /* I believe indx is 1 based */
     if (NULL == ptr || indx < 1)
-        return (NULL);
+        return NULL;
     /* Termination condition is if the index equals the number of children on
        out left plus the current node */
     while (ptr != NULL && indx != ((int32)LeftCnt(ptr)) + 1) {
@@ -267,9 +267,9 @@ tbbtindx(TBBT_NODE *root, int32 indx)
             ptr = ptr->Rchild;
         }
         else
-            return (NULL); /* Only `indx' or fewer nodes in tree */
+            return NULL; /* Only `indx' or fewer nodes in tree */
     }
-    return (ptr);
+    return ptr;
 }
 
 /* swapkid -- Often referred to as "rotating" nodes.  ptr and ptr's `side'
@@ -342,7 +342,7 @@ swapkid(TBBT_NODE **root, TBBT_NODE *ptr, intn side)
         ptr->rcnt = klcnt;
     } /* end if */
     ptr->flags = ptrflg;
-    return (kid);
+    return kid;
 }
 
 /* balance -- Move up tree, incrimenting number of left children when needed
@@ -481,7 +481,7 @@ tbbtins(TBBT_NODE **root, void *item, void *key,
     TBBT_NODE *ptr, *parent;
 
     if (NULL != tbbtfind(*root, (key ? key : item), compar, arg, &parent) || NULL == (ptr = tbbt_get_node()))
-        return (NULL);
+        return NULL;
     ptr->data   = item;
     ptr->key    = key ? key : item;
     ptr->Parent = parent;
@@ -491,7 +491,7 @@ tbbtins(TBBT_NODE **root, void *item, void *key,
     if (NULL == parent) { /* Adding first node to tree: */
         *root       = ptr;
         ptr->Lchild = ptr->Rchild = NULL;
-        return (ptr);
+        return ptr;
     }
     cmp = KEYcmp(ptr->key, parent->key, arg);
     if (cmp < 0) {
@@ -505,7 +505,7 @@ tbbtins(TBBT_NODE **root, void *item, void *key,
         parent->Rchild = ptr;
     }
     balance(root, parent, (cmp < 0) ? LEFT : RIGHT, 1);
-    return (ptr);
+    return ptr;
 }
 
 /* tbbtdins -- Insert a node into a "described" tree */
@@ -516,11 +516,11 @@ tbbtdins(TBBT_TREE *tree, void *item, void *key)
     TBBT_NODE *ret_node; /* the node to return */
 
     if (tree == NULL)
-        return (NULL);
+        return NULL;
     ret_node = tbbtins(&(tree->root), item, key, tree->compar, tree->cmparg);
     if (ret_node != NULL)
         tree->count++;
-    return (ret_node);
+    return ret_node;
 }
 
 /* tbbtrem -- Remove a node from a tree.  You pass in the address of the
@@ -544,7 +544,7 @@ tbbtrem(TBBT_NODE **root, TBBT_NODE *node, void **kp)
     void      *data; /* Saved pointer to data item of deleted node */
 
     if (NULL == root || NULL == node)
-        return (NULL); /* Argument couldn't find node to delete */
+        return NULL; /* Argument couldn't find node to delete */
     data = node->data; /* Save pointer to data item to be returned at end */
     if (NULL != kp)
         *kp = node->key;
@@ -586,7 +586,7 @@ tbbtrem(TBBT_NODE **root, TBBT_NODE *node, void **kp)
                 *root = NULL;
             } /* end else */
             tbbt_release_node(node);
-            return (data);
+            return data;
         }
         side = (par->Rchild == leaf) ? RIGHT : LEFT;
         next = leaf->link[side];
@@ -641,7 +641,7 @@ tbbtrem(TBBT_NODE **root, TBBT_NODE *node, void **kp)
     tbbt_release_node(leaf);
     balance(root, par, side, -1);
     ((TBBT_TREE *)root)->count--;
-    return (data);
+    return data;
 }
 
 /* tbbtdmake - Allocate a new tree description record for an empty tree */

--- a/hdf/src/tbbt.c
+++ b/hdf/src/tbbt.c
@@ -544,7 +544,7 @@ tbbtrem(TBBT_NODE **root, TBBT_NODE *node, void **kp)
     void      *data; /* Saved pointer to data item of deleted node */
 
     if (NULL == root || NULL == node)
-        return NULL; /* Argument couldn't find node to delete */
+        return NULL;   /* Argument couldn't find node to delete */
     data = node->data; /* Save pointer to data item to be returned at end */
     if (NULL != kp)
         *kp = node->key;

--- a/hdf/src/vattrf.c
+++ b/hdf/src/vattrf.c
@@ -38,10 +38,10 @@ nvsfcfdx(intf *vsid, _fcd fldnm, intf *findex, intf *fldnmlen)
 
     fld = HDf2cstring(fldnm, (intn)*fldnmlen);
     if (!fld)
-        return (FAIL);
+        return FAIL;
     ret = (intf)VSfindex((int32)*vsid, fld, (int32 *)findex);
     free(fld);
-    return (ret);
+    return ret;
 }
 
 /* -------------------------------------------------
@@ -59,12 +59,12 @@ nvsfcsat(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, intf *
 
     attrname = HDf2cstring(attrnm, (intn)*attrnmlen);
     if (!attrname)
-        return (FAIL);
+        return FAIL;
     cfindex = *findex;
     ret =
         (intf)VSsetattr((int32)*vsid, (int32)cfindex, attrname, (int32)*dtype, (int32)*count, (void *)values);
     free(attrname);
-    return (ret);
+    return ret;
 }
 
 /* ----------------------------------------------------
@@ -82,12 +82,12 @@ nvsfcsca(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, _fcd v
 
     attrname = HDf2cstring(attrnm, (intn)*attrnmlen);
     if (!attrname)
-        return (FAIL);
+        return FAIL;
     cfindex = *findex;
     ret     = (intf)VSsetattr((int32)*vsid, (int32)cfindex, attrname, (int32)*dtype, (int32)*count,
                               (void *)_fcdtocp(values));
     free(attrname);
-    return (ret);
+    return ret;
 }
 
 /* -------------------------------------------------------
@@ -102,7 +102,7 @@ nvsfnats(intf *vsid)
     intf ret;
 
     ret = (intf)VSnattrs((int32)*vsid);
-    return (ret);
+    return ret;
 }
 
 /* -------------------------------------------------------
@@ -119,7 +119,7 @@ nvsffnas(intf *vsid, intf *findex)
 
     cfindex = *findex;
     ret     = (intf)VSfnattrs((int32)*vsid, (int32)cfindex);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -137,12 +137,12 @@ nvsfcfda(intf *vsid, intf *findex, _fcd attrnm, intf *attrnmlen)
 
     attrname = HDf2cstring(attrnm, (intn)*attrnmlen);
     if (!attrname)
-        return (FAIL);
+        return FAIL;
     cfindex = *findex;
 
     ret = (intf)VSfindattr((int32)*vsid, (int32)cfindex, attrname);
     free(attrname);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -176,7 +176,7 @@ nvsfcain(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, int
         HDpackFstring(tattrname, _fcdtocp(attrname), (intn)*attrnamelen);
     }
     free(tattrname);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -192,7 +192,7 @@ nvsfgnat(intf *vsid, intf *findex, intf *aindex, intf *values)
 
     cfindex = *findex;
     ret     = (intf)VSgetattr((int32)*vsid, (int32)cfindex, (int32)*aindex, (void *)values);
-    return (ret);
+    return ret;
 }
 
 /* --------------------------------------------------------
@@ -208,7 +208,7 @@ nvsfgcat(intf *vsid, intf *findex, intf *aindex, _fcd values)
 
     cfindex = *findex;
     ret     = (intf)VSgetattr((int32)*vsid, cfindex, (int32)*aindex, (void *)_fcdtocp(values));
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -221,7 +221,7 @@ nvsfisat(intf *vsid)
 {
     intf ret;
     ret = (intf)VSisattr((int32)*vsid);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -237,10 +237,10 @@ nvfcsatt(intf *vgid, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *
 
     attrname = HDf2cstring(attrnm, (intn)*attrnmlen);
     if (!attrname)
-        return (FAIL);
+        return FAIL;
     ret = (intf)Vsetattr((int32)*vgid, attrname, (int32)*dtype, (int32)*count, (void *)values);
     free(attrname);
-    return (ret);
+    return ret;
 }
 
 /* ----------------------------------------------------
@@ -257,10 +257,10 @@ nvfcscat(intf *vgid, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *a
 
     attrname = HDf2cstring(attrnm, (intn)*attrnmlen);
     if (!attrname)
-        return (FAIL);
+        return FAIL;
     ret = (intf)Vsetattr((int32)*vgid, attrname, (int32)*dtype, (int32)*count, (void *)_fcdtocp(values));
     free(attrname);
-    return (ret);
+    return ret;
 }
 
 /* -------------------------------------------------------
@@ -274,7 +274,7 @@ nvfnatts(intf *vgid)
     intf ret;
 
     ret = (intf)Vnattrs((int32)*vgid);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -290,10 +290,10 @@ nvfcfdat(intf *vgid, _fcd attrnm, intf *attrnmlen)
 
     attrname = HDf2cstring(attrnm, (intn)*attrnmlen);
     if (!attrname)
-        return (FAIL);
+        return FAIL;
     ret = (intf)Vfindattr((int32)*vgid, attrname);
     free(attrname);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -307,7 +307,7 @@ nvfainfo(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf
     intf ret;
     ret = (intf)Vattrinfo((int32)*vgid, (int32)*aindex, _fcdtocp(attrname), (int32 *)dtype, (int32 *)count,
                           (int32 *)size);
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -320,7 +320,7 @@ nvfgnatt(intf *vgid, intf *aindex, intf *values)
 {
     intf ret;
     ret = (intf)Vgetattr((int32)*vgid, *aindex, (void *)values);
-    return (ret);
+    return ret;
 }
 
 /* --------------------------------------------------------
@@ -333,7 +333,7 @@ nvfgcatt(intf *vgid, intf *aindex, _fcd values)
 {
     intf ret;
     ret = (intf)Vgetattr((int32)*vgid, (int32)*aindex, (void *)_fcdtocp(values));
-    return (ret);
+    return ret;
 }
 
 /* ---------------------------------------------------------
@@ -346,5 +346,5 @@ nvfgver(intf *vgid)
 {
     intf ret;
     ret = (intf)Vgetversion((int32)*vgid);
-    return (ret);
+    return ret;
 }

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -144,7 +144,7 @@ vicheckcompat(HFILEID f)
 
     HEclear();         /* clear the stack to remove faux failures - bug #655 */
     if (foundold == 0) /* has no old vset elements */
-        return 1;    /* just assume compatible */
+        return 1;      /* just assume compatible */
 
     if (foundnew > 0)
         return 1; /* file is already compatible */

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -79,10 +79,10 @@ static int16
 VSIZEOF(int16 x)
 {
     if (x < 0 || x > (int16)(LOCALSIZETAB_SIZE - 1)) {
-        return (FAIL);
+        return FAIL;
     }
     else {
-        return (local_sizetab[x]);
+        return local_sizetab[x];
     }
 } /* VSIZEOF */
 
@@ -144,12 +144,12 @@ vicheckcompat(HFILEID f)
 
     HEclear();         /* clear the stack to remove faux failures - bug #655 */
     if (foundold == 0) /* has no old vset elements */
-        return (1);    /* just assume compatible */
+        return 1;    /* just assume compatible */
 
     if (foundnew > 0)
-        return (1); /* file is already compatible */
+        return 1; /* file is already compatible */
     else
-        return (0); /* file is not compatible */
+        return 0; /* file is not compatible */
 } /* vicheckcompat */
 
 /* ------------------------------------------------------------------ */
@@ -280,7 +280,7 @@ vimakecompat(HFILEID f)
     Hendaccess(aid);
     VSIrelease_vdata_node(vs);
 
-    return (1);
+    return 1;
 
 } /* vimakecompat */
 
@@ -311,7 +311,7 @@ vcheckcompat(char *fs)
     ret = vicheckcompat(f);
     Hclose(f);
 
-    return (ret);
+    return ret;
 } /* vcheckcompat */
 
 /* ================================================================== */
@@ -337,7 +337,7 @@ vmakecompat(char *fs)
         HRETURN_ERROR(DFE_BADOPEN, FAIL);
     ret = vimakecompat(f);
     Hclose(f);
-    return (ret);
+    return ret;
 } /* vmakecompat */
 
 /* ==================================================================== */

--- a/hdf/src/vg.c
+++ b/hdf/src/vg.c
@@ -98,14 +98,14 @@ matchnocase(char *strx, /* IN: first string to be compared */
     ny = strlen(stry);
 
     if (nx != ny)
-        return (FALSE); /* different lengths */
+        return FALSE; /* different lengths */
 
     for (i = 0; i < nx; i++, strx++, stry++) {
         if (toupper(*strx) != toupper(*stry))
-            return (FALSE); /* not identical */
+            return FALSE; /* not identical */
     }
 
-    return (TRUE);
+    return TRUE;
 } /* matchnocase */
 #endif /* VDATA_FIELDS_ALL_UPPER */
 

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -1039,7 +1039,7 @@ nvhscdc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _f
     if ((*datatype != DFNT_CHAR) && (*datatype != DFNT_UCHAR))
         return FAIL;
     return nvhsdc(f, field, (uint8 *)_fcdtocp(cbuf), n, datatype, vsname, vsclass, fieldlen, vsnamelen,
-                   vsclasslen);
+                  vsclasslen);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1055,7 +1055,7 @@ nvhscdmc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _
     if ((*datatype != DFNT_CHAR) && (*datatype != DFNT_UCHAR))
         return FAIL;
     return nvhsdmc(f, field, (uint8 *)_fcdtocp(cbuf), n, datatype, vsname, vsclass, order, fieldlen,
-                    vsnamelen, vsclasslen);
+                   vsnamelen, vsclasslen);
 }
 
 /* ------------------------------------------------------------------ */

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -89,10 +89,10 @@ ndfivopn(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 
     fn = HDf2cstring(name, (intn)*namelen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)Vopen(fn, (intn)*acc_mode, (int16)*defdds);
     free(fn);
-    return (ret);
+    return ret;
 } /* end ndfivopn() */
 
 /*-----------------------------------------------------------------------------
@@ -107,7 +107,7 @@ ndfivopn(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 FRETVAL(intf)
 ndfvclos(intf *file_id)
 {
-    return (Vclose((int32)*file_id));
+    return Vclose((int32)*file_id);
 } /* ndfvclos() */
 
 /*
@@ -123,12 +123,12 @@ nvatchc(intf *f, intf *vgid, _fcd accesstype)
 
     acc = HDf2cstring(accesstype, 1);
     if (!acc)
-        return (FAIL);
+        return FAIL;
 
     vkey = Vattach((int32)*f, *vgid, acc);
     free(acc);
 
-    return ((intf)vkey);
+    return (intf)vkey;
 }
 
 /* ------------------------------------------------------------------ */
@@ -141,7 +141,7 @@ nvatchc(intf *f, intf *vgid, _fcd accesstype)
 FRETVAL(intf)
 nvdtchc(intf *vkey)
 {
-    return (Vdetach(*vkey));
+    return Vdetach(*vkey);
 }
 /* ------------------------------------------------------------------ */
 
@@ -153,7 +153,7 @@ nvdtchc(intf *vkey)
 FRETVAL(intf)
 nvgnamc(intf *vkey, _fcd vgname)
 {
-    return (Vgetname(*vkey, _fcdtocp(vgname)));
+    return Vgetname(*vkey, _fcdtocp(vgname));
 } /* VGNAMC */
 
 /* ------------------------------------------------------------------ */
@@ -165,7 +165,7 @@ nvgnamc(intf *vkey, _fcd vgname)
 FRETVAL(intf)
 nvgclsc(intf *vkey, _fcd vgclass)
 {
-    return (Vgetclass(*vkey, _fcdtocp(vgclass)));
+    return Vgetclass(*vkey, _fcdtocp(vgclass));
 } /* VGCLSC */
 
 /* ------------------------------------------------------------------ */
@@ -177,7 +177,7 @@ nvgclsc(intf *vkey, _fcd vgclass)
 FRETVAL(intf)
 nvinqc(intf *vkey, intf *nentries, _fcd vgname)
 {
-    return ((intf)Vinquire(*vkey, (int32 *)nentries, _fcdtocp(vgname)));
+    return (intf)Vinquire(*vkey, (int32 *)nentries, _fcdtocp(vgname));
 } /* VINQC */
 
 /* ------------------------------------------------------------------ */
@@ -189,7 +189,7 @@ nvinqc(intf *vkey, intf *nentries, _fcd vgname)
 FRETVAL(intf)
 nvdelete(intf *f, intf *vkey)
 {
-    return ((intf)Vdelete((int32)*f, (int32)*vkey));
+    return (intf)Vdelete((int32)*f, (int32)*vkey);
 } /* nvdelete */
 
 /* ------------------------------------------------------------------ */
@@ -201,7 +201,7 @@ nvdelete(intf *f, intf *vkey)
 FRETVAL(intf)
 nvgidc(intf *f, intf *vgid)
 {
-    return ((intf)Vgetid((int32)*f, *vgid));
+    return (intf)Vgetid((int32)*f, *vgid);
 }
 
 /* ------------------------------------------------------------------ */
@@ -213,7 +213,7 @@ nvgidc(intf *f, intf *vgid)
 FRETVAL(intf)
 nvgnxtc(intf *vkey, intf *id)
 {
-    return (Vgetnext(*vkey, *id));
+    return Vgetnext(*vkey, *id);
 }
 
 /* ------------------------------------------------------------------ */
@@ -230,12 +230,12 @@ nvsnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
 
     name = HDf2cstring(vgname, (intn)*vgnamelen);
     if (!name)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(name); */
     ret = (intf)Vsetname(*vkey, name);
     free(name);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -252,12 +252,12 @@ nvsclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 
     tclass = HDf2cstring(vgclass, (intn)*vgclasslen);
     if (!tclass)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(tclass); */
     ret = (intf)Vsetclass(*vkey, tclass);
     free(tclass);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -269,7 +269,7 @@ nvsclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 FRETVAL(intf)
 nvinsrtc(intf *vkey, intf *vobjptr)
 {
-    return ((intf)Vinsert(*vkey, *vobjptr));
+    return (intf)Vinsert(*vkey, *vobjptr);
 }
 
 /* ------------------------------------------------------------------ */
@@ -281,7 +281,7 @@ nvinsrtc(intf *vkey, intf *vobjptr)
 FRETVAL(intf)
 nvisvgc(intf *vkey, intf *id)
 {
-    return ((intf)Visvg(*vkey, *id));
+    return (intf)Visvg(*vkey, *id);
 }
 
 /* ------------------------------------------------------------------ */
@@ -292,7 +292,7 @@ nvisvgc(intf *vkey, intf *id)
 FRETVAL(intf)
 nvfstart(intf *f)
 {
-    return (Vstart((int32)*f));
+    return Vstart((int32)*f);
 } /* nvfstart */
 
 /* ------------------------------------------------------------------ */
@@ -303,7 +303,7 @@ nvfstart(intf *f)
 FRETVAL(intf)
 nvfend(intf *f)
 {
-    return ((intf)Vend((int32)*f));
+    return (intf)Vend((int32)*f);
 } /* nvfend */
 
 /* ------------------------------------------------------------------ */
@@ -315,7 +315,7 @@ nvfend(intf *f)
 FRETVAL(intf)
 nvisvsc(intf *vkey, intf *id)
 {
-    return ((intf)Visvs(*vkey, *id));
+    return (intf)Visvs(*vkey, *id);
 }
 
 /* ================================================== */
@@ -331,7 +331,7 @@ FRETVAL(intf)
 nvsatchc(intf *f, intf *vsid, _fcd accesstype)
 {
     /* need not HDf2cstring since only first char is accessed. */
-    return (VSattach((int32)*f, *vsid, _fcdtocp(accesstype)));
+    return VSattach((int32)*f, *vsid, _fcdtocp(accesstype));
 }
 
 /* ------------------------------------------------------------------ */
@@ -343,7 +343,7 @@ nvsatchc(intf *f, intf *vsid, _fcd accesstype)
 FRETVAL(intf)
 nvsdtchc(intf *vkey)
 {
-    return (VSdetach(*vkey));
+    return VSdetach(*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -355,7 +355,7 @@ nvsdtchc(intf *vkey)
 FRETVAL(intf)
 nvsqref(intf *vkey)
 {
-    return ((intf)VSQueryref((int32)*vkey));
+    return (intf)VSQueryref((int32)*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -367,7 +367,7 @@ nvsqref(intf *vkey)
 FRETVAL(intf)
 nvsqtag(intf *vkey)
 {
-    return ((intf)VSQuerytag((int32)*vkey));
+    return (intf)VSQuerytag((int32)*vkey);
 }
 
 /* ----------------------------------------------------------------- */
@@ -379,7 +379,7 @@ nvsqtag(intf *vkey)
 FRETVAL(intf)
 nvsgver(intf *vkey)
 {
-    return ((intf)VSgetversion((int32)*vkey));
+    return (intf)VSgetversion((int32)*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -391,7 +391,7 @@ nvsgver(intf *vkey)
 FRETVAL(intf)
 nvsseekc(intf *vkey, intf *eltpos)
 {
-    return ((intf)VSseek(*vkey, *eltpos));
+    return (intf)VSseek(*vkey, *eltpos);
 }
 
 /* ------------------------------------------------------------------ */
@@ -417,7 +417,7 @@ nvsgnamc(intf *vkey, _fcd vsname, intf *vsnamelen)
     HDpackFstring(tvsname, _fcdtocp(vsname), (intn)*vsnamelen);
     free(tvsname);
 
-    return (status);
+    return status;
 } /* VSGNAMC */
 
 /* ------------------------------------------------------------------ */
@@ -443,7 +443,7 @@ nvsgclsc(intf *vkey, _fcd vsclass, intf *vsclasslen)
     HDpackFstring(tvsclass, _fcdtocp(vsclass), (intn)*vsclasslen);
     free(tvsclass);
 
-    return (status);
+    return status;
 } /* VSGCLSC */
 
 /* ------------------------------------------------------------------ */
@@ -502,12 +502,12 @@ nvsfexc(intf *vkey, _fcd fields, intf *fieldslen)
 
     flds = HDf2cstring(fields, (intn)*fieldslen);
     if (!flds)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(flds); */
     ret = (int32)VSfexist(*vkey, flds);
     free(flds);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -524,12 +524,12 @@ nvsfndc(intf *f, _fcd name, intf *namelen)
 
     cname = HDf2cstring(name, (intn)*namelen);
     if (!cname)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(flds); */
     ret = (intf)VSfind(*f, cname);
     free(cname);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -541,7 +541,7 @@ nvsfndc(intf *f, _fcd name, intf *namelen)
 FRETVAL(intf)
 nvsgidc(intf *f, intf *vsid)
 {
-    return ((intf)VSgetid(*f, *vsid));
+    return (intf)VSgetid(*f, *vsid);
 }
 
 /* ------------------------------------------------------------------ */
@@ -553,7 +553,7 @@ nvsgidc(intf *f, intf *vsid)
 FRETVAL(intf)
 nvsdltc(intf *f, intf *vsid)
 {
-    return ((intf)VSdelete(*f, *vsid));
+    return (intf)VSdelete(*f, *vsid);
 }
 
 /* ------------------------------------------------------------------ */
@@ -565,7 +565,7 @@ nvsdltc(intf *f, intf *vsid)
 FRETVAL(intf)
 nvsapp(intf *vkey, intf *blk)
 {
-    return ((intf)VSappendable((int32)*vkey, (int32)*blk));
+    return (intf)VSappendable((int32)*vkey, (int32)*blk);
 }
 
 /* ------------------------------------------------------------------ */
@@ -582,12 +582,12 @@ nvssnamc(intf *vkey, _fcd vsname, intf *vsnamelen)
 
     name = HDf2cstring(vsname, (intn)*vsnamelen);
     if (!name)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks (name); */
     ret = (intf)VSsetname(*vkey, name);
     free(name);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -604,12 +604,12 @@ nvssclsc(intf *vkey, _fcd vsclass, intf *vsclasslen)
 
     tclass = HDf2cstring(vsclass, (intn)*vsclasslen);
     if (!tclass)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(tclass); */
     ret = (intf)VSsetclass(*vkey, tclass);
     free(tclass);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -626,12 +626,12 @@ nvssfldc(intf *vkey, _fcd fields, intf *fieldslen)
 
     flds = HDf2cstring(fields, (intn)*fieldslen);
     if (!flds)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(flds); */
     ret = (int32)VSsetfields(*vkey, flds);
     free(flds);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -643,7 +643,7 @@ nvssfldc(intf *vkey, _fcd fields, intf *fieldslen)
 FRETVAL(intf)
 nvssintc(intf *vkey, intf *interlace)
 {
-    return ((intf)VSsetinterlace(*vkey, *interlace));
+    return (intf)VSsetinterlace(*vkey, *interlace);
 }
 
 /* ------------------------------------------------------------------ */
@@ -660,11 +660,11 @@ nvsfdefc(intf *vkey, _fcd field, intf *localtype, intf *order, intf *fieldlen)
 
     fld = HDf2cstring(field, (intn)*fieldlen);
     if (!fld)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(fld); */
     ret = (int32)VSfdefine(*vkey, fld, *localtype, *order);
     free(fld);
-    return (ret);
+    return ret;
 }
 
 /*-----------------------------------------------------------------------------
@@ -686,10 +686,10 @@ nvssextfc(intf *id, _fcd name, intf *offset, intf *namelen)
 
     fn = HDf2cstring(name, *namelen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)VSsetexternalfile(*id, fn, *offset);
     free((void *)fn);
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -701,7 +701,7 @@ nvssextfc(intf *id, _fcd name, intf *offset, intf *namelen)
 FRETVAL(intf)
 nvfnflds(intf *vkey)
 {
-    return ((intf)VFnfields((int32)*vkey));
+    return (intf)VFnfields((int32)*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -719,10 +719,10 @@ nvffnamec(intf *vkey, intf *index, _fcd fname, intf *len)
         /* strcpy(_fcdtocp(fname),fieldname);*/
         HDpackFstring(fieldname, _fcdtocp(fname), (intn)*len);
         /* free(fieldname); */
-        return (SUCCEED);
+        return SUCCEED;
     }
     else
-        return (FAIL);
+        return FAIL;
 } /* vffnamec */
 
 /* ------------------------------------------------------------------ */
@@ -734,7 +734,7 @@ nvffnamec(intf *vkey, intf *index, _fcd fname, intf *len)
 FRETVAL(intf)
 nvfftype(intf *vkey, intf *index)
 {
-    return ((intf)VFfieldtype((int32)*vkey, (int32)*index));
+    return (intf)VFfieldtype((int32)*vkey, (int32)*index);
 } /* vfftype */
 
 /* ------------------------------------------------------------------ */
@@ -746,7 +746,7 @@ nvfftype(intf *vkey, intf *index)
 FRETVAL(intf)
 nvffisiz(intf *vkey, intf *index)
 {
-    return ((intf)VFfieldisize((int32)*vkey, (int32)*index));
+    return (intf)VFfieldisize((int32)*vkey, (int32)*index);
 } /* vffisiz */
 
 /* ------------------------------------------------------------------ */
@@ -758,7 +758,7 @@ nvffisiz(intf *vkey, intf *index)
 FRETVAL(intf)
 nvffesiz(intf *vkey, intf *index)
 {
-    return ((intf)VFfieldesize((int32)*vkey, (int32)*index));
+    return (intf)VFfieldesize((int32)*vkey, (int32)*index);
 } /* vffesiz */
 
 /* ------------------------------------------------------------------ */
@@ -770,7 +770,7 @@ nvffesiz(intf *vkey, intf *index)
 FRETVAL(intf)
 nvffordr(intf *vkey, intf *index)
 {
-    return ((intf)VFfieldorder((int32)*vkey, (int32)*index));
+    return (intf)VFfieldorder((int32)*vkey, (int32)*index);
 } /* vffordr */
 
 /* ------------------------------------------------------------------ */
@@ -782,7 +782,7 @@ nvffordr(intf *vkey, intf *index)
 FRETVAL(intf)
 nvsfrdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
 {
-    return ((intf)VSread(*vkey, (uint8 *)_fcdtocp(cbuf), *nelt, *interlace));
+    return (intf)VSread(*vkey, (uint8 *)_fcdtocp(cbuf), *nelt, *interlace);
 }
 /* ------------------------------------------------------------------ */
 /*
@@ -793,7 +793,7 @@ nvsfrdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
 FRETVAL(intf)
 nvsfrd(intf *vkey, intf *buf, intf *nelt, intf *interlace)
 {
-    return ((intf)VSread(*vkey, (uint8 *)buf, *nelt, *interlace));
+    return (intf)VSread(*vkey, (uint8 *)buf, *nelt, *interlace);
 }
 
 /* ------------------------------------------------------------------ */
@@ -805,7 +805,7 @@ nvsfrd(intf *vkey, intf *buf, intf *nelt, intf *interlace)
 FRETVAL(intf)
 nvsreadc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
 {
-    return ((intf)VSread(*vkey, buf, *nelt, *interlace));
+    return (intf)VSread(*vkey, buf, *nelt, *interlace);
 }
 
 /* ------------------------------------------------------------------ */
@@ -817,7 +817,7 @@ nvsreadc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
 FRETVAL(intf)
 nvsfwrtc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
 {
-    return ((intf)VSwrite(*vkey, (uint8 *)_fcdtocp(cbuf), *nelt, *interlace));
+    return (intf)VSwrite(*vkey, (uint8 *)_fcdtocp(cbuf), *nelt, *interlace);
 }
 
 /* ------------------------------------------------------------------ */
@@ -829,7 +829,7 @@ nvsfwrtc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
 FRETVAL(intf)
 nvsfwrt(intf *vkey, intf *buf, intf *nelt, intf *interlace)
 {
-    return ((intf)VSwrite(*vkey, (uint8 *)buf, *nelt, *interlace));
+    return (intf)VSwrite(*vkey, (uint8 *)buf, *nelt, *interlace);
 }
 
 /* ------------------------------------------------------------------ */
@@ -841,7 +841,7 @@ nvsfwrt(intf *vkey, intf *buf, intf *nelt, intf *interlace)
 FRETVAL(intf)
 nvswritc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
 {
-    return ((intf)VSwrite(*vkey, buf, *nelt, *interlace));
+    return (intf)VSwrite(*vkey, buf, *nelt, *interlace);
 }
 
 /* ======================================== */
@@ -858,7 +858,7 @@ nvswritc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
 FRETVAL(intf)
 nvsgintc(intf *vkey)
 {
-    return ((intf)VSgetinterlace(*vkey));
+    return (intf)VSgetinterlace(*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -870,7 +870,7 @@ nvsgintc(intf *vkey)
 FRETVAL(intf)
 nvseltsc(intf *vkey)
 {
-    return ((intf)VSelts(*vkey));
+    return (intf)VSelts(*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -882,7 +882,7 @@ nvseltsc(intf *vkey)
 FRETVAL(intf)
 nvsgfldc(intf *vkey, _fcd fields)
 {
-    return ((intf)VSgetfields(*vkey, _fcdtocp(fields)));
+    return (intf)VSgetfields(*vkey, _fcdtocp(fields));
 } /* VSGFLDC */
 
 /* ------------------------------------------------------------------ */
@@ -899,11 +899,11 @@ nvssizc(intf *vkey, _fcd fields, intf *fieldslen)
 
     flds = HDf2cstring(fields, (intn)*fieldslen);
     if (!flds)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(flds); */
     ret = VSsizeof(*vkey, flds);
     free(flds);
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -915,7 +915,7 @@ nvssizc(intf *vkey, _fcd fields, intf *fieldslen)
 FRETVAL(intf)
 nventsc(intf *f, intf *vgid)
 {
-    return ((intf)Ventries(*f, *vgid));
+    return (intf)Ventries(*f, *vgid);
 }
 
 /* ------------------------------------------------------------------ */
@@ -927,7 +927,7 @@ nventsc(intf *f, intf *vgid)
 FRETVAL(intf)
 nvlonec(intf *f, intf *idarray, intf *asize)
 {
-    return ((intf)Vlone(*f, (int32 *)idarray, (int32)*asize));
+    return (intf)Vlone(*f, (int32 *)idarray, (int32)*asize);
 }
 
 /* ------------------------------------------------------------------ */
@@ -939,7 +939,7 @@ nvlonec(intf *f, intf *idarray, intf *asize)
 FRETVAL(intf)
 nvslonec(intf *f, intf *idarray, intf *asize)
 {
-    return (VSlone(*f, (int32 *)idarray, (int32)*asize));
+    return VSlone(*f, (int32 *)idarray, (int32)*asize);
 }
 
 /* ------------------------------------------------------------------ */
@@ -956,12 +956,12 @@ nvfindc(intf *f, _fcd name, intf *namelen)
 
     tmp_name = HDf2cstring(name, (intn)*namelen);
     if (!tmp_name)
-        return (FAIL);
+        return FAIL;
 
     ret = (intf)Vfind((int32)*f, tmp_name);
     free(tmp_name);
 
-    return (ret);
+    return ret;
 } /* end nvfindc() */
 
 /* ------------------------------------------------------------------ */
@@ -978,12 +978,12 @@ nvfndclsc(intf *f, _fcd vgclass, intf *classlen)
 
     t_class = HDf2cstring(vgclass, (intn)*classlen);
     if (!t_class)
-        return (FAIL);
+        return FAIL;
 
     ret = (intf)Vfindclass((int32)*f, t_class);
     free(t_class);
 
-    return (ret);
+    return ret;
 } /* end nvfndclsc() */
 
 /*
@@ -1006,17 +1006,17 @@ nvhsdc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _f
 
     fld = HDf2cstring(field, (intn)*fieldlen);
     if (!fld)
-        return (FAIL);
+        return FAIL;
     name = HDf2cstring(vsname, (intn)*vsnamelen);
     if (!name) {
         free(fld);
-        return (FAIL);
+        return FAIL;
     }
     tclass = HDf2cstring(vsclass, (intn)*vsclasslen);
     if (!tclass) {
         free(fld);
         free(name);
-        return (FAIL);
+        return FAIL;
     }
 
     ret_val = (intf)VHstoredata(*f, fld, buf, *n, *datatype, name, tclass);
@@ -1024,7 +1024,7 @@ nvhsdc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _f
     free(name);
     free(tclass);
 
-    return (ret_val);
+    return ret_val;
 }
 
 /*----------------------------------------------------------
@@ -1038,8 +1038,8 @@ nvhscdc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _f
 {
     if ((*datatype != DFNT_CHAR) && (*datatype != DFNT_UCHAR))
         return FAIL;
-    return (nvhsdc(f, field, (uint8 *)_fcdtocp(cbuf), n, datatype, vsname, vsclass, fieldlen, vsnamelen,
-                   vsclasslen));
+    return nvhsdc(f, field, (uint8 *)_fcdtocp(cbuf), n, datatype, vsname, vsclass, fieldlen, vsnamelen,
+                   vsclasslen);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1054,8 +1054,8 @@ nvhscdmc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _
 {
     if ((*datatype != DFNT_CHAR) && (*datatype != DFNT_UCHAR))
         return FAIL;
-    return (nvhsdmc(f, field, (uint8 *)_fcdtocp(cbuf), n, datatype, vsname, vsclass, order, fieldlen,
-                    vsnamelen, vsclasslen));
+    return nvhsdmc(f, field, (uint8 *)_fcdtocp(cbuf), n, datatype, vsname, vsclass, order, fieldlen,
+                    vsnamelen, vsclasslen);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1073,17 +1073,17 @@ nvhsdmc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _
 
     fld = HDf2cstring(field, (intn)*fieldlen);
     if (!fld)
-        return (FAIL);
+        return FAIL;
     name = HDf2cstring(vsname, (intn)*vsnamelen);
     if (!name) {
         free(fld);
-        return (FAIL);
+        return FAIL;
     }
     tclass = HDf2cstring(vsclass, (intn)*vsclasslen);
     if (!tclass) {
         free(fld);
         free(name);
-        return (FAIL);
+        return FAIL;
     }
 
     ret_val = (intf)VHstoredatam(*f, fld, buf, *n, *datatype, name, tclass, *order);
@@ -1091,7 +1091,7 @@ nvhsdmc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _
     free(name);
     free(tclass);
 
-    return (ret_val);
+    return ret_val;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1109,18 +1109,18 @@ nvhmkgpc(intf *f, intf *tagarray, intf *refarray, intf *n, _fcd vgname, _fcd vgc
 
     gname = HDf2cstring(vgname, (intn)*vgnamelen);
     if (!gname)
-        return (FAIL);
+        return FAIL;
     gclass = HDf2cstring(vgclass, (intn)*vgclasslen);
     if (!gclass) {
         free(gname);
-        return (FAIL);
+        return FAIL;
     }
 
     ret_val = (intf)VHmakegroup(*f, (int32 *)tagarray, (int32 *)refarray, *n, gname, gclass);
     free(gname);
     free(gclass);
 
-    return (ret_val);
+    return ret_val;
 }
 
 /* ================================================================== */
@@ -1137,12 +1137,12 @@ nvflocc(intf *vkey, _fcd field, intf *fieldlen)
 
     fld = HDf2cstring(field, (intn)*fieldlen);
     if (!fld)
-        return (FAIL);
+        return FAIL;
     /* trimendblanks(fld); */
     ret = (int32)Vflocate(*vkey, fld);
     free(fld);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1154,7 +1154,7 @@ nvflocc(intf *vkey, _fcd field, intf *fieldlen)
 FRETVAL(intf)
 nvinqtrc(intf *vkey, intf *tag, intf *ref)
 {
-    return ((intf)Vinqtagref(*vkey, *tag, *ref));
+    return (intf)Vinqtagref(*vkey, *tag, *ref);
 }
 /* ------------------------------------------------------------------ */
 /*
@@ -1165,7 +1165,7 @@ nvinqtrc(intf *vkey, intf *tag, intf *ref)
 FRETVAL(intf)
 nvntrc(intf *vkey)
 {
-    return ((intf)Vntagrefs(*vkey));
+    return (intf)Vntagrefs(*vkey);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1177,7 +1177,7 @@ nvntrc(intf *vkey)
 FRETVAL(intf)
 nvnrefs(intf *vkey, intf *tag)
 {
-    return ((intf)Vnrefs((int32)*vkey, (int32)*tag));
+    return (intf)Vnrefs((int32)*vkey, (int32)*tag);
 } /* end nvnrefs() */
 
 /* ------------------------------------------------------------------ */
@@ -1189,7 +1189,7 @@ nvnrefs(intf *vkey, intf *tag)
 FRETVAL(intf)
 nvqref(intf *vkey)
 {
-    return ((intf)VQueryref((int32)*vkey));
+    return (intf)VQueryref((int32)*vkey);
 } /* end nvqref() */
 
 /* ------------------------------------------------------------------ */
@@ -1201,7 +1201,7 @@ nvqref(intf *vkey)
 FRETVAL(intf)
 nvqtag(intf *vkey)
 {
-    return ((intf)VQuerytag((int32)*vkey));
+    return (intf)VQuerytag((int32)*vkey);
 } /* end nvqtag() */
 
 /* ------------------------------------------------------------------ */
@@ -1214,7 +1214,7 @@ nvqtag(intf *vkey)
 FRETVAL(intf)
 nvgttrsc(intf *vkey, intf *tagarray, intf *refarray, intf *n)
 {
-    return ((intf)Vgettagrefs(*vkey, (int32 *)tagarray, (int32 *)refarray, *n));
+    return (intf)Vgettagrefs(*vkey, (int32 *)tagarray, (int32 *)refarray, *n);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1226,7 +1226,7 @@ nvgttrsc(intf *vkey, intf *tagarray, intf *refarray, intf *n)
 FRETVAL(intf)
 nvgttrc(intf *vkey, intf *which, intf *tag, intf *ref)
 {
-    return ((intf)Vgettagref(*vkey, *which, (int32 *)tag, (int32 *)ref));
+    return (intf)Vgettagref(*vkey, *which, (int32 *)tag, (int32 *)ref);
 }
 /* ------------------------------------------------------------------ */
 
@@ -1238,7 +1238,7 @@ nvgttrc(intf *vkey, intf *which, intf *tag, intf *ref)
 FRETVAL(intf)
 nvadtrc(intf *vkey, intf *tag, intf *ref)
 {
-    return ((intf)Vaddtagref(*vkey, *tag, *ref));
+    return (intf)Vaddtagref(*vkey, *tag, *ref);
 }
 /* ------------------------------------------------------------------ */
 
@@ -1256,7 +1256,7 @@ nvsqfnelt(intf *vkey, intf *nelt)
     stat = VSQuerycount((int32)*vkey, &ret_nelt);
 
     *nelt = (intf)ret_nelt;
-    return ((intf)stat);
+    return (intf)stat;
 }
 /* ------------------------------------------------------------------ */
 
@@ -1274,7 +1274,7 @@ nvsqfintr(intf *vkey, intf *interlace)
     stat = VSQueryinterlace((int32)*vkey, &ret_inter);
 
     *interlace = (intf)ret_inter;
-    return ((intf)stat);
+    return (intf)stat;
 }
 /* ------------------------------------------------------------------ */
 
@@ -1291,11 +1291,11 @@ nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen)
 
     fld = HDf2cstring(fields, (intn)*fieldslen);
     if (!fld)
-        return (FAIL);
+        return FAIL;
     ret = (intf)VSQueryfields((int32)*vkey, fld);
     free(fld);
 
-    return (ret);
+    return ret;
 }
 /* ------------------------------------------------------------------ */
 
@@ -1313,7 +1313,7 @@ nvsqfvsiz(intf *vkey, intf *size)
     stat = VSQueryvsize((int32)*vkey, &ret_size);
 
     *size = (intf)ret_size;
-    return ((intf)stat);
+    return (intf)stat;
 }
 /* ------------------------------------------------------------------ */
 
@@ -1330,11 +1330,11 @@ nvsqnamec(intf *vkey, _fcd name, intf *namelen)
 
     nam = HDf2cstring(name, (intn)*namelen);
     if (!nam)
-        return (FAIL);
+        return FAIL;
     ret = (intf)VSQueryname((int32)*vkey, nam);
     free(nam);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1349,12 +1349,12 @@ nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
 
     flds_in_buf = HDf2cstring(buflds, (intn)*buflds_len);
     if (!flds_in_buf) {
-        return (FAIL);
+        return FAIL;
     }
     afield = HDf2cstring(pckfld, (intn)*fld_len);
     if (!afield) {
         free(flds_in_buf);
-        return (FAIL);
+        return FAIL;
     }
     if (*flds_in_buf == '\0') {
         free(flds_in_buf);
@@ -1371,7 +1371,7 @@ nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
     free(flds_in_buf);
     free(afield);
 
-    return (ret);
+    return ret;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1386,12 +1386,12 @@ nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
 
     flds_in_buf = HDf2cstring(buflds, (intn)*buflds_len);
     if (!flds_in_buf) {
-        return (FAIL);
+        return FAIL;
     }
     afield = HDf2cstring(pckfld, (intn)*fld_len);
     if (!afield) {
         free(flds_in_buf);
-        return (FAIL);
+        return FAIL;
     }
     if (*flds_in_buf == '\0') {
         free(flds_in_buf);
@@ -1408,7 +1408,7 @@ nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
     free(flds_in_buf);
     free(afield);
 
-    return (ret);
+    return ret;
 }
 
 /*
@@ -1420,7 +1420,7 @@ nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
 FRETVAL(intf)
 nvdtrc(intf *vkey, intf *tag, intf *ref)
 {
-    return ((intf)Vdeletetagref(*vkey, *tag, *ref));
+    return (intf)Vdeletetagref(*vkey, *tag, *ref);
 }
 
 /*------------------------------------------------------------------------
@@ -1443,11 +1443,11 @@ nvscfcls(intf *id, _fcd name, intf *namelen)
     fi_id      = *id;
     class_name = HDf2cstring(name, (intn)*namelen);
     if (!class_name)
-        return (FAIL);
+        return FAIL;
 
     ret = VSfindclass(fi_id, class_name);
     free(class_name);
-    return (ret);
+    return ret;
 }
 /*------------------------------------------------------------------------
  *       Name:      vscsetblsz
@@ -1466,7 +1466,7 @@ nvscsetblsz(intf *id, intf *block_size)
     c_ret = VSsetblocksize(*id, *block_size);
     if (c_ret == 0)
         ret = 0;
-    return (ret);
+    return ret;
 }
 /*------------------------------------------------------------------------
  *       Name:      vscsetnmbl
@@ -1485,7 +1485,7 @@ nvscsetnmbl(intf *id, intf *num_blocks)
     c_ret = VSsetnumblocks(*id, *num_blocks);
     if (c_ret == 0)
         ret = 0;
-    return (ret);
+    return ret;
 }
 /*------------------------------------------------------------------------
  *       Name:      vscgblinfo
@@ -1510,7 +1510,7 @@ nvscgblinfo(intf *id, intf *block_size, intf *num_blocks)
         *num_blocks = c_num_blocks;
         ret         = 0;
     }
-    return (ret);
+    return ret;
 }
 /*------------------------------------------------------------------------
  *       Name:      vcgvgrp
@@ -1543,7 +1543,7 @@ nvcgvgrp(intf *id, intf *start_vg, intf *vg_count, intf *refarray)
 
         free(c_refarray);
     }
-    return (ret);
+    return ret;
 }
 /*------------------------------------------------------------------------
  *       Name:      vscgvdatas
@@ -1577,5 +1577,5 @@ nvscgvdatas(intf *id, intf *start_vd, intf *vd_count, intf *refarray)
         free(c_refarray);
     }
 
-    return (ret);
+    return ret;
 }

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -179,7 +179,7 @@ VIget_vgroup_node(void)
     memset(ret_value, 0, sizeof(VGROUP));
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* VIget_vgroup_node */
 
 /******************************************************************************
@@ -234,7 +234,7 @@ VIget_vginstance_node(void)
     memset(ret_value, 0, sizeof(vginstance_t));
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* VIget_vginstance_node */
 
 /******************************************************************************
@@ -277,7 +277,7 @@ Get_vfile(HFILEID f /* IN: file handle */)
     /* find file record */
     t = (void **)tbbtdfind(vtree, (void *)&key, NULL);
 
-    return ((vfile_t *)(t == NULL ? NULL : *t));
+    return (vfile_t *)(t == NULL ? NULL : *t);
 } /* end Get_vfile() */
 
 /*******************************************************************************
@@ -298,7 +298,7 @@ New_vfile(HFILEID f /* IN: file handle */)
 
     /* Allocate the vfile_t structure */
     if (NULL == (v = (vfile_t *)calloc(1, sizeof(vfile_t))))
-        return (NULL);
+        return NULL;
 
     /* Assign the file ID & insert into the tree */
     v->f = f;
@@ -307,7 +307,7 @@ New_vfile(HFILEID f /* IN: file handle */)
     tbbtdins(vtree, (void *)v, NULL);
 
     /* return vfile_t struct */
-    return (v);
+    return v;
 } /* end New_vfile() */
 
 /*******************************************************************************
@@ -2834,7 +2834,7 @@ VIstart(void)
         HGOTO_ERROR(DFE_CANTINIT, FAIL);
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* end VIstart() */
 
 /*******************************************************************************

--- a/hdf/src/vio.c
+++ b/hdf/src/vio.c
@@ -108,7 +108,7 @@ VSIget_vdata_node(void)
     memset(ret_value, 0, sizeof(VDATA));
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* VSIget_vdata_node */
 
 /******************************************************************************
@@ -164,7 +164,7 @@ VSIget_vsinstance_node(void)
     memset(ret_value, 0, sizeof(vsinstance_t));
 
 done:
-    return (ret_value);
+    return ret_value;
 } /* VSIget_vsinstance_node */
 
 /******************************************************************************
@@ -296,7 +296,7 @@ int32
 vexistvs(HFILEID f, /* IN: file handle */
          uint16  vsid /* IN: vdata id i.e. ref */)
 {
-    return ((NULL == vsinst(f, vsid)) ? FAIL : TRUE);
+    return (NULL == vsinst(f, vsid)) ? FAIL : TRUE;
 } /* vexistvs */
 
 /* ------------------------------------------------------------------ */

--- a/hdf/src/vparse.c
+++ b/hdf/src/vparse.c
@@ -91,7 +91,7 @@ scanattrs(const char *attrs, int32 *attrc, char ***attrv)
             /* make sure we've got a legitimate length */
             len = (intn)(s - s0);
             if (len <= 0)
-                return (FAIL);
+                return FAIL;
 
             /* save that token */
             ss = symptr[nsym] = sym[nsym];
@@ -122,7 +122,7 @@ scanattrs(const char *attrs, int32 *attrc, char ***attrv)
     /* save the last token */
     len = (intn)(s - s0);
     if (len <= 0)
-        return (FAIL);
+        return FAIL;
     ss = symptr[nsym] = sym[nsym];
     nsym++;
 
@@ -134,7 +134,7 @@ scanattrs(const char *attrs, int32 *attrc, char ***attrv)
     *attrc       = nsym;
     *attrv       = (char **)symptr;
 
-    return (SUCCEED); /* ok */
+    return SUCCEED; /* ok */
 } /* scanattrs */
 
 /*******************************************************************************

--- a/hdf/test/anfile.c
+++ b/hdf/test/anfile.c
@@ -133,7 +133,7 @@ checkann(const char *oldstr, const char *newstr, int32 ret, const char *type, in
         printf("%s is INCORRECT.\n", type);
         printf("It is:  %s\n", newstr);
         printf("It should be: %s\n", oldstr);
-        return (FAIL);
+        return FAIL;
     }
-    return (SUCCEED);
+    return SUCCEED;
 }

--- a/hdf/test/buffer.c
+++ b/hdf/test/buffer.c
@@ -278,7 +278,7 @@ read_test(int32 aid)
         acc_time += (end_time.tv_sec - start_time.tv_sec) * FACTOR + (end_time.tv_usec - start_time.tv_usec);
     } /* end for */
 
-    return (acc_time);
+    return acc_time;
 } /* end read_test() */
 
 static long
@@ -401,7 +401,7 @@ write_test(int32 aid, intn num_timings)
         acc_time += (end_time.tv_sec - start_time.tv_sec) * FACTOR + (end_time.tv_usec - start_time.tv_usec);
     } /* end for */
 
-    return (acc_time);
+    return acc_time;
 } /* end read_test() */
 
 int

--- a/hdf/test/comp.c
+++ b/hdf/test/comp.c
@@ -262,7 +262,7 @@ write_data(int32 fid, comp_model_t m_type, model_info *m_info, comp_coder_t c_ty
     aid     = HCcreate(fid, COMP_TAG, ret_ref, m_type, m_info, c_type, c_info);
     CHECK(aid, FAIL, "HCcreate");
     if (aid == FAIL)
-        return (0);
+        return 0;
 
     switch (ntype) {
         case DFNT_INT8:
@@ -284,7 +284,7 @@ write_data(int32 fid, comp_model_t m_type, model_info *m_info, comp_coder_t c_ty
             data_ptr = (void *)outbuf_uint32[test_num];
             break;
         default:
-            return (0);
+            return 0;
     } /* end switch */
 
     write_size = BUFSIZE * DFKNTsize(ntype);
@@ -298,7 +298,7 @@ write_data(int32 fid, comp_model_t m_type, model_info *m_info, comp_coder_t c_ty
     err_ret = Hendaccess(aid);
     CHECK(err_ret, FAIL, "Hendaccess");
 
-    return (ret_ref);
+    return ret_ref;
 } /* end write_data() */
 
 static void

--- a/hdf/test/forsupf.c
+++ b/hdf/test/forsupf.c
@@ -32,7 +32,7 @@ ngetverb(void)
 
     if (verb_str != NULL)
         verb_level = (intn)strtol(verb_str, NULL, 0); /* convert whole string using base 10 */
-    return ((intf)verb_level);
+    return (intf)verb_level;
 } /* end getverb() */
 
 /*-----------------------------------------------------------------------------
@@ -53,10 +53,10 @@ nhisystem(_fcd cmd, intf *cmdlen)
 
     fn = HDf2cstring(cmd, (intn)*cmdlen);
     if (!fn)
-        return (FAIL);
+        return FAIL;
     ret = (intf)system(fn);
     free(fn);
-    return (ret);
+    return ret;
 } /* end nhisystem() */
 
 /*-----------------------------------------------------------------------------
@@ -82,7 +82,7 @@ nfixnamec(_fcd name, intf *name_len, _fcd name_out, intf *name_len_out)
 
     c_name = HDf2cstring(name, (intn)*name_len);
     if (!c_name)
-        return (FAIL);
+        return FAIL;
 
     /* Here comes Bill's code */
     /* Generate the correct name for the test file, by prepending the source path */
@@ -96,5 +96,5 @@ nfixnamec(_fcd name, intf *name_len, _fcd name_out, intf *name_len_out)
 
     ret = 0;
     free(c_name);
-    return (ret);
+    return ret;
 } /* end nfixname() */

--- a/hdf/test/fortest.c
+++ b/hdf/test/fortest.c
@@ -45,7 +45,7 @@ InitTest(const char *TheName, const char *TheCall, const char *TheDescr)
         Test[Index].SkipFlag  = 0;
         Index++;
     }
-    return (Index);
+    return Index;
 }
 
 int
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
 
     if ((cmdfile = fopen(cmdfilename, "w")) == NULL) {
         printf("***Can't write to cmdfile(%s)***\n", cmdfilename);
-        return (-1);
+        return -1;
     }
 
     /* Default setting */
@@ -201,7 +201,7 @@ main(int argc, char *argv[])
     fflush(stdout);
 
 #ifndef CMAKE_INTDIR /* not built with cmake */
-    return (system("./fortestF"));
+    return system("./fortestF");
 #else
     return 0; /*(system("./fortestF"));*/
 #endif

--- a/hdf/test/gentest.c
+++ b/hdf/test/gentest.c
@@ -79,11 +79,11 @@ gen_bitio_test(void)
     intn   i;        /* local counting variable */
 
     if ((fid = Hopen(BITIO_NAME, DFACC_CREATE, 0)) == FAIL)
-        return (FAIL);
+        return FAIL;
 
     if ((bit_data = (uint8 *)malloc(BITIO_SIZE1 * sizeof(uint8))) == NULL) {
         Hclose(fid);
-        return (FAIL);
+        return FAIL;
     } /* end if */
 
     for (i = 0; i < BITIO_SIZE1; i++) /* fill with pseudo-random data */
@@ -92,15 +92,15 @@ gen_bitio_test(void)
     if (FAIL == Hputelement(fid, BITIO_TAG1, BITIO_REF1, bit_data, BITIO_SIZE1)) {
         free(bit_data);
         Hclose(fid);
-        return (FAIL);
+        return FAIL;
     }
 
     free(bit_data);
 
     if (FAIL == Hclose(fid))
-        return (FAIL);
+        return FAIL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end gen_bitio_test() */
 
 /*--------------------------------------------------------------------------
@@ -131,17 +131,17 @@ gen_nbit_test(void)
     intn   i;          /* local counting variable */
 
     if ((fid = Hopen(NBIT_NAME, DFACC_CREATE, 0)) == FAIL)
-        return (FAIL);
+        return FAIL;
 
     if ((nbit_data = (uint8 *)malloc(NBIT_SIZE1 * sizeof(uint8))) == NULL) {
         Hclose(fid);
-        return (FAIL);
+        return FAIL;
     }
 
     if ((out_data = (uint8 *)malloc(NBIT_SIZE1 * sizeof(uint8))) == NULL) {
         free(nbit_data);
         Hclose(fid);
-        return (FAIL);
+        return FAIL;
     }
 
     for (i = 0; i < NBIT_SIZE1; i++) /* fill with pseudo-random data */
@@ -170,16 +170,16 @@ gen_nbit_test(void)
         free(nbit_data);
         free(out_data);
         Hclose(fid);
-        return (FAIL);
+        return FAIL;
     } /* end if */
 
     free(nbit_data);
     free(out_data);
 
     if (FAIL == Hclose(fid))
-        return (FAIL);
+        return FAIL;
 
-    return (SUCCEED);
+    return SUCCEED;
 } /* end gen_nbit_test() */
 
 int

--- a/hdf/test/rig.c
+++ b/hdf/test/rig.c
@@ -829,7 +829,7 @@ read_binary_block(const char *filename, /* file to be read */
 
     /* Read in the specified block of data */
     readlen = fread((void *)buffer, 1, nitems, fd);
-    return (readlen);
+    return readlen;
 }
 
 /* ------------------------------- test_r24_jpeg ------------------------------- */

--- a/hdf/test/slab.c
+++ b/hdf/test/slab.c
@@ -2309,7 +2309,7 @@ slab4w(void)
     else
         MESSAGE(10, printf("\n          slab4w:  %d wrong values in slab.  \n", (int)num_err););
 
-    return (int)(num_err);
+    return (int)num_err;
 }
 
 /*

--- a/hdf/test/tdatainfo.c
+++ b/hdf/test/tdatainfo.c
@@ -596,7 +596,7 @@ get_annot_datainfo(int32 an_id, ann_type annot_type, int32 num_anns, t_ann_info_
         /* Number of annotations whose datainfo is retrieved */
         ret_value++;
     }
-    return (ret_value);
+    return ret_value;
 } /* get_annot_datainfo */
 
 /****************************************************************************

--- a/hdf/test/tmgrattr.c
+++ b/hdf/test/tmgrattr.c
@@ -436,7 +436,7 @@ test_mgr_userattr()
     CHECK(status, FAIL, "Hclose");
 
     /* Return the number of errors that's been kept track of so far */
-    return (num_errs);
+    return num_errs;
 } /* test_mgr_userattr */
 
 /****************************************************************

--- a/hdf/test/tmgrcomp.c
+++ b/hdf/test/tmgrcomp.c
@@ -175,7 +175,7 @@ test_mgr_compress_a()
     CHECK(ret, FAIL, "Hclose");
 
     /* Return the number of errors that's been kept track of so far */
-    return (num_errs);
+    return num_errs;
 } /* end test_mgr_compress_a() */
 
 /* Create/Write/Read 8-bit JPEG compressed image */
@@ -302,7 +302,7 @@ test_mgr_compress_b()
     CHECK(ret, FAIL, "Hclose");
 
     /* Return the number of errors that's been kept track of so far */
-    return (num_errs);
+    return num_errs;
 } /* end test_mgr_compress_b() */
 
 /* Create/Write/Read 24-bit JPEG compressed image */
@@ -413,7 +413,7 @@ test_mgr_compress_c()
     CHECK(status, FAIL, "Hclose");
 
     /* Return the number of errors that's been kept track of so far */
-    return (num_errs);
+    return num_errs;
 } /* end test_mgr_compress_c() */
 
 /*--------------------------------------------------------------------------
@@ -653,7 +653,7 @@ test_get_compress()
     CHECK(status, FAIL, "Hclose");
 
     /* Return the number of errors that's been kept track of so far */
-    return (num_errs);
+    return num_errs;
 } /* end test_get_compress */
 
 /*--------------------------------------------------------------------------
@@ -906,7 +906,7 @@ test_mgr_chunk_compress()
     CHECK(status, FAIL, "Hclose");
 
     /* Return the number of errors that's been kept track of so far */
-    return (num_errs);
+    return num_errs;
 } /* end of test_mgr_chunk_compress */
 
 /****************************************************************

--- a/hdf/test/tree.c
+++ b/hdf/test/tree.c
@@ -61,7 +61,7 @@ intn
 tcompare(void *k1, void *k2, intn cmparg)
 {
     (void)cmparg;
-    return ((intn)((*(int32 *)k1) - (*(int32 *)k2)));
+    return (intn)((*(int32 *)k1) - (*(int32 *)k2));
 }
 
 void

--- a/hdf/test/tutils.c
+++ b/hdf/test/tutils.c
@@ -26,9 +26,9 @@ fuzzy_memcmp(const void *s1, const void *s2, int32 len, intn fuzz_factor)
         len--;
     } /* end while */
     if (len == 0)
-        return (0);
+        return 0;
     else {
-        return ((intn)(*t1 - *t2));
+        return (intn)(*t1 - *t2);
     }
 } /* end fuzzy_memcmp() */
 

--- a/hdf/test/tvset.c
+++ b/hdf/test/tvset.c
@@ -2244,7 +2244,7 @@ check_vgs(int32 id, uintn start_vg, uintn n_vgs, char *ident_text, /* just for d
     refarray = (uint16 *)malloc(sizeof(uint16) * count);
     if (refarray == NULL) {
         fprintf(stderr, "check_vgs: Allocation refarray failed\n");
-        return (-1);
+        return -1;
     }
 
     /* Get all the vgroups in the file */
@@ -2284,7 +2284,7 @@ check_vds(int32 id, uintn start_vd, uintn n_vds, char *ident_text, /* just for d
     refarray = (uint16 *)malloc(sizeof(uint16) * count);
     if (refarray == NULL) {
         fprintf(stderr, "check_vds: Allocation refarray failed\n");
-        return (-1);
+        return -1;
     }
 
     /* Get all the vdatas in the file */


### PR DESCRIPTION
It was sometimes `return foo;` and other times `return (foo);`