### PR TITLE
Code cleanup - Remove getcompress functions

### DIFF
--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -365,9 +365,6 @@ HDFLIBAPI intn HXsetdir(const char *dir);
 HDFLIBAPI int32 HCcreate(int32 file_id, uint16 tag, uint16 ref, comp_model_t model_type, model_info *m_info,
                          comp_coder_t coder_type, comp_info *c_info);
 
-HDFLIBAPI intn HCPgetcompress(int32 file_id, uint16 data_tag, uint16 data_ref, comp_coder_t *coder_type,
-                              comp_info *c_info);
-
 HDFLIBAPI intn HCPgetcompinfo(int32 file_id, uint16 data_tag, uint16 data_ref, comp_coder_t *coder_type,
                               comp_info *c_info);
 

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -4083,7 +4083,7 @@ done:
 
 /*--------------------------------------------------------------------------
  NAME
-    GRgetcompress
+    GRgetcompress - Deprecated in favor of GRgetcompinfo
 
  PURPOSE
     Get the compression information of a raster image's data.
@@ -4109,53 +4109,15 @@ done:
     mapped to a quantization table.  Thus, only the correct compression
     type will be returned; cinfo will only contain 0s.
 
- EXAMPLES
- REVISION LOG
-    July 2001: Added to fix bug #307 -BMR
-    Apr 2005: Replaced by GRgetcompinfo due to deficiency in handling some
-                special elements. -BMR
 --------------------------------------------------------------------------*/
 intn
 GRgetcompress(int32 riid, comp_coder_t *comp_type, comp_info *cinfo)
 {
-    ri_info_t *ri_ptr; /* ptr to the image to work with */
-    int32      file_id;
-    uint16     scheme; /* compression scheme used for JPEG images */
-    intn       ret_value = SUCCEED;
+    intn ret_value = SUCCEED;
 
-    /* clear error stack and check validity of args */
-    HEclear();
-
-    /* check the validity of the RI ID */
-    if (HAatom_group(riid) != RIIDGROUP)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* and check the output arguments */
-    if (comp_type == NULL || cinfo == NULL)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* locate RI's object in hash table */
-    if (NULL == (ri_ptr = (ri_info_t *)HAatom_object(riid)))
-        HGOTO_ERROR(DFE_BADPTR, FAIL);
-
-    file_id = ri_ptr->gr_ptr->hdf_file_id; /* temporary use */
-
-    /* If the compression scheme used was JPEG, return the compression type
-       and 0 for the 'quality' and 'force_baseline' parameters, because
-       these parameters are currently not possible to be retrieved. */
-    scheme = ri_ptr->img_dim.comp_tag;
-    if (scheme == DFTAG_JPEG5 || scheme == DFTAG_GREYJPEG5 || scheme == DFTAG_JPEG ||
-        scheme == DFTAG_GREYJPEG) {
-        *comp_type                 = COMP_CODE_JPEG;
-        cinfo->jpeg.quality        = 0;
-        cinfo->jpeg.force_baseline = 0;
-    }
-    else {
-        /* use lower-level routine to get the compression information */
-        ret_value = HCPgetcompress(file_id, ri_ptr->img_tag, ri_ptr->img_ref, comp_type, cinfo);
-        if (ret_value == FAIL)
-            HGOTO_ERROR(DFE_INTERNAL, FAIL);
-    }
+    ret_value = GRgetcompinfo(riid, comp_type, cinfo);
+    if (ret_value == FAIL)
+        HGOTO_ERROR(DFE_INTERNAL, FAIL);
 
 done:
     return ret_value;
@@ -4292,15 +4254,6 @@ done:
     parameters, 'quality' and 'force_baseline', are irreversibly
     mapped to a quantization table.  Thus, only the correct compression
     type will be returned; cinfo will only contain 0s.
-
- EXAMPLES
- REVISION LOG
-    July 2001: Added to fix bug #307 - BMR (from GRgetcompress)
-    Apr 2005:  This function was actually created at this time, but it is
-               almost a duplicate of GRgetcompress, which is intended to be
-               removed in the future, due to its incorrect behavior.  The
-               only difference is the call to the low-level routine,
-               HCPgetcompinfo, instead of HCPgetcompress.
 
 --------------------------------------------------------------------------*/
 intn

--- a/mfhdf/fortran/mfsdf.c
+++ b/mfhdf/fortran/mfsdf.c
@@ -1572,7 +1572,7 @@ nsfsflmd(intf *id, intf *fillmode)
 
 /*-------------------------------------------------------------------------
  * Name:    scgichnk
- * Puporse: Call SDgetchunkinfo
+ * Purpose: Call SDgetchunkinfo
  * Inputs:  id: SDS access id
  * Outputs: dim_length: chunk dimensions
  *          flags:            -1 - SDS is nonchunked
@@ -1747,7 +1747,7 @@ nscscchnk(intf *id, intf *maxcache, intf *flags)
 
 /*-------------------------------------------------------------------------
  * Name:    scschnk
- * Puporse: Call SDsetchunk
+ * Purpose: Call SDsetchunk
  * Inputs:  id: SDS access id
  *          dim_length: chunk dimensions
  *          comp_type:  type of compression
@@ -1932,7 +1932,7 @@ nscwcchnk(intf *id, intf *start, _fcd char_data)
 
 /*-------------------------------------------------------------------------
  * Name:    scscompress
- * Puporse: Call SDsetcompress
+ * Purpose: Call SDsetcompress
  * Inputs:  id: SDS access id
  *          comp_type:  type of compression
  *                      COMP_CODE_NONE = 0
@@ -1998,7 +1998,7 @@ nscscompress(intf *id, intf *comp_type, intf *comp_prm)
 
 /*-------------------------------------------------------------------------
  * Name:    scgcompress
- * Puporse: Call SDgetcompress
+ * Purpose: Call SDgetcompinfo
  * Inputs:  id: SDS access id
  * Outputs: comp_type:  type of compression
  *                      COMP_CODE_NONE = 0

--- a/mfhdf/fortran/tszip.f
+++ b/mfhdf/fortran/tszip.f
@@ -277,17 +277,12 @@ C
      .                compressed dataset'
                 err_szip = err_szip + 1
                 endif
-C            write(*,*) comp_arg(1), comp_prm_out(1)
-C            write(*,*) comp_arg(2), comp_prm_out(2)
-C            write(*,*) comp_prm_out(3)
-C            write(*,*) comp_prm_out(4)
-C            write(*,*) comp_prm_out(5)
 
-C                if ((comp_arg(1) .ne. comp_prm_out(1)) .or.
-C     .              (comp_arg(2) .ne. comp_prm_out(2))) then
-C            print *, 'wrong compression parameter'
-C                err_szip = err_szip + 1
-C                endif
+        if ((comp_arg(1) .ne. comp_prm_out(1)) .or.
+     .       (comp_arg(2) .ne. comp_prm_out(2))) then
+            print *, 'wrong compression parameter'
+                err_szip = err_szip + 1
+                endif
 
 C
 C   Read part of the data back using sfrdata function

--- a/mfhdf/libsrc/mfsd.c
+++ b/mfhdf/libsrc/mfsd.c
@@ -3321,7 +3321,8 @@ done:
 /************************** Deprecated ******************************
  NAME
     SDgetexternalfile -- retrieves external file information
-    (Deprecated)
+    (Deprecated in favor of SDgetexternalinfo)
+
  USAGE
     int32 SDgetexternalfile(id, filename, offset)
         int32 id;
@@ -3741,9 +3742,10 @@ done:
 
 #ifndef H4_NO_DEPRECATED_SYMBOLS
 
-/******************************************************************************
+/****************************** Deprecated ***********************************
  NAME
     SDgetcompress -- Retrieves compression information of a dataset
+    (Deprecated in favor of SDgetcompinfo)
 
  DESCRIPTION
     This routine uses HCPgetcompress to retrieve the compression type
@@ -3751,11 +3753,6 @@ done:
 
  RETURNS
     SUCCEED/FAIL
-
- MODIFICATION
-    July 2001: Added to fix bug #307 - BMR
-    Apr 2005:  This function has incorrect behavior and is replaced by
-        SDgetcompinfo.  SDgetcompress will be removed in the future.
 
 ******************************************************************************/
 intn
@@ -3773,24 +3770,7 @@ SDgetcompress(
     /* clear error stack */
     HEclear();
 
-    if (comp_type == NULL || c_info == NULL)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    handle = SDIhandle_from_id(id, SDSTYPE);
-    if (handle == NULL || handle->file_type != HDF_FILE)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-    if (handle->vars == NULL)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    var = SDIget_var(handle, id);
-    if (var == NULL)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    if (!var->data_ref)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* use lower-level routine to get the compression information */
-    status = HCPgetcompress(handle->hdf_file, var->data_tag, var->data_ref, comp_type, c_info);
+    status = SDgetcompinfo(id, comp_type, c_info);
     if (status == FAIL)
         HGOTO_ERROR(DFE_INTERNAL, FAIL);
 
@@ -3810,14 +3790,6 @@ done:
 
  RETURNS
     SUCCEED/FAIL
-
- MODIFICATION
-    July 2001: Added to fix bug #307 - BMR (from SDgetcompress)
-    Apr 2005:  This function was actually created at this time, but it is
-        almost a duplicate of SDgetcompress, which is intended to be
-        removed in the future, due to its incorrect behavior.  The
-        only difference is the call to the low-level routine,
-        HCPgetcompinfo, instead of HCPgetcompress.
 
 ******************************************************************************/
 intn


### PR DESCRIPTION
The functions SDgetcompress/GRgetcompress have incorrect behavior and were deprecated in favor of SDgetcompinfo/GRgetcompinfo several releases ago. They should not be used anymore.

Removed the internal function HCPgetcompress and replaced the contents of SDgetcompress/GRgetcompress with a call to SDgetcompinfo/GRgetcompinfo.

Uncommented the failed test in Fortran when getcompress function was used.  It succeeds now.

Java API will be updated in another PR.