### PR TITLE
Install examples into docdir

### DIFF
--- a/config/examples.am
+++ b/config/examples.am
@@ -42,7 +42,7 @@ CHECK_CLEANFILES+= *.hdf
 CLEANFILES=$(EXAMPLE_PROG)
 
 # How to create EXAMPLEDIR if it doesn't already exist
-$(EXAMPLEDIR):
+$(DESTDIR)$(EXAMPLEDIR):
 	mkdir -p $@
 
 # Install and uninstall rules.  We install the source files, not the
@@ -52,42 +52,42 @@ install-data-local:
 uninstall-local:
 	@$(MAKE) $(AM_MAKEFLAGS) uninstall-examples
 
-install-examples: $(EXAMPLEDIR)
+install-examples: $(DESTDIR)$(EXAMPLEDIR)
 	@for f in X $(INSTALL_FILES); do                                     \
 	  if test $$f != X; then                                             \
-	    (set -x; $(INSTALL) $(srcdir)/$$f $(EXAMPLEDIR)/. || exit 1);    \
-            chmod a-x $(EXAMPLEDIR)/$$f;                                     \
+	    (set -x; $(INSTALL) $(srcdir)/$$f $(DESTDIR)$(EXAMPLEDIR)/. || exit 1);    \
+            chmod a-x $(DESTDIR)$(EXAMPLEDIR)/$$f;                                     \
 	  fi;                                                                \
 	done
 	@for f in X $(INSTALL_SCRIPT_FILES); do                              \
 	  if test $$f != X; then                                             \
-	    (set -x; $(INSTALL) $(srcdir)/$$f $(EXAMPLEDIR)/. || exit 1);    \
+	    (set -x; $(INSTALL) $(srcdir)/$$f $(DESTDIR)$(EXAMPLEDIR)/. || exit 1);    \
 	  fi;                                                                \
 	done
 	@for f in X $(INSTALL_TOP_FILES); do                                 \
 	  if test $$f != X; then                                             \
-	    (set -x; $(INSTALL) $(srcdir)/$$f $(EXAMPLETOPDIR)/. || exit 1); \
-	    chmod a-x $(EXAMPLETOPDIR)/$$f;                                  \
+	    (set -x; $(INSTALL) $(srcdir)/$$f $(DESTDIR)$(EXAMPLETOPDIR)/. || exit 1); \
+	    chmod a-x $(DESTDIR)$(EXAMPLETOPDIR)/$$f;                                  \
 	  fi;                                                                \
 	done
 	@for f in X $(INSTALL_TOP_SCRIPT_FILES); do                          \
 	  if test $$f != X; then                                             \
-	    (set -x; $(INSTALL) $(srcdir)/$$f $(EXAMPLETOPDIR)/. || exit 1); \
+	    (set -x; $(INSTALL) $(srcdir)/$$f $(DESTDIR)$(EXAMPLETOPDIR)/. || exit 1); \
 	  fi;                                                                \
 	done
 
 uninstall-examples:
-	@if test -n "$(INSTALL_FILES)" -a -d $(EXAMPLEDIR); then           \
-	  set -x; cd $(EXAMPLEDIR) && $(RM) $(INSTALL_FILES);              \
+	@if test -n "$(INSTALL_FILES)" -a -d $(DESTDIR)$(EXAMPLEDIR); then           \
+	  set -x; cd $(EXAMPLEDIR) && $(RM) $(DESTDIR)$(INSTALL_FILES);              \
 	fi
-	@if test -n "$(INSTALL_SCRIPT_FILES)" -a -d $(EXAMPLEDIR); then    \
-	  set -x; cd $(EXAMPLEDIR) && $(RM) $(INSTALL_SCRIPT_FILES);       \
+	@if test -n "$(INSTALL_SCRIPT_FILES)" -a -d $(DESTDIR)$(EXAMPLEDIR); then    \
+	  set -x; cd $(EXAMPLEDIR) && $(RM) $(DESTDIR)$(INSTALL_SCRIPT_FILES);       \
 	fi
-	@if test -n "$(INSTALL_TOP_FILES)" -a -d $(EXAMPLETOPDIR); then    \
-	  set -x; cd $(EXAMPLETOPDIR) && $(RM) $(INSTALL_TOP_FILES);       \
+	@if test -n "$(INSTALL_TOP_FILES)" -a -d $(DESTDIR)$(EXAMPLETOPDIR); then    \
+	  set -x; cd $(EXAMPLETOPDIR) && $(RM) $(DESTDIR)$(INSTALL_TOP_FILES);       \
 	fi
-	@if test -n "$(INSTALL_TOP_SCRIPT_FILES)" -a -d $(EXAMPLETOPDIR); then    \
-	  set -x; cd $(EXAMPLETOPDIR) && $(RM) $(INSTALL_TOP_SCRIPT_FILES);       \
+	@if test -n "$(INSTALL_TOP_SCRIPT_FILES)" -a -d $(DESTDIR)$(EXAMPLETOPDIR); then    \
+	  set -x; cd $(EXAMPLETOPDIR) && $(RM) $(DESTDIR)$(INSTALL_TOP_SCRIPT_FILES);       \
 	fi
 
 installcheck-local:

--- a/hdf/examples/Makefile.am
+++ b/hdf/examples/Makefile.am
@@ -46,8 +46,8 @@ INSTALL_TOP_SCRIPT_FILES = run-all-ex.sh
 INSTALL_TOP_FILES = README
 
 # Where to install example files
-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf4_examples/c
-EXAMPLETOPDIR=${DESTDIR}$(exec_prefix)/share/hdf4_examples
+EXAMPLEDIR=$(docdir)/examples/c
+EXAMPLETOPDIR=$(docdir)/examples
 
 # How to build C programs using h4cc
 $(EXTRA_PROG): $(H4CC)

--- a/hdf/fortran/examples/Makefile.am
+++ b/hdf/fortran/examples/Makefile.am
@@ -41,7 +41,7 @@ INSTALL_FILES= VD_read_from_vdata.f VD_read_mixed_vdata.f \
 INSTALL_SCRIPT_FILES = run-fortran-ex.sh
 
 # Where to install Fortran example files
-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf4_examples/fortran
+EXAMPLEDIR=$(docdir)/examples/fortran
 
 # How to build Fortran programs using h4fc
 $(EXTRA_PROG): $(H4FC)

--- a/mfhdf/examples/Makefile.am
+++ b/mfhdf/examples/Makefile.am
@@ -23,7 +23,7 @@ INSTALL_FILES = SD_create_sds.c SD_write_to_sds.c SD_write_slab.c        \
 	SD_get_info.c SD_find_sds_by_name.c SD_set_get_dim_info.c        \
 	SD_dimscale_vs_sds.c SD_set_attr.c SD_get_attr.c SD_chunking_example.c
 
-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf4_examples/c
+EXAMPLEDIR=$(docdir)/examples/c
 
 # How to build programs using h4cc
 $(EXTRA_PROG): $(H4CC)

--- a/mfhdf/fortran/examples/Makefile.am
+++ b/mfhdf/fortran/examples/Makefile.am
@@ -24,7 +24,7 @@ INSTALL_FILES=SD_create_sds.f SD_write_to_sds.f SD_write_slab.f SD_alter_sds_val
 	SD_set_attr.f SD_get_attr.f SD_compress_sds.f SD_chunking_example.f
 
 # Where to install example files
-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf4_examples/fortran
+EXAMPLEDIR=$(docdir)/examples/fortran
 
 # How to build Fortran programs using h4fc
 $(EXTRA_PROG): $(H4FC)


### PR DESCRIPTION
FWIW - this is a patch we've carried for a long time in Fedora to install the examples to a location in compliance with our packaging standards.