### PR TITLE
nbit.c: Cleanup test_nbit7 to make sure inbuf is freed. 

### DIFF
--- a/hdf/test/nbit.c
+++ b/hdf/test/nbit.c
@@ -568,7 +568,7 @@ test_nbit7(int32 fid)
     c_info.nbit.fill_one  = TRUE;
     c_info.nbit.start_bit = NBIT_OFF7;
     c_info.nbit.bit_len   = NBIT_BITS7;
-    model_info m_info;
+    model_info  m_info;
     const int32 aid1 = HCcreate(fid, NBIT_TAG7, ref1, COMP_MODEL_STDIO, &m_info, COMP_CODE_NBIT, &c_info);
     CHECK_VOID(aid1, FAIL, "HCcreate");
 


### PR DESCRIPTION
A first trial of fix an issue found by Coverity in HDF4. I'm sticking to test files so that it has the least chance of impacting users as I get accustomed to doing fixes for HDF4.

Tightened up the scope of local variables and added `const` when possible.

Especially important is moving the allocations to as late as possible
to reduce the number of locations where they need to be freed.

```
CID 1546820 (https://github.com/HDFGroup/hdf4/pull/2 of 2): Resource leak (RESOURCE_LEAK)
10. leaked_storage: Variable inbuf going out of scope leaks the storage it points to.
```