### PR TITLE
mfsd.c SDgetcompress: Remove unused variables.

### DIFF
--- a/mfhdf/libsrc/mfsd.c
+++ b/mfhdf/libsrc/mfsd.c
@@ -3762,10 +3762,8 @@ SDgetcompress(
     comp_info    *c_info /* OUT: ptr to compression information structure for storing the retrieved info */
 )
 {
-    NC     *handle;
-    NC_var *var       = NULL;
-    intn    status    = FAIL;
-    intn    ret_value = SUCCEED;
+    intn status    = FAIL;
+    intn ret_value = SUCCEED;
 
     /* clear error stack */
     HEclear();


### PR DESCRIPTION
On my local bazel build, I got:

```
third_party/hdf4/mfhdf/libsrc/mfsd.c:3765:13: error: unused variable 'handle' [-Werror,-Wunused-variable]
 3765 |     NC     *handle;
      |             ^~~~~~
third_party/hdf4/mfhdf/libsrc/mfsd.c:3766:13: error: unused variable 'var' [-Werror,-Wunused-variable]
 3766 |     NC_var *var       = NULL;
      |             ^~~
2 errors generated.
```