### PR TITLE
Add ABI compatibility reports

### DIFF
--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Get published binary (Linux)
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-            name: tgz-ubuntu-2204_gcc-binary
+            name: tgz-ubuntu-2204-binary
             path: ${{ github.workspace }}
 
       - name: List files for the space (Linux)
@@ -56,7 +56,7 @@ jobs:
           ls -l ${{ github.workspace }}
 
       - name: Uncompress gh binary (Linux)
-        run: tar -zxvf ${{ github.workspace }}/${{ inputs.file_base }}-ubuntu-2204_gcc.tar.gz
+        run: tar -zxvf ${{ github.workspace }}/${{ inputs.file_base }}-ubuntu-2204.tar.gz
 
       - name: Uncompress hdf4 binary (Linux)
         run:  |

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Uncompress hdf4 reference binary (Linux)
         run:  |
           cd "${{ github.workspace }}/hdf4R"
-          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/hdf-${{ inputs.file_ref }}-Linux.tar.gz --strip-components 1
+          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/HDF-${{ steps.convert-hdf4lib-refname.outputs.HDF4R_DOTS }}-Linux.tar.gz --strip-components 1
 
       - name: List files for the HDFR space (Linux)
         run: |

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           mkdir "${{ github.workspace }}/hdf4R"
           cd "${{ github.workspace }}/hdf4R"
-          wget -q https://github.com/HDFGroup/hdf4/releases/download/hdf4-${{ inputs.file_ref }}/hdf4-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
+          wget -q https://github.com/HDFGroup/hdf4/releases/download/hdf-${{ inputs.file_ref }}/hdf-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
           tar zxf hdf4-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
 
       - name: List files for the space (Linux)

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Get published binary (Linux)
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-            name: tgz-ubuntu-2204-binary
+            name: tgz-ubuntu-2204_gcc-binary
             path: ${{ github.workspace }}
 
       - name: List files for the space (Linux)

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -1,0 +1,152 @@
+name: hdf4 Check Application Binary Interface (ABI)
+
+on:
+  workflow_call:
+    inputs:
+      use_tag:
+        description: 'Release version tag'
+        type: string
+        required: false
+        default: snapshot
+      use_environ:
+        description: 'Environment to locate files'
+        type: string
+        required: true
+        default: snapshots
+      file_base:
+        description: "The common base name of the binary"
+        required: true
+        type: string
+      file_ref:
+        description: "The reference name for the release binary"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt update
+          sudo apt install -q -y abi-compliance-checker abi-dumper
+          sudo apt install -q -y japi-compliance-checker
+
+      - name: Convert hdf4 reference name (Linux)
+        id: convert-hdf4lib-refname
+        run:  |
+          FILE_DOTS=$(echo "${{ inputs.file_ref }}" | sed -r "s/([0-9]+)\_([0-9]+)\_([0-9]+)\-([0-9]+).*/\1\.\2\.\3\-\4/")
+          echo "HDF4R_DOTS=$FILE_DOTS" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4.1.1
+
+      - name: Get published binary (Linux)
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        with:
+            name: tgz-ubuntu-2204_gcc-binary
+            path: ${{ github.workspace }}
+
+      - name: List files for the space (Linux)
+        run: |
+          ls -l ${{ github.workspace }}
+
+      - name: Uncompress gh binary (Linux)
+        run: tar -zxvf ${{ github.workspace }}/${{ inputs.file_base }}-ubuntu-2204_gcc.tar.gz
+
+      - name: Uncompress hdf4 binary (Linux)
+        run:  |
+          cd "${{ github.workspace }}/hdf4"
+          tar -zxvf ${{ github.workspace }}/hdf4/HDF-*-Linux.tar.gz --strip-components 1
+
+      - name: List files for the HDF space (Linux)
+        run: |
+          ls -l ${{ github.workspace }}/hdf4
+          ls -l ${{ github.workspace }}/hdf4/HDF_Group/HDF
+
+      - name: set hdf4lib name
+        id: set-hdf4lib-name
+        run: |
+          HDF4DIR=${{ github.workspace }}/hdf4/HDF_Group/HDF/
+          FILE_NAME_HDF4=$(ls ${{ github.workspace }}/hdf4/HDF_Group/HDF)
+          FILE_VERS=$(echo "$FILE_NAME_HDF4" | sed -r "s/([0-9]+\.[0-9]+\.[0-9]+\-[0-9]+)\..*/\1/")
+          echo "HDF4_ROOT=$HDF4DIR$FILE_NAME_HDF4" >> $GITHUB_OUTPUT
+          echo "HDF4_VERS=$FILE_VERS" >> $GITHUB_OUTPUT
+
+      - name: Download reference version
+        run: |
+          mkdir "${{ github.workspace }}/hdf4R"
+          cd "${{ github.workspace }}/hdf4R"
+          wget -q https://github.com/HDFGroup/hdf4/releases/download/hdf4-${{ inputs.file_ref }}/hdf4-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
+          tar zxf hdf4-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
+
+      - name: List files for the space (Linux)
+        run: |
+          ls -l ${{ github.workspace }}/hdf4R
+
+      - name: Uncompress hdf4 reference binary (Linux)
+        run:  |
+          cd "${{ github.workspace }}/hdf4R"
+          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/HDF-${{ steps.convert-hdf4lib-refname.outputs.HDF4R_DOTS }}-Linux.tar.gz --strip-components 1
+
+      - name: List files for the HDFR space (Linux)
+        run: |
+          ls -l ${{ github.workspace }}/hdf4R
+          ls -l ${{ github.workspace }}/hdf4R/HDF_Group/HDF
+
+      - name: set hdf4lib reference name
+        id: set-hdf4lib-refname
+        run: |
+          HDF4RDIR=${{ github.workspace }}/hdf4R/HDF_Group/HDF/
+          FILE_NAME_HDF4R=$(ls ${{ github.workspace }}/hdf4R/HDF_Group/HDF)
+          echo "HDF4R_ROOT=$HDF4RDIR$FILE_NAME_HDF4R" >> $GITHUB_OUTPUT
+          echo "HDF4R_VERS=$FILE_NAME_HDF4R" >> $GITHUB_OUTPUT
+
+      - name: List files for the lib spaces (Linux)
+        run: |
+          ls -l ${{ steps.set-hdf4lib-name.outputs.HDF4_ROOT }}/lib
+          ls -l ${{ steps.set-hdf4lib-refname.outputs.HDF4R_ROOT }}/lib
+
+      - name: Run Java API report
+        run: |
+          japi-compliance-checker ${{ steps.set-hdf4lib-refname.outputs.HDF5R_ROOT }}/lib/jarhdf4-${{ steps.convert-hdf4lib-refname.outputs.HDF4R_DOTS }}.jar ${{ steps.set-hdf4lib-name.outputs.HDF4_ROOT }}/lib/jarhdf4-${{ steps.set-hdf4lib-name.outputs.HDF4_VERS }}.jar
+
+      - name: Run hdf ABI report
+        run: |
+          abi-dumper ${{ steps.set-hdf4lib-refname.outputs.HDF4R_ROOT }}/lib/libhdf.so -o ABI-0.dump -public-headers ${{ steps.set-hdf4lib-refname.outputs.HDF4R_ROOT }}/include
+          abi-dumper ${{ steps.set-hdf4lib-name.outputs.HDF4_ROOT }}/lib/libhdf.so -o ABI-1.dump -public-headers ${{ steps.set-hdf4lib-name.outputs.HDF4_ROOT }}/include
+          abi-compliance-checker -l ${{ inputs.file_base }}-hdf -old ABI-0.dump -new ABI-1.dump
+        continue-on-error: true
+
+      - name: Run mfhdf ABI report
+        run: |
+          abi-dumper ${{ steps.set-hdf4lib-refname.outputs.HDF4R_ROOT }}/lib/libmfhdf.so -o ABI-2.dump -public-headers ${{ steps.set-hdf4lib-refname.outputs.HDF4R_ROOT }}/include
+          abi-dumper ${{ steps.set-hdf4lib-name.outputs.HDF4_ROOT }}/lib/libmfhdf.so -o ABI-3.dump -public-headers ${{ steps.set-hdf4lib-name.outputs.HDF4_ROOT }}/include
+          abi-compliance-checker -l ${{ inputs.file_base }}-mfhdf -old ABI-2.dump -new ABI-3.dump
+        continue-on-error: true
+
+      - name: Copy ABI reports
+        run: |
+          cp compat_reports/jarhdf4-/${{ steps.set-hdf4lib-refname.outputs.HDF5R_VERS }}_to_${{ steps.set-hdf4lib-name.outputs.HDF4_VERS }}/compat_report.html ${{ inputs.file_base }}-java_compat_report.html
+          ls -l compat_reports/${{ inputs.file_base }}-hdf/X_to_Y
+          cp compat_reports/${{ inputs.file_base }}-hdf/X_to_Y/compat_report.html ${{ inputs.file_base }}-hdf_compat_report.html
+          ls -l compat_reports/${{ inputs.file_base }}-mfhdf/X_to_Y
+          cp compat_reports/${{ inputs.file_base }}-mfhdf/X_to_Y/compat_report.html ${{ inputs.file_base }}-mfhdf_compat_report.html
+
+      - name: List files for the report spaces (Linux)
+        run: |
+          ls -l compat_reports
+          ls -l *.html
+
+      - name: Save output as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: abi-reports
+          path: |
+            ${{ inputs.file_base }}-hdf_compat_report.html
+            ${{ inputs.file_base }}-mfhdf_compat_report.html
+            ${{ inputs.file_base }}-java_compat_report.html

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -56,7 +56,7 @@ jobs:
           ls -l ${{ github.workspace }}
 
       - name: Uncompress gh binary (Linux)
-        run: tar -zxvf ${{ github.workspace }}/${{ inputs.file_base }}-ubuntu-2204.tar.gz
+        run: tar -zxvf ${{ github.workspace }}/${{ inputs.file_base }}-ubuntu-2204_gcc.tar.gz
 
       - name: Uncompress hdf4 binary (Linux)
         run:  |

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -82,7 +82,7 @@ jobs:
           mkdir "${{ github.workspace }}/hdf4R"
           cd "${{ github.workspace }}/hdf4R"
           wget -q https://github.com/HDFGroup/hdf4/releases/download/hdf-${{ inputs.file_ref }}/hdf-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
-          tar zxf hdf4-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
+          tar zxf hdf-${{ inputs.file_ref }}-ubuntu-2204.tar.gz
 
       - name: List files for the space (Linux)
         run: |

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Uncompress hdf4 reference binary (Linux)
         run:  |
           cd "${{ github.workspace }}/hdf4R"
-          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/HDF-${{ steps.convert-hdf4lib-refname.outputs.HDF4R_DOTS }}-Linux.tar.gz --strip-components 1
+          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/hdf-${{ steps.convert-hdf4lib-refname.outputs.HDF4R_DOTS }}-Linux.tar.gz --strip-components 1
 
       - name: List files for the HDFR space (Linux)
         run: |

--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Uncompress hdf4 reference binary (Linux)
         run:  |
           cd "${{ github.workspace }}/hdf4R"
-          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/hdf-${{ steps.convert-hdf4lib-refname.outputs.HDF4R_DOTS }}-Linux.tar.gz --strip-components 1
+          tar -zxvf ${{ github.workspace }}/hdf4R/hdf4/hdf-${{ inputs.file_ref }}-Linux.tar.gz --strip-components 1
 
       - name: List files for the HDFR space (Linux)
         run: |

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.1.1
     - name: Run clang-format style check for C and Java code
       uses: DoozyX/clang-format-lint-action@v0.13
       with:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
       - uses: codespell-project/actions-codespell@master
         with:
           skip: ./config/sanitizer/sanitizers.cmake,./hdf/util/testfiles/*.raw,./hdf/util/testfiles/head.r8,./mfhdf/ncdump/*,./mfhdf/ncgen/*,./mfhdf/nctest/*,./mfhdf/README,./mfhdf/THANKS,./mfhdf/FAQ

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -28,8 +28,18 @@ jobs:
       #use_environ: snapshots
     if: ${{ needs.call-workflow-tarball.outputs.has_changes == 'true' }}
 
-  call-workflow-release:
+  call-workflow-abi:
     needs: [call-workflow-tarball, call-workflow-ctest]
+    uses: ./.github/workflows/abi-report.yml
+    with:
+      file_ref: '4_2_16-2'
+      file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
+      use_tag: snapshot
+      use_environ: snapshots
+    if: ${{ needs.call-workflow-tarball.outputs.has_changes == 'true' }}
+
+  call-workflow-release:
+    needs: [call-workflow-tarball, call-workflow-ctest, call-workflow-abi]
     permissions:
       contents: write # In order to allow tag creation
     uses: ./.github/workflows/release-files.yml

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -28,18 +28,19 @@ jobs:
       #use_environ: snapshots
     if: ${{ needs.call-workflow-tarball.outputs.has_changes == 'true' }}
 
-  call-workflow-abi:
-    needs: [call-workflow-tarball, call-workflow-ctest]
-    uses: ./.github/workflows/abi-report.yml
-    with:
-      file_ref: '4_2_16-2'
-      file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
-      use_tag: snapshot
-      use_environ: snapshots
-    if: ${{ needs.call-workflow-tarball.outputs.has_changes == 'true' }}
+#  call-workflow-abi:
+#    needs: [call-workflow-tarball, call-workflow-ctest]
+#    uses: ./.github/workflows/abi-report.yml
+#    with:
+#      file_ref: '4_3_0-1'
+#      file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
+#      use_tag: snapshot
+#      use_environ: snapshots
+#    if: ${{ needs.call-workflow-tarball.outputs.has_changes == 'true' }}
 
   call-workflow-release:
-    needs: [call-workflow-tarball, call-workflow-ctest, call-workflow-abi]
+#    needs: [call-workflow-tarball, call-workflow-ctest, call-workflow-abi]
+    needs: [call-workflow-tarball, call-workflow-ctest]
     permissions:
       contents: write # In order to allow tag creation
     uses: ./.github/workflows/release-files.yml

--- a/.github/workflows/intel-auto.yml
+++ b/.github/workflows/intel-auto.yml
@@ -16,7 +16,7 @@ jobs:
     name: "Intel ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/intel-cmake.yml
+++ b/.github/workflows/intel-cmake.yml
@@ -19,7 +19,7 @@ jobs:
     name: "ubuntu-oneapi ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       # Only CMake need ninja-build, but we just install it unilaterally
       # libssl, etc. are needed for the ros3 VFD
@@ -80,7 +80,7 @@ jobs:
     name: "windows-oneapi ${{ inputs.build_mode }}"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: Install Dependencies (Windows)
         run: choco install ninja

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -145,7 +145,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       #
       # CMAKE CONFIGURE

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -126,11 +126,11 @@ jobs:
               name: tgz-ubuntu-2204_intel-binary
               path: ${{ github.workspace }}
 
-      - name: Get published abi reports (Linux)
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-        with:
-              name: abi-reports
-              path: ${{ github.workspace }}
+#      - name: Get published abi reports (Linux)
+#        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+#        with:
+#              name: abi-reports
+#              path: ${{ github.workspace }}
 
       - name: Store snapshot name
         run: |

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -126,6 +126,12 @@ jobs:
               name: tgz-ubuntu-2204_intel-binary
               path: ${{ github.workspace }}
 
+      - name: Get published abi reports (Linux)
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        with:
+              name: abi-reports
+              path: ${{ github.workspace }}
+
       - name: Store snapshot name
         run: |
           echo "${{ steps.get-file-base.outputs.FILE_BASE }}" > ./last-file.txt
@@ -139,6 +145,9 @@ jobs:
           prerelease: true
           files: |
               last-file.txt
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-hdf_compat_report.html
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-mfhdf_compat_report.html
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-java_compat_report.html
               ${{ steps.get-file-base.outputs.FILE_BASE }}.doxygen.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip
@@ -158,6 +167,9 @@ jobs:
           prerelease: false
           #body_path: ${{ github.workspace }}-CHANGELOG.txt
           files: |
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-hdf_compat_report.html
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-mfhdf_compat_report.html
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-java_compat_report.html
               ${{ steps.get-file-base.outputs.FILE_BASE }}.doxygen.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -145,9 +145,6 @@ jobs:
           prerelease: true
           files: |
               last-file.txt
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-hdf_compat_report.html
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-mfhdf_compat_report.html
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-java_compat_report.html
               ${{ steps.get-file-base.outputs.FILE_BASE }}.doxygen.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip
@@ -157,6 +154,9 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2204_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
+#              ${{ steps.get-file-base.outputs.FILE_BASE }}-hdf_compat_report.html
+#              ${{ steps.get-file-base.outputs.FILE_BASE }}-mfhdf_compat_report.html
+#              ${{ steps.get-file-base.outputs.FILE_BASE }}-java_compat_report.html
 
       - name: Release tag
         id: create_release
@@ -167,9 +167,6 @@ jobs:
           prerelease: false
           #body_path: ${{ github.workspace }}-CHANGELOG.txt
           files: |
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-hdf_compat_report.html
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-mfhdf_compat_report.html
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-java_compat_report.html
               ${{ steps.get-file-base.outputs.FILE_BASE }}.doxygen.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip
@@ -179,6 +176,9 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2204_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
+#              ${{ steps.get-file-base.outputs.FILE_BASE }}-hdf_compat_report.html
+#              ${{ steps.get-file-base.outputs.FILE_BASE }}-mfhdf_compat_report.html
+#              ${{ steps.get-file-base.outputs.FILE_BASE }}-java_compat_report.html
 
       - name: List files for the space (Linux)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,18 +86,18 @@ jobs:
       file_base: ${{ needs.create-files-ctest.outputs.file_base }}
       preset_name: ci-StdShar
 
-  call-workflow-abi:
-    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest]
-    uses: ./.github/workflows/abi-report.yml
-    with:
-      file_ref: '4_2_16-2'
-      file_base: ${{ needs.create-files-ctest.outputs.file_base }}
-      use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
-      use_environ: release
+#  call-workflow-abi:
+#    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest]
+#    uses: ./.github/workflows/abi-report.yml
+#    with:
+#      file_ref: '4_2_16-2'
+#      file_base: ${{ needs.create-files-ctest.outputs.file_base }}
+#      use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
+#      use_environ: release
 
   call-workflow-release:
-    #needs: [call-workflow-tarball, call-workflow-ctest]
-    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest, call-workflow-abi]
+#    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest, call-workflow-abi]
+    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest]
     permissions:
       contents: write # In order to allow tag creation
     uses: ./.github/workflows/release-files.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           path: hdfsrc
 
@@ -86,9 +86,18 @@ jobs:
       file_base: ${{ needs.create-files-ctest.outputs.file_base }}
       preset_name: ci-StdShar
 
+  call-workflow-abi:
+    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest]
+    uses: ./.github/workflows/abi-report.yml
+    with:
+      file_ref: '4_2_16-2'
+      file_base: ${{ needs.create-files-ctest.outputs.file_base }}
+      use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
+      use_environ: release
+
   call-workflow-release:
     #needs: [call-workflow-tarball, call-workflow-ctest]
-    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest]
+    needs: [log-the-inputs, create-files-ctest, call-workflow-ctest, call-workflow-abi]
     permissions:
       contents: write # In order to allow tag creation
     uses: ./.github/workflows/release-files.yml

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           path: hdfsrc
 


### PR DESCRIPTION
The reports cannot be generated until after the 4.3.0 release because there are no GH binary releases for the previous release.