### PR TITLE
Removes remnants of FNAME scheme

### DIFF
--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -163,8 +163,6 @@ typedef int intf;
 /* Integer that is the same size as a pointer */
 typedef intptr_t hdf_pint_t;
 
-#define FNAME_POST_UNDERSCORE
-
 /*-----------------------------------------------------*/
 /*              encode and decode macros               */
 /*-----------------------------------------------------*/
@@ -287,27 +285,6 @@ typedef intptr_t hdf_pint_t;
 #ifndef FRETVAL    /* !MAC */
 #define FCALLKEYW  /*NONE*/
 #define FRETVAL(x) x
-#endif
-
-/*----------------------------------------------------------------
-** MACRO FNAME for any fortran callable routine name.
-**
-**  This macro prepends, appends, or does not modify a name
-**  passed as a macro parameter to it based on the FNAME_PRE_UNDERSCORE,
-**  FNAME_POST_UNDERSCORE macros set for a specific system.
-**
-**---------------------------------------------------------------*/
-#if defined(FNAME_PRE_UNDERSCORE) && defined(FNAME_POST_UNDERSCORE)
-#define FNAME(x) _##x##_
-#endif
-#if defined(FNAME_PRE_UNDERSCORE) && !defined(FNAME_POST_UNDERSCORE)
-#define FNAME(x) _##x
-#endif
-#if !defined(FNAME_PRE_UNDERSCORE) && defined(FNAME_POST_UNDERSCORE)
-#define FNAME(x) x##_
-#endif
-#if !defined(FNAME_PRE_UNDERSCORE) && !defined(FNAME_POST_UNDERSCORE)
-#define FNAME(x) x
 #endif
 
 /**************************************************************************

--- a/hdf/src/mfanf.c
+++ b/hdf/src/mfanf.c
@@ -58,13 +58,6 @@
   interface. They call the corresponding C-functions in "mfan.c"
 
   The basic routines called by fortran will be of the form afxxxx
-
-  If only a C stub is needed it will be named nafxxxx have the FNAME()
-  function applied to it.
-
-  If a Fortran stub is also required the fortran stub will be called
-  afxxxx(mfanff.f) and the one in here will be nacxxx and again be FNAME()ed
-
 -----------------------------------------------------------------------------*/
 
 /*-----------------------------------------------------------------------------

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -19,14 +19,6 @@
   the Vxxx interfaces.
 
   The basic routines called by fortran will be of the form vfxxx.
-
-  If only a C stub is needed it will be named nvfxxx and have the FNAME()
-  function applied to it. There are a few exceptions where C stub is
-  named for example ndfixxx or ndfxxx, oh well.
-
-  If a Fortran stub is also required the fortran stub will be called
-  vfxxx(vgff.f) and the one in here will be nvfxxxc and again be FNAME()ed
-
 -----------------------------------------------------------------------------*/
 
 /*

--- a/mfhdf/fortran/mfsdf.c
+++ b/mfhdf/fortran/mfsdf.c
@@ -17,13 +17,6 @@
   interface.
 
   The basic routines called by fortran will be of the form sfxxxx
-
-  If only a C stub is needed it will be named nsfxxxx have the FNAME()
-  function applied to it.
-
-  If a Fortran stub is also required the fortran stub will be called
-  sfxxxx and the one in here will be nscxxx and again be FNAME()ed
-
 */
 #include "mfsdf.h"
 


### PR DESCRIPTION
In the past, Fortran names were decorated using FNAME macros. This is no longer true and this PR removes the unused macros.

Removed from hdfi.h:

    * FNAME()
    * FNAME_POST_UNDERSCORE