### PR TITLE
rig.c: Cleanup read_binary_block() to always close fd.

### DIFF
--- a/hdf/test/rig.c
+++ b/hdf/test/rig.c
@@ -11,6 +11,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdlib.h>
 #include "tproto.h"
 
 #define XSIZE    13
@@ -812,24 +813,24 @@ read_binary_block(const char *filename, /* file to be read */
                   size_t      nitems,   /* number of bytes to read */
                   uint8      *buffer)        /* buffer to store the binary data in */
 {
-    FILE  *fd;
-    size_t readlen = 0; /* number of bytes actually read */
-
     /* Open the file to read binary data */
-    if ((fd = fopen(filename, "rb")) == NULL) {
+    FILE *fd = fopen(filename, "rb");
+    if (fd == NULL) {
         fprintf(stderr, "can't open %s\n", filename);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     /* Forward to the specified offset to start reading */
     if (fseek(fd, (off_t)offset, SEEK_SET) == -1) {
         fprintf(stderr, "can't seek offset %d\n", (int)offset);
-        exit(1);
+        fclose(fd);
+        exit(EXIT_FAILURE);
     }
 
     /* Read in the specified block of data */
-    readlen = fread((void *)buffer, 1, nitems, fd);
-    return (readlen);
+    const size_t readlen = fread((void *)buffer, 1, nitems, fd);
+    fclose(fd);
+    return readlen;
 }
 
 /* ------------------------------- test_r24_jpeg ------------------------------- */


### PR DESCRIPTION
- Combine definition and assignment of variables
- Convert `exit(1)` to `exit(EXIT_FAILURE)`
- Add a `const` to `readlen`

```
CID 1546508 (#1 of 1): Resource leak (RESOURCE_LEAK)
7. leaked_storage: Variable fd going out of scope leaks the storage it points to.
```