### PR TITLE
Cleaned up datainfo header files

### DIFF
--- a/hdf/src/hdatainfo.h
+++ b/hdf/src/hdatainfo.h
@@ -14,40 +14,19 @@
 #ifndef H4_HDATAINFO_H
 #define H4_HDATAINFO_H
 
-#include "H4api_adpt.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Structure that holds a data descriptor.  First added for GRgetpalinfo. */
-typedef struct hdf_ddinfo_t {
-    uint16 tag;
-    uint16 ref;
-    int32  offset;
-    int32  length;
-} hdf_ddinfo_t;
-
-/* Public functions for getting raw data information */
-
-HDFLIBAPI intn ANgetdatainfo(int32 ann_id, int32 *offset, int32 *length);
-
-HDFLIBAPI intn HDgetdatainfo(int32 file_id, uint16 data_tag, uint16 data_ref, int32 *chk_coord,
-                             uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
-
-HDFLIBAPI intn VSgetdatainfo(int32 vsid, uintn start_block, uintn info_count, int32 *offsetarray,
-                             int32 *lengtharray);
-
-HDFLIBAPI intn VSgetattdatainfo(int32 vsid, int32 findex, intn attrindex, int32 *offset, int32 *length);
-
-HDFLIBAPI intn Vgetattdatainfo(int32 vgid, intn attrindex, int32 *offset, int32 *length);
-
-HDFLIBAPI intn GRgetdatainfo(int32 riid, uintn start_block, uintn info_count, int32 *offsetarray,
-                             int32 *lengtharray);
-
-HDFLIBAPI intn GRgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length);
-
-HDFLIBAPI intn GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array);
+/*****************************************************************************
+ *
+ * hdatainfo.h
+ *
+ * The public structure and APIs in this file were moved into hproto.h in
+ * version 4.3.0.  Applications don't need to and should no longer include this
+ * header file.
+ *
+ ******************************************************************************/
 
 #ifdef __cplusplus
 }

--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -441,6 +441,38 @@ HDFLIBAPI int32 Hendbitaccess(int32 bitfile_id, intn flushbit);
 HDFLIBAPI intn HPbitshutdown(void);
 
 /*
+ ** from hdatainfo.c
+ */
+
+/* Structure that holds a data descriptor */
+typedef struct hdf_ddinfo_t {
+    uint16 tag;
+    uint16 ref;
+    int32  offset;
+    int32  length;
+} hdf_ddinfo_t;
+
+/*
+ ** Public functions for getting raw data information - from hdatainfo.c
+ */
+HDFLIBAPI intn ANgetdatainfo(int32 ann_id, int32 *offset, int32 *length);
+
+HDFLIBAPI intn HDgetdatainfo(int32 file_id, uint16 data_tag, uint16 data_ref, int32 *chk_coord, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+
+HDFLIBAPI intn VSgetdatainfo(int32 vsid, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+
+HDFLIBAPI intn VSgetattdatainfo(int32 vsid, int32 findex, intn attrindex, int32 *offset, int32 *length);
+
+HDFLIBAPI intn Vgetattdatainfo(int32 vgid, intn attrindex, int32 *offset, int32 *length);
+
+HDFLIBAPI intn GRgetdatainfo(int32 riid, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+
+HDFLIBAPI intn GRgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length);
+
+HDFLIBAPI intn GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array);
+
+
+/*
  ** from dfutil.c
  */
 HDFLIBAPI uint16 DFfindnextref(int32 file_id, uint16 tag, uint16 lref);
@@ -808,7 +840,9 @@ HDFLIBAPI intn DFKsb4b(void *s, void *d, uint32 num_elm, uint32 source_stride, u
 
 HDFLIBAPI intn DFKsb8b(void *s, void *d, uint32 num_elm, uint32 source_stride, uint32 dest_stride);
 
-/* Multi-file Annotation C-routines found in mfan.c */
+/*
+ ** Multi-file Annotation - from mfan.c
+ */
 HDFLIBAPI int32 ANstart(int32 file_id);
 
 HDFLIBAPI intn ANfileinfo(int32 an_id, int32 *n_file_label, int32 *n_file_desc, int32 *n_obj_label,
@@ -844,10 +878,9 @@ HDFLIBAPI uint16 ANatype2tag(ann_type atype);
 
 HDFLIBAPI ann_type ANtag2atype(uint16 atag);
 
-/* BMR: Removed because this function is meant to be private.
-HDFLIBAPI intn ANdestroy(void); */
-
-/* Multi-file Raster C-routines found in mfgr.c */
+/*
+ ** Multi-file General Raster - from mfgr.c
+ */
 HDFLIBAPI intn rigcompare(void *k1, void *k2, intn cmparg);
 
 HDFLIBAPI int32 GRstart(int32 hdf_file_id);

--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -457,20 +457,22 @@ typedef struct hdf_ddinfo_t {
  */
 HDFLIBAPI intn ANgetdatainfo(int32 ann_id, int32 *offset, int32 *length);
 
-HDFLIBAPI intn HDgetdatainfo(int32 file_id, uint16 data_tag, uint16 data_ref, int32 *chk_coord, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+HDFLIBAPI intn HDgetdatainfo(int32 file_id, uint16 data_tag, uint16 data_ref, int32 *chk_coord,
+                             uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
 
-HDFLIBAPI intn VSgetdatainfo(int32 vsid, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+HDFLIBAPI intn VSgetdatainfo(int32 vsid, uintn start_block, uintn info_count, int32 *offsetarray,
+                             int32 *lengtharray);
 
 HDFLIBAPI intn VSgetattdatainfo(int32 vsid, int32 findex, intn attrindex, int32 *offset, int32 *length);
 
 HDFLIBAPI intn Vgetattdatainfo(int32 vgid, intn attrindex, int32 *offset, int32 *length);
 
-HDFLIBAPI intn GRgetdatainfo(int32 riid, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+HDFLIBAPI intn GRgetdatainfo(int32 riid, uintn start_block, uintn info_count, int32 *offsetarray,
+                             int32 *lengtharray);
 
 HDFLIBAPI intn GRgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length);
 
 HDFLIBAPI intn GRgetpalinfo(int32 gr_id, uintn pal_count, hdf_ddinfo_t *palinfo_array);
-
 
 /*
  ** from dfutil.c

--- a/mfhdf/libsrc/mfdatainfo.h
+++ b/mfhdf/libsrc/mfdatainfo.h
@@ -20,17 +20,14 @@
 extern "C" {
 #endif
 
-/* Public functions for getting raw data information */
-
-HDFLIBAPI intn SDgetdatainfo(int32 sdsid, int32 *chk_coord, uintn start_block, uintn info_count,
-                             int32 *offsetarray, int32 *lengtharray);
-
-HDFLIBAPI intn SDgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length);
-
-HDFLIBAPI intn SDgetoldattdatainfo(int32 dimid, int32 sdsid, char *attr_name, int32 *offset, int32 *length);
-
-HDFLIBAPI intn SDgetanndatainfo(int32 sdsid, ann_type annot_type, uintn size, int32 *offsetarray,
-                                int32 *lengtharray);
+/*****************************************************************************
+ *
+ * mfdatainfo.h
+ *
+ * The public APIs in this file were moved into mfhdf.h in version 4.3.0.
+ * Applications don't need to and should no longer include this header file.
+ *
+ ******************************************************************************/
 
 #ifdef __cplusplus
 }

--- a/mfhdf/libsrc/mfhdf.h
+++ b/mfhdf/libsrc/mfhdf.h
@@ -416,13 +416,15 @@ HDFLIBAPI intn SDsetchunkcache(int32 sdsid,    /* IN: sds access id */
  ** Public functions for getting raw data information - from mfdatainfo.c
  */
 
-HDFLIBAPI intn SDgetdatainfo(int32 sdsid, int32 *chk_coord, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+HDFLIBAPI intn SDgetdatainfo(int32 sdsid, int32 *chk_coord, uintn start_block, uintn info_count,
+                             int32 *offsetarray, int32 *lengtharray);
 
 HDFLIBAPI intn SDgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length);
 
 HDFLIBAPI intn SDgetoldattdatainfo(int32 dimid, int32 sdsid, char *attr_name, int32 *offset, int32 *length);
 
-HDFLIBAPI intn SDgetanndatainfo(int32 sdsid, ann_type annot_type, uintn size, int32 *offsetarray, int32 *lengtharray);
+HDFLIBAPI intn SDgetanndatainfo(int32 sdsid, ann_type annot_type, uintn size, int32 *offsetarray,
+                                int32 *lengtharray);
 
 #ifdef __cplusplus
 }

--- a/mfhdf/libsrc/mfhdf.h
+++ b/mfhdf/libsrc/mfhdf.h
@@ -28,7 +28,6 @@
 #endif
 
 #include "mfhdfi.h"
-#include "mfdatainfo.h"
 
 #define SD_UNLIMITED        NC_UNLIMITED /* use this as marker for unlimited dimension */
 #define SD_NOFILL           NC_NOFILL
@@ -412,6 +411,18 @@ RETURNS
 HDFLIBAPI intn SDsetchunkcache(int32 sdsid,    /* IN: sds access id */
                                int32 maxcache, /* IN: max number of chunks to cache */
                                int32 flags /* IN: flags = 0, HDF_CACHEALL */);
+
+/*
+ ** Public functions for getting raw data information - from mfdatainfo.c
+ */
+
+HDFLIBAPI intn SDgetdatainfo(int32 sdsid, int32 *chk_coord, uintn start_block, uintn info_count, int32 *offsetarray, int32 *lengtharray);
+
+HDFLIBAPI intn SDgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length);
+
+HDFLIBAPI intn SDgetoldattdatainfo(int32 dimid, int32 sdsid, char *attr_name, int32 *offset, int32 *length);
+
+HDFLIBAPI intn SDgetanndatainfo(int32 sdsid, ann_type annot_type, uintn size, int32 *offsetarray, int32 *lengtharray);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Moved prototypes of hdf datainfo functions into hproto.h and mfhdf datainfo functions into mfhdf.h.

The header files hdatainfo.h and mfdatainfo.h should no longer be used in applications.
