### PR TITLE
Remove Fortran FRETVAL macros

### DIFF
--- a/hdf/src/df24f.c
+++ b/hdf/src/df24f.c
@@ -56,7 +56,7 @@ static int dimsset = 0;
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2reqil(intf *il)
 {
     return DFGRIreqil((intn)*il, (intn)IMAGE);
@@ -73,7 +73,7 @@ nd2reqil(intf *il)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2sdims(intf *xdim, intf *ydim)
 {
     dimsset = 1;
@@ -94,7 +94,7 @@ nd2sdims(intf *xdim, intf *ydim)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2igdim(_fcd filename, intf *pxdim, intf *pydim, intf *pil, intf *fnlen)
 {
     char *fn;
@@ -121,7 +121,7 @@ nd2igdim(_fcd filename, intf *pxdim, intf *pydim, intf *pil, intf *fnlen)
  * Remarks: space is assumed to be xdim * ydim * 3 bytes
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen)
 {
     char *fn;
@@ -148,7 +148,7 @@ nd2igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen)
  * Remarks: array image is assumed to be xdim * ydim * ncomps bytes
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen, intf *newfile)
 {
     char *fn;
@@ -176,7 +176,7 @@ nd2iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen, intf *n
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2setil(intf *il)
 {
     return DFGRIsetil((intn)*il, IMAGE);
@@ -192,7 +192,7 @@ nd2setil(intf *il)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2first(void)
 {
     return DFGRIrestart();
@@ -208,7 +208,7 @@ nd2first(void)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2lref(void)
 {
     return (intf)DFGRIlastref();
@@ -227,7 +227,7 @@ nd2lref(void)
  *          must be called.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2scomp(intf *scheme)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -251,7 +251,7 @@ nd2scomp(intf *scheme)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2sjpeg(intf *quality, intf *force_baseline)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -271,7 +271,7 @@ nd2sjpeg(intf *quality, intf *force_baseline)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndf24reqil(intf *il)
 {
     return DFGRIreqil((intn)*il, IMAGE);
@@ -288,7 +288,7 @@ ndf24reqil(intf *il)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndf24setdims(intf *xdim, intf *ydim)
 {
     dimsset = 1;
@@ -305,7 +305,7 @@ ndf24setdims(intf *xdim, intf *ydim)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndf24setil(intf *il)
 {
     return DFGRIsetil((intn)*il, IMAGE);
@@ -321,7 +321,7 @@ ndf24setil(intf *il)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndf24restart(void)
 {
     return DFGRIrestart();
@@ -340,7 +340,7 @@ ndf24restart(void)
  *          must be called.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndf24scompress(intf *scheme)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -364,7 +364,7 @@ ndf24scompress(intf *scheme)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndf24sjpeg(intf *quality, intf *force_baseline)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -386,7 +386,7 @@ ndf24sjpeg(intf *quality, intf *force_baseline)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2irref(_fcd filename, intf *ref, intf *fnlen)
 {
     char *fn;
@@ -411,7 +411,7 @@ nd2irref(_fcd filename, intf *ref, intf *fnlen)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd2inimg(_fcd filename, intf *fnlen)
 {
     char *fn;

--- a/hdf/src/dfanf.c
+++ b/hdf/src/dfanf.c
@@ -70,7 +70,7 @@
  * Invokes: DFSDIclear
  *-------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndaclear(void)
 {
     return DFANIclear();
@@ -88,7 +88,7 @@ ndaclear(void)
  * Invokes: DFANIgetannlen, HDf2cstring, DFIfreespace
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndaiganl(_fcd filename, intf *tag, intf *ref, intf *type, intf *fnlen)
 {
     char *fn;
@@ -117,7 +117,7 @@ ndaiganl(_fcd filename, intf *tag, intf *ref, intf *type, intf *fnlen)
  * Invokes: DFANIgetann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndaigann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *maxlen, intf *type, intf *fnlen)
 {
     char *fn;
@@ -147,7 +147,7 @@ ndaigann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *maxlen, int
  * Invokes: DFANIgetann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndaipann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *annlen, intf *type, intf *fnlen)
 {
     char *fn;
@@ -181,7 +181,7 @@ ndaipann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *annlen, int
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsize, intf *maxlen,
          intf *startpos, intf *fnlen)
 {
@@ -225,7 +225,7 @@ ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsiz
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndalref(void)
 {
     return (intf)DFANlastref();
@@ -242,7 +242,7 @@ ndalref(void)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfanlastref(void)
 {
     return (intf)DFANlastref();
@@ -263,7 +263,7 @@ ndfanlastref(void)
  * Invokes: DFANaddfileann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfanaddfds(intf *dfile, _fcd desc, intf *desclen)
 {
     return DFANIaddfann(*dfile, _fcdtocp(desc), *desclen, DFAN_DESC);
@@ -279,7 +279,7 @@ ndfanaddfds(intf *dfile, _fcd desc, intf *desclen)
  * Invokes: DFANIgetfannlen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfangetfidlen(intf *dfile, intf *isfirst)
 {
     return DFANIgetfannlen(*dfile, DFAN_LABEL, (intn)*isfirst);
@@ -295,7 +295,7 @@ ndfangetfidlen(intf *dfile, intf *isfirst)
  * Invokes: DFANIgetfannlen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfangetfdslen(intf *dfile, intf *isfirst)
 {
     return DFANIgetfannlen(*dfile, DFAN_DESC, (intn)*isfirst);
@@ -312,7 +312,7 @@ ndfangetfdslen(intf *dfile, intf *isfirst)
  * Invokes: DFANgetfann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfangetfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
     return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_LABEL, (intn)*isfirst);
@@ -329,7 +329,7 @@ ndfangetfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
  * Invokes: DFANgetfann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfangetfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
     return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_DESC, (intn)*isfirst);
@@ -350,7 +350,7 @@ ndfangetfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
  * Invokes: DFANaddfileann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndaafds(intf *dfile, _fcd desc, intf *desclen)
 {
     return DFANIaddfann(*dfile, _fcdtocp(desc), *desclen, DFAN_DESC);
@@ -366,7 +366,7 @@ ndaafds(intf *dfile, _fcd desc, intf *desclen)
  * Invokes: DFANIgetfannlen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndagfidl(intf *dfile, intf *isfirst)
 {
     return DFANIgetfannlen(*dfile, DFAN_LABEL, (intn)*isfirst);
@@ -382,7 +382,7 @@ ndagfidl(intf *dfile, intf *isfirst)
  * Invokes: DFANIgetfannlen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndagfdsl(intf *dfile, intf *isfirst)
 {
     return DFANIgetfannlen(*dfile, DFAN_DESC, (intn)*isfirst);
@@ -399,7 +399,7 @@ ndagfdsl(intf *dfile, intf *isfirst)
  * Invokes: DFANIgetfann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndagfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
     return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_LABEL, (intn)*isfirst);
@@ -417,7 +417,7 @@ ndagfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
  * Invokes: DFANgetfann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndagfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
 {
     return DFANIgetfann(*dfile, _fcdtocp(id), *maxlen, DFAN_DESC, (intn)*isfirst);
@@ -438,7 +438,7 @@ ndagfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst)
  * Invokes: DFANaddfann
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndaiafid(intf *dfile, _fcd id, intf *idlen)
 {
     return DFANIaddfann(*dfile, _fcdtocp(id), *idlen, DFAN_LABEL);

--- a/hdf/src/dff.c
+++ b/hdf/src/dff.c
@@ -56,7 +56,7 @@
  *       This is a design error and has no easy portable solution.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 {
     char *fn;
@@ -78,7 +78,7 @@ ndfiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
  * Invokes: DFclose
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfclose(intf *dfile)
 {
     return DFclose((DF *)*dfile);
@@ -94,7 +94,7 @@ ndfclose(intf *dfile)
  * Invokes: DFdesc
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfdesc(intf *dfile, intf ptr[][4], intf *begin, intf *num)
 {
     DFdesc *ptr1;
@@ -131,7 +131,7 @@ ndfdesc(intf *dfile, intf ptr[][4], intf *begin, intf *num)
  * Invokes: DFdup
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfdup(intf *dfile, intf *tag, intf *ref, intf *otag, intf *oref)
 {
     return DFdup((DF *)*dfile, (uint16)*tag, (uint16)*ref, (uint16)*otag, (uint16)*oref);
@@ -147,7 +147,7 @@ ndfdup(intf *dfile, intf *tag, intf *ref, intf *otag, intf *oref)
  * Invokes: DFdel
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfdel(intf *dfile, intf *tag, intf *ref)
 {
     return DFdel((DF *)*dfile, (uint16)*tag, (uint16)*ref);
@@ -164,7 +164,7 @@ ndfdel(intf *dfile, intf *tag, intf *ref)
  * Invokes: DFaccess
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfiaccess(intf *dfile, intf *tag, intf *ref, _fcd acc_mode, intf *acclen)
 {
     char *acc;
@@ -187,7 +187,7 @@ ndfiaccess(intf *dfile, intf *tag, intf *ref, _fcd acc_mode, intf *acclen)
  * Invokes: DFread
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfread(intf *dfile, _fcd ptr, intf *len)
 {
     return DFread((DF *)*dfile, (char *)_fcdtocp(ptr), *len);
@@ -203,7 +203,7 @@ ndfread(intf *dfile, _fcd ptr, intf *len)
  * Invokes: DFseek
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfseek(intf *dfile, intf *offset)
 {
     return DFseek((DF *)*dfile, *offset);
@@ -220,7 +220,7 @@ ndfseek(intf *dfile, intf *offset)
  * Invokes: DFwrite
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfwrite(intf *dfile, _fcd ptr, intf *len)
 {
     return DFwrite((DF *)*dfile, (char *)_fcdtocp(ptr), *len);
@@ -235,7 +235,7 @@ ndfwrite(intf *dfile, _fcd ptr, intf *len)
  * Invokes: DFupdate
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfupdate(intf *dfile)
 {
     return DFupdate((DF *)*dfile);
@@ -252,7 +252,7 @@ ndfupdate(intf *dfile)
  * Invokes: DFgetelement
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfget(intf *dfile, intf *tag, intf *ref, _fcd ptr)
 {
     return DFgetelement((DF *)*dfile, (uint16)*tag, (uint16)*ref, (char *)_fcdtocp(ptr));
@@ -270,7 +270,7 @@ ndfget(intf *dfile, intf *tag, intf *ref, _fcd ptr)
  * Invokes: DFputelement
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfput(intf *dfile, intf *tag, intf *ref, _fcd ptr, intf *len)
 {
     return DFputelement((DF *)*dfile, (uint16)*tag, (uint16)*ref, (char *)_fcdtocp(ptr), *len);
@@ -286,7 +286,7 @@ ndfput(intf *dfile, intf *tag, intf *ref, _fcd ptr, intf *len)
  * Invokes: DFsetfind
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsfind(intf *dfile, intf *tag, intf *ref)
 {
     return DFsetfind((DF *)*dfile, (uint16)*tag, (uint16)*ref);
@@ -303,7 +303,7 @@ ndfsfind(intf *dfile, intf *tag, intf *ref)
  * Invokes: DFfind
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndffind(intf *dfile, intf *itag, intf *iref, intf *len)
 {
     DFdesc *ptr1;
@@ -332,7 +332,7 @@ ndffind(intf *dfile, intf *itag, intf *iref, intf *len)
  * Invokes: DFerrno
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndferrno(void)
 {
     return DFerrno();
@@ -347,7 +347,7 @@ ndferrno(void)
  * Invokes: DFnewref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfnewref(intf *dfile)
 {
     return (intf)DFnewref((DF *)*dfile);
@@ -363,7 +363,7 @@ ndfnewref(intf *dfile)
  * Invokes: DFnumber
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfnumber(intf *dfile, intf *tag)
 {
     return DFnumber((DF *)*dfile, (uint16)*tag);
@@ -379,7 +379,7 @@ ndfnumber(intf *dfile, intf *tag)
  * Invokes: DFstat
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfstat(intf *dfile, DFdata *dfinfo)
 {
     return DFstat((DF *)*dfile, dfinfo);
@@ -395,7 +395,7 @@ ndfstat(intf *dfile, DFdata *dfinfo)
  * Invokes: DFishdf
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfiishdf(_fcd name, intf *namelen)
 {
     char *fn;

--- a/hdf/src/dfpf.c
+++ b/hdf/src/dfpf.c
@@ -41,7 +41,7 @@
  * Invokes: DFPgetpal
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndpigpal(_fcd filename, _fcd pal, intf *fnlen)
 {
     char *fn;
@@ -72,7 +72,7 @@ ndpigpal(_fcd filename, _fcd pal, intf *fnlen)
  *          call
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndpippal(_fcd filename, _fcd pal, intf *overwrite, _fcd filemode, intf *fnlen)
 {
     char *fn;
@@ -95,7 +95,7 @@ ndpippal(_fcd filename, _fcd pal, intf *overwrite, _fcd filemode, intf *fnlen)
  * Invokes: DFPnpals
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndpinpal(_fcd filename, intf *fnlen)
 {
     char *fn;
@@ -120,7 +120,7 @@ ndpinpal(_fcd filename, intf *fnlen)
  * Remarks: checks if palette with this ref exists
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndpirref(_fcd filename, intf *ref, intf *fnlen)
 {
     char *fn;
@@ -145,7 +145,7 @@ ndpirref(_fcd filename, intf *ref, intf *fnlen)
  * Invokes: DFPwriteref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndpiwref(_fcd filename, intf *ref, intf *fnlen)
 {
 
@@ -169,7 +169,7 @@ ndpiwref(_fcd filename, intf *ref, intf *fnlen)
  * Remarks: Invokes DFPrestart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndprest(void)
 {
     return DFPrestart();
@@ -186,7 +186,7 @@ ndprest(void)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndplref(void)
 {
     return (intf)DFPlastref();
@@ -201,7 +201,7 @@ ndplref(void)
  * Remarks: Invokes DFPrestart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfprestart(void)
 {
     return DFPrestart();
@@ -218,7 +218,7 @@ ndfprestart(void)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfplastref(void)
 {
     return (intf)DFPlastref();

--- a/hdf/src/dfr8f.c
+++ b/hdf/src/dfr8f.c
@@ -44,7 +44,7 @@
  * Invokes: DFR8setpalette
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8spal(_fcd pal)
 {
     return DFR8setpalette((uint8 *)_fcdtocp(pal));
@@ -59,7 +59,7 @@ nd8spal(_fcd pal)
  * Invokes: DFR8restart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8first(void)
 {
     return DFR8restart();
@@ -77,7 +77,7 @@ nd8first(void)
  * Invokes: DFR8getdims
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8igdim(_fcd filename, intf *xdim, intf *ydim, intf *ispal, intf *lenfn)
 {
     char *fn;
@@ -111,7 +111,7 @@ nd8igdim(_fcd filename, intf *xdim, intf *ydim, intf *ispal, intf *lenfn)
  * Invokes: DFR8getimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, _fcd pal, intf *lenfn)
 {
     char *fn;
@@ -138,7 +138,7 @@ nd8igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, _fcd pal, intf *lenf
  * Invokes: DFR8putimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8ipimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf *lenfn)
 {
     char *fn;
@@ -165,7 +165,7 @@ nd8ipimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf
  * Invokes: DFR8addimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf *lenfn)
 {
     char *fn;
@@ -190,7 +190,7 @@ nd8iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf
  * Remarks: checks if image with this ref exists
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8irref(_fcd filename, intf *ref, intf *fnlen)
 {
     char  *fn;
@@ -218,7 +218,7 @@ nd8irref(_fcd filename, intf *ref, intf *fnlen)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8iwref(_fcd filename, intf *ref, intf *fnlen)
 {
     char  *fn;
@@ -246,7 +246,7 @@ nd8iwref(_fcd filename, intf *ref, intf *fnlen)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8inims(_fcd filename, intf *fnlen)
 {
     char *fn;
@@ -269,7 +269,7 @@ nd8inims(_fcd filename, intf *fnlen)
  * Invokes: DFR8lastref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8lref(void)
 {
     return (intf)DFR8lastref();
@@ -288,7 +288,7 @@ nd8lref(void)
  *          must be called.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8scomp(intf *scheme)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -312,7 +312,7 @@ nd8scomp(intf *scheme)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nd8sjpeg(intf *quality, intf *force_baseline)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -332,7 +332,7 @@ nd8sjpeg(intf *quality, intf *force_baseline)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfr8lastref(void)
 {
     return (intf)DFR8lastref();
@@ -347,7 +347,7 @@ ndfr8lastref(void)
  * Invokes: DFR8setpalette
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfr8setpalette(_fcd pal)
 {
     return DFR8setpalette((uint8 *)_fcdtocp(pal));
@@ -362,7 +362,7 @@ ndfr8setpalette(_fcd pal)
  * Invokes: DFR8restart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfr8restart(void)
 {
     return DFR8restart();
@@ -381,7 +381,7 @@ ndfr8restart(void)
  *          must be called.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfr8scompress(intf *scheme)
 {
     comp_info cinfo; /* Structure containing compression parameters */
@@ -405,7 +405,7 @@ ndfr8scompress(intf *scheme)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfr8sjpeg(intf *quality, intf *force_baseline)
 {
     comp_info cinfo; /* Structure containing compression parameters */

--- a/hdf/src/dfsdf.c
+++ b/hdf/src/dfsdf.c
@@ -83,7 +83,7 @@
  * Invokes: DFSDgetdimscale
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgdisc(intf *dim, intf *maxsize, void *scale)
 {
     intn rank, cdim;
@@ -112,7 +112,7 @@ ndsgdisc(intf *dim, intf *maxsize, void *scale)
  * Invokes: DFSDgetrange
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgrang(void *pmax, void *pmin)
 {
     return DFSDgetrange(pmax, pmin);
@@ -128,7 +128,7 @@ ndsgrang(void *pmax, void *pmin)
  * Invokes: DFSDsetdims
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndssdims(intf *rank, intf dimsizes[])
 {
     int32 i, *cdims, *p;
@@ -159,7 +159,7 @@ ndssdims(intf *rank, intf dimsizes[])
  * Invokes: DFSDsetdimscale
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndssdisc(intf *dim, intf *dimsize, void *scale)
 {
     int  cdim;
@@ -183,7 +183,7 @@ ndssdisc(intf *dim, intf *dimsize, void *scale)
  * Remarks: Max and Min are set only for next SDG, reset to NULL after
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndssrang(void *max, void *min)
 {
     return DFSDsetrange(max, min);
@@ -198,7 +198,7 @@ ndssrang(void *max, void *min)
  * Invokes: DFSDclear
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsclear(void)
 {
     return DFSDclear();
@@ -213,7 +213,7 @@ ndsclear(void)
  * Invokes: DFSDsetlengths
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsslens(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf *maxlen_coordsys)
 {
     return (DFSDsetlengths((intn)*maxlen_label, (intn)*maxlen_unit, (intn)*maxlen_format,
@@ -230,7 +230,7 @@ ndsslens(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf *maxle
  * Invokes: DFSDgetdimlen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgdiln(intf *dim, intf *llabel, intf *lunit, intf *lformat)
 {
     intn rank, cdim;
@@ -266,7 +266,7 @@ ndsgdiln(intf *dim, intf *llabel, intf *lunit, intf *lformat)
  * Invokes: DFSDgetdatalen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgdaln(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
 {
     intf ret;
@@ -290,7 +290,7 @@ ndsgdaln(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
  * Invokes: DFSDrestart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsfirst(void)
 {
 
@@ -308,7 +308,7 @@ ndsfirst(void)
  * Invokes: DFSDIputslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndspslc(intf windims[], void *data, intf dims[])
 {
     int32 *cdims, *cwindims, *p, *wp;
@@ -348,7 +348,7 @@ ndspslc(intf windims[], void *data, intf dims[])
  * Invokes: DFSDIendslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndseslc(void)
 {
 
@@ -366,7 +366,7 @@ ndseslc(void)
  * Remarks: 0 specifies default value
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndssnt(intf *numbertype)
 {
     return DFSDsetNT(*numbertype);
@@ -382,7 +382,7 @@ ndssnt(intf *numbertype)
  * Remarks: 0 specifies default value
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgnt(intf *pnumbertype)
 {
     return DFSDgetNT((int32 *)pnumbertype);
@@ -401,7 +401,7 @@ ndsgnt(intf *pnumbertype)
  * Invokes: DFSDgetdims
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsigdim(_fcd filename, intf *prank, intf sizes[], intf *maxrank, intf *lenfn)
 {
     char *fn;
@@ -437,7 +437,7 @@ ndsigdim(_fcd filename, intf *prank, intf sizes[], intf *maxrank, intf *lenfn)
  * Invokes: DFSDIgetdata,DFSDIrefresh,DFSDIisndg
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsigdat(_fcd filename, intf *rank, intf maxsizes[], void *data, intf *fnlen)
 {
     int32  i;
@@ -486,7 +486,7 @@ ndsigdat(_fcd filename, intf *rank, intf maxsizes[], void *data, intf *fnlen)
  * Invokes: DFSDIputdata
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsipdat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
 {
     char *fn;
@@ -528,7 +528,7 @@ ndsipdat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
  * Invokes: DFSDIputdata
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsiadat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
 {
     char *fn;
@@ -571,7 +571,7 @@ ndsiadat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen)
  * Invokes: DFSDIgetslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsigslc(_fcd filename, intf winst[], intf windims[], void *data, intf dims[], intf *fnlen)
 {
     char  *fn;
@@ -634,7 +634,7 @@ ndsigslc(_fcd filename, intf winst[], intf windims[], void *data, intf dims[], i
  * Invokes: DFSDstartslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsisslc(_fcd filename, intf *fnlen)
 {
     char *fn;
@@ -659,7 +659,7 @@ ndsisslc(_fcd filename, intf *fnlen)
  * Invokes: DFSDstartslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsirref(_fcd filename, intf *ref, intf *fnlen)
 {
     char *fn;
@@ -684,7 +684,7 @@ ndsirref(_fcd filename, intf *ref, intf *fnlen)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndslref(void)
 {
     return (intf)DFSDlastref();
@@ -701,7 +701,7 @@ ndslref(void)
  * Method:  convert string, call DFSDndatasets
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsinum(_fcd filename, intf *len)
 {
     char *cname;
@@ -729,7 +729,7 @@ ndsinum(_fcd filename, intf *len)
  * Users:    HDF Fortran programmers
  *------------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsip32s(_fcd filename, intf *ref, intf *ispre32, intf *len)
 {
     char *cname;
@@ -753,7 +753,7 @@ ndsip32s(_fcd filename, intf *ref, intf *ispre32, intf *len)
  * Invokes: DFSDgetdatastrs
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetdatastrs(_fcd label, _fcd unit, _fcd format, _fcd coordsys)
 {
     return (DFSDgetdatastrs((char *)_fcdtocp(label), (char *)_fcdtocp(unit), (char *)_fcdtocp(format),
@@ -769,7 +769,7 @@ ndfsdgetdatastrs(_fcd label, _fcd unit, _fcd format, _fcd coordsys)
  * Invokes: DFSDgetdimstrs
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format)
 {
     intn isndg;
@@ -799,7 +799,7 @@ ndfsdgetdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format)
  * Invokes: DFSDgetdimscale
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetdimscale(intf *dim, intf *maxsize, void *scale)
 {
 
@@ -829,7 +829,7 @@ ndfsdgetdimscale(intf *dim, intf *maxsize, void *scale)
  * Invokes: DFSDgetrange
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetrange(void *pmax, void *pmin)
 {
     return DFSDgetrange(pmax, pmin);
@@ -845,7 +845,7 @@ ndfsdgetrange(void *pmax, void *pmin)
  * Invokes: DFSDsetdims
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdsetdims(intf *rank, intf dimsizes[])
 {
 
@@ -877,7 +877,7 @@ ndfsdsetdims(intf *rank, intf dimsizes[])
  * Invokes: DFSDsetdimscale
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdsetdimscale(intf *dim, intf *dimsize, void *scale)
 {
     intn rank, cdim;
@@ -900,7 +900,7 @@ ndfsdsetdimscale(intf *dim, intf *dimsize, void *scale)
  * Remarks: Max and Min are set only for next SDG, reset to NULL after
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdsetrange(void *max, void *min)
 {
     return DFSDsetrange(max, min);
@@ -915,7 +915,7 @@ ndfsdsetrange(void *max, void *min)
  * Invokes: DFSDclear
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdclear(void)
 {
     return DFSDclear();
@@ -930,7 +930,7 @@ ndfsdclear(void)
  * Invokes: DFSDsetlengths
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdsetlengths(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf *maxlen_coordsys)
 {
     return (DFSDsetlengths((intn)*maxlen_label, (intn)*maxlen_unit, (intn)*maxlen_format,
@@ -947,7 +947,7 @@ ndfsdsetlengths(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf
  * Invokes: DFSDgetdimlen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetdimlen(intf *dim, intf *llabel, intf *lunit, intf *lformat)
 {
     intn isndg;
@@ -983,7 +983,7 @@ ndfsdgetdimlen(intf *dim, intf *llabel, intf *lunit, intf *lformat)
  * Invokes: DFSDgetdatalen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetdatalen(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
 {
     intf ret;
@@ -1008,7 +1008,7 @@ ndfsdgetdatalen(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys)
  * Invokes: DFSDrestart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdrestart(void)
 {
     return DFSDrestart();
@@ -1026,7 +1026,7 @@ ndfsdrestart(void)
  * Invokes: DFSDIputslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdputslice(intf windims[], void *data, intf dims[])
 {
     intn   rank, i;
@@ -1064,7 +1064,7 @@ ndfsdputslice(intf windims[], void *data, intf dims[])
  * Invokes: DFSDIendslice
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdendslice(void)
 {
     return DFSDIendslice(1);
@@ -1081,7 +1081,7 @@ ndfsdendslice(void)
  * Remarks: 0 specifies default value
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdsetnt(intf *numbertype)
 {
     return DFSDsetNT(*numbertype);
@@ -1097,7 +1097,7 @@ ndfsdsetnt(intf *numbertype)
  * Remarks: 0 specifies default value
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdgetnt(intf *pnumbertype)
 {
     return DFSDgetNT((int32 *)pnumbertype);
@@ -1114,7 +1114,7 @@ ndfsdgetnt(intf *pnumbertype)
  * Remarks: none
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfsdlastref(void)
 {
     return (intf)DFSDlastref();
@@ -1137,7 +1137,7 @@ ndfsdlastref(void)
  * Method:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsisdis(intf *dim, _fcd flabel, _fcd funit, _fcd fformat, intf *llabel, intf *lunit, intf *lformat)
 {
     char *label  = HDf2cstring(flabel, (intn)*llabel);
@@ -1176,7 +1176,7 @@ ndsisdis(intf *dim, _fcd flabel, _fcd funit, _fcd fformat, intf *llabel, intf *l
  * Invokes: DFSDgetdimstrs
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsigdis(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *lunit, intf *lformat)
 {
     char *ilabel, *iunit, *iformat;
@@ -1229,7 +1229,7 @@ ndsigdis(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *luni
  * Method:  Stores values in global structure Writesdg
  * Remarks:
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 ndsisdas(_fcd flabel, _fcd funit, _fcd fformat, _fcd fcoordsys, intf *isfortran, intf *llabel, intf *lunit,
          intf *lformat, intf *lcoordsys)
 {
@@ -1267,7 +1267,7 @@ ndsisdas(_fcd flabel, _fcd funit, _fcd fformat, _fcd fcoordsys, intf *isfortran,
  * Invokes: DFSDgetdatastrs
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsigdas(_fcd label, _fcd unit, _fcd format, _fcd coordsys, intf *llabel, intf *lunit, intf *lformat,
          intf *lcoord)
 {
@@ -1310,7 +1310,7 @@ ndsigdas(_fcd label, _fcd unit, _fcd format, _fcd coordsys, intf *llabel, intf *
  * Users:   HDF Fortran programmers
  * Invokes: DFSDgetdatastrs
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 ndsscal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *cal_type)
 {
     intf    ret;
@@ -1340,7 +1340,7 @@ ndsscal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *
  * Invokes: DFSDgetcal
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgcal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *cal_type)
 {
     intf    ret;
@@ -1370,7 +1370,7 @@ ndsgcal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *
  * Invokes: DFSDwriteref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsiwref(_fcd filename, intf *fnlen, intf *ref)
 {
     char *fn;
@@ -1393,7 +1393,7 @@ ndsiwref(_fcd filename, intf *fnlen, intf *ref)
  * Invokes: DFSDsetfillvalue
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndssfill(void *fill_value)
 {
     return DFSDsetfillvalue(fill_value);
@@ -1408,7 +1408,7 @@ ndssfill(void *fill_value)
  * Invokes: DFSDgetfillvalue
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsgfill(void *fill_value)
 {
     return DFSDgetfillvalue(fill_value);
@@ -1425,7 +1425,7 @@ ndsgfill(void *fill_value)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsisslab(_fcd filename, intf *fnlen)
 {
     char *fn;
@@ -1451,7 +1451,7 @@ ndsisslab(_fcd filename, intf *fnlen)
  * Invokes: DFSDIgetwrank, malloc, free, HDf2cstring, DFSDwriteslab
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndswslab(intf start[], intf stride[], intf count[], void *data)
 {
     int32 *lstart, *lstride, *lcount, *aptr, *bptr, *cptr;
@@ -1499,7 +1499,7 @@ ndswslab(intf start[], intf stride[], intf count[], void *data)
  * Remarks:
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndseslab(void)
 {
     return DFSDendslab();
@@ -1520,7 +1520,7 @@ ndseslab(void)
  * Invokes: DFSDreadslab
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndsirslab(_fcd filename, intf *fnlen, intf start[], intf slab_size[], intf stride[], void *buffer,
           intf buffer_size[])
 {

--- a/hdf/src/dfufp2if.c
+++ b/hdf/src/dfufp2if.c
@@ -24,7 +24,7 @@
  * Invokes: DFUfptoimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(int)
+int
 nduif2i(int32 *hdim, int32 *vdim, float32 *max, float32 *min, float32 hscale[], float32 vscale[],
         float32 data[], _fcd palette, _fcd outfile, int *ct_method, int32 *hres, int32 *vres, int *compress,
         int *lenfn)

--- a/hdf/src/dfutilf.c
+++ b/hdf/src/dfutilf.c
@@ -33,7 +33,7 @@
  * Invokes: DFfindnextref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfindnr(intf *dfile, intf *tag, intf *lref)
 {
     return (intf)DFfindnextref(*dfile, (uint16)*tag, (uint16)*lref);
@@ -55,7 +55,7 @@ ndfindnr(intf *dfile, intf *tag, intf *lref)
  * Invokes: DFfindnextref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndffindnextref(intf *dfile, intf *tag, intf *lref)
 {
     return (intf)DFfindnextref(*dfile, (uint16)*tag, (uint16)*lref);

--- a/hdf/src/hdfi.h
+++ b/hdf/src/hdfi.h
@@ -269,24 +269,6 @@ typedef intptr_t hdf_pint_t;
         p += n                                                                                               \
     }
 
-/*----------------------------------------------------------------
-** MACRO FCALLKEYW for any special fortran-C stub keyword
-**
-** Microsoft C and Fortran need __fortran for Fortran callable C
-**  routines.
-**
-** MACRO FRETVAL for any return value from a fortran-C stub function
-**  Replaces the older FCALLKEYW macro.
-**---------------------------------------------------------------*/
-#ifdef FRETVAL
-#undef FRETVAL
-#endif
-
-#ifndef FRETVAL    /* !MAC */
-#define FCALLKEYW  /*NONE*/
-#define FRETVAL(x) x
-#endif
-
 /**************************************************************************
  *  Generally useful macro definitions
  **************************************************************************/

--- a/hdf/src/herrf.c
+++ b/hdf/src/herrf.c
@@ -35,7 +35,7 @@
  *          Instead it prints automatically to stdout.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(VOID)
+void
 nheprnt(intf *print_levels)
 {
     HEprint(stderr, *print_levels);
@@ -52,7 +52,7 @@ nheprnt(intf *print_levels)
  *          Instead it prints automatically to stdout.
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nheprntc(_fcd filename, intf *print_levels, intf *namelen)
 {
     FILE *err_file;
@@ -82,7 +82,7 @@ nheprntc(_fcd filename, intf *print_levels, intf *namelen)
  * Outputs: error_message - error message assocoated with the error code
  * Returns: SUCCEED (0) if successful and FAIL(-1) otherwise
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nhestringc(intf *error_code, _fcd error_message, intf *len)
 {
     char *cstring = NULL;

--- a/hdf/src/hfilef.c
+++ b/hdf/src/hfilef.c
@@ -36,7 +36,7 @@
  * Method:  Convert filename to C string, call Hopen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 {
     char *fn;
@@ -59,7 +59,7 @@ nhiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
  * Invokes: Hclose
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhclose(intf *file_id)
 {
     return Hclose(*file_id);
@@ -74,7 +74,7 @@ nhclose(intf *file_id)
  * Invokes: Hnumber
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhnumber(intf *file_id, intf *tag)
 {
     return Hnumber((int32)*file_id, (uint16)*tag);
@@ -90,7 +90,7 @@ nhnumber(intf *file_id, intf *tag)
  * Method:  Convert dir to C string, call HXsetdir
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhxisdir(_fcd dir, intf *dirlen)
 {
     char *fn;
@@ -114,7 +114,7 @@ nhxisdir(_fcd dir, intf *dirlen)
  * Method:  Convert dir to C string, call HXsetcdir
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhxiscdir(_fcd dir, intf *dirlen)
 {
     char *fn;
@@ -137,7 +137,7 @@ nhxiscdir(_fcd dir, intf *dirlen)
  * Invokes: HDdont_atexit
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhddontatexit(void)
 {
     return (intf)(HDdont_atexit());
@@ -152,7 +152,7 @@ nhddontatexit(void)
  *          string  - version number text string
  * Returns: SUCCEED (0) if successful and FAIL(-1) otherwise
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nhglibverc(intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len)
 {
     char  *cstring;
@@ -186,7 +186,7 @@ nhglibverc(intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len)
  *          string  - version number text string
  * Returns: SUCCEED (0) if successful and FAIL(-1) otherwise
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nhgfilverc(intf *file_id, intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len)
 {
     char  *cstring;
@@ -220,7 +220,7 @@ nhgfilverc(intf *file_id, intf *major_v, intf *minor_v, intf *release, _fcd stri
  * Method:  Convert filename to C string, call Hishdf
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhiishdf(_fcd name, intf *namelen)
 {
     char *fn;
@@ -244,7 +244,7 @@ nhiishdf(_fcd name, intf *namelen)
  * Returns: SUCCEED (0)  on success, FALSE (-1) on failure
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhconfinfc(intf *coder_type, intf *info)
 {
     comp_coder_t coder_type_c;

--- a/hdf/src/hproto_fortran.h
+++ b/hdf/src/hproto_fortran.h
@@ -43,44 +43,44 @@ extern "C" {
 #define ndagfds        H4_F77_FUNC(dagfds, DAGFDS)
 #define ndaiafid       H4_F77_FUNC(daiafid, DAIAFID)
 
-HDFFCLIBAPI FRETVAL(intf) ndaiganl(_fcd filename, intf *tag, intf *ref, intf *type, intf *fnlen);
+HDFFCLIBAPI intf ndaiganl(_fcd filename, intf *tag, intf *ref, intf *type, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndaigann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *maxlen, intf *type, intf *fnlen);
+HDFFCLIBAPI intf ndaigann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *maxlen, intf *type,
+                          intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndaipann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *annlen, intf *type, intf *fnlen);
+HDFFCLIBAPI intf ndaipann(_fcd filename, intf *tag, intf *ref, _fcd annotation, intf *annlen, intf *type,
+                          intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsize,
-                                   intf *maxlen, intf *startpos, intf *fnlen);
+HDFFCLIBAPI intf ndailist(_fcd filename, intf *tag, intf reflist[], _fcd labellist, intf *listsize,
+                          intf *maxlen, intf *startpos, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndalref(void);
+HDFFCLIBAPI intf ndalref(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndaclear(void);
+HDFFCLIBAPI intf ndaclear(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfanlastref(void);
+HDFFCLIBAPI intf ndfanlastref(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfanaddfds(intf *dfile, _fcd desc, intf *desclen);
+HDFFCLIBAPI intf ndfanaddfds(intf *dfile, _fcd desc, intf *desclen);
 
-HDFFCLIBAPI FRETVAL(intf) ndfangetfidlen(intf *dfile, intf *isfirst);
+HDFFCLIBAPI intf ndfangetfidlen(intf *dfile, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndfangetfdslen(intf *dfile, intf *isfirst);
+HDFFCLIBAPI intf ndfangetfdslen(intf *dfile, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndfangetfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
+HDFFCLIBAPI intf ndfangetfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndfangetfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
+HDFFCLIBAPI intf ndfangetfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndaafds(intf *dfile, _fcd desc, intf *desclen);
+HDFFCLIBAPI intf ndaafds(intf *dfile, _fcd desc, intf *desclen);
 
-HDFFCLIBAPI FRETVAL(intf) ndagfidl(intf *dfile, intf *isfirst);
+HDFFCLIBAPI intf ndagfidl(intf *dfile, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndagfdsl(intf *dfile, intf *isfirst);
+HDFFCLIBAPI intf ndagfdsl(intf *dfile, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndagfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
+HDFFCLIBAPI intf ndagfid(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndagfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
+HDFFCLIBAPI intf ndagfds(intf *dfile, _fcd id, intf *maxlen, intf *isfirst);
 
-HDFFCLIBAPI FRETVAL(intf) ndaiafid(intf *dfile, _fcd id, intf *idlen);
+HDFFCLIBAPI intf ndaiafid(intf *dfile, _fcd id, intf *idlen);
 
 /*
  ** from dfr8F.c
@@ -103,41 +103,39 @@ HDFFCLIBAPI FRETVAL(intf) ndaiafid(intf *dfile, _fcd id, intf *idlen);
 #define nd8sjpeg        H4_F77_FUNC(d8sjpeg, D8SJPEG)
 #define ndfr8sjpeg      H4_F77_FUNC(dfr8sjpeg, DFR8SJPEG)
 
-HDFFCLIBAPI FRETVAL(intf) nd8spal(_fcd pal);
+HDFFCLIBAPI intf nd8spal(_fcd pal);
 
-HDFFCLIBAPI FRETVAL(intf) nd8first(void);
+HDFFCLIBAPI intf nd8first(void);
 
-HDFFCLIBAPI FRETVAL(intf) nd8igdim(_fcd filename, intf *xdim, intf *ydim, intf *ispal, intf *lenfn);
+HDFFCLIBAPI intf nd8igdim(_fcd filename, intf *xdim, intf *ydim, intf *ispal, intf *lenfn);
 
-HDFFCLIBAPI FRETVAL(intf) nd8igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, _fcd pal, intf *lenfn);
+HDFFCLIBAPI intf nd8igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, _fcd pal, intf *lenfn);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nd8ipimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf *lenfn);
+HDFFCLIBAPI intf nd8ipimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf *lenfn);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nd8iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf *lenfn);
+HDFFCLIBAPI intf nd8iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *compress, intf *lenfn);
 
-HDFFCLIBAPI FRETVAL(intf) nd8irref(_fcd filename, intf *ref, intf *fnlen);
+HDFFCLIBAPI intf nd8irref(_fcd filename, intf *ref, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) nd8iwref(_fcd filename, intf *ref, intf *fnlen);
+HDFFCLIBAPI intf nd8iwref(_fcd filename, intf *ref, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) nd8inims(_fcd filename, intf *fnlen);
+HDFFCLIBAPI intf nd8inims(_fcd filename, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) nd8lref(void);
+HDFFCLIBAPI intf nd8lref(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfr8lastref(void);
+HDFFCLIBAPI intf ndfr8lastref(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfr8setpalette(_fcd pal);
+HDFFCLIBAPI intf ndfr8setpalette(_fcd pal);
 
-HDFFCLIBAPI FRETVAL(intf) ndfr8restart(void);
+HDFFCLIBAPI intf ndfr8restart(void);
 
-HDFFCLIBAPI FRETVAL(intf) nd8scomp(intf *scheme);
+HDFFCLIBAPI intf nd8scomp(intf *scheme);
 
-HDFFCLIBAPI FRETVAL(intf) ndfr8scompress(intf *scheme);
+HDFFCLIBAPI intf ndfr8scompress(intf *scheme);
 
-HDFFCLIBAPI FRETVAL(intf) nd8sjpeg(intf *quality, intf *force_baseline);
+HDFFCLIBAPI intf nd8sjpeg(intf *quality, intf *force_baseline);
 
-HDFFCLIBAPI FRETVAL(intf) ndfr8sjpeg(intf *quality, intf *force_baseline);
+HDFFCLIBAPI intf ndfr8sjpeg(intf *quality, intf *force_baseline);
 
 /*
  ** from dfsdF.c
@@ -197,127 +195,123 @@ HDFFCLIBAPI FRETVAL(intf) ndfr8sjpeg(intf *quality, intf *force_baseline);
 #define ndseslab         H4_F77_FUNC(dseslab, DSESLAB)
 #define ndsirslab        H4_F77_FUNC(dsirslab, DSIRSLAB)
 
-HDFFCLIBAPI FRETVAL(intf) ndsgdisc(intf *dim, intf *maxsize, void *scale);
+HDFFCLIBAPI intf ndsgdisc(intf *dim, intf *maxsize, void *scale);
 
-HDFFCLIBAPI FRETVAL(intf) ndsgrang(void *pmax, void *pmin);
+HDFFCLIBAPI intf ndsgrang(void *pmax, void *pmin);
 
-HDFFCLIBAPI FRETVAL(intf) ndssdims(intf *rank, intf dimsizes[]);
+HDFFCLIBAPI intf ndssdims(intf *rank, intf dimsizes[]);
 
-HDFFCLIBAPI FRETVAL(intf) ndssdisc(intf *dim, intf *dimsize, void *scale);
+HDFFCLIBAPI intf ndssdisc(intf *dim, intf *dimsize, void *scale);
 
-HDFFCLIBAPI FRETVAL(intf) ndssrang(void *max, void *min);
+HDFFCLIBAPI intf ndssrang(void *max, void *min);
 
-HDFFCLIBAPI FRETVAL(intf) ndsclear(void);
+HDFFCLIBAPI intf ndsclear(void);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndsslens(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf *maxlen_coordsys);
+HDFFCLIBAPI intf ndsslens(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf *maxlen_coordsys);
 
-HDFFCLIBAPI FRETVAL(intf) ndsgdiln(intf *dim, intf *llabel, intf *lunit, intf *lformat);
+HDFFCLIBAPI intf ndsgdiln(intf *dim, intf *llabel, intf *lunit, intf *lformat);
 
-HDFFCLIBAPI FRETVAL(intf) ndsgdaln(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys);
+HDFFCLIBAPI intf ndsgdaln(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys);
 
-HDFFCLIBAPI FRETVAL(intf) ndsfirst(void);
+HDFFCLIBAPI intf ndsfirst(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndspslc(intf windims[], void *data, intf dims[]);
+HDFFCLIBAPI intf ndspslc(intf windims[], void *data, intf dims[]);
 
-HDFFCLIBAPI FRETVAL(intf) ndseslc(void);
+HDFFCLIBAPI intf ndseslc(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndssnt(intf *numbertype);
+HDFFCLIBAPI intf ndssnt(intf *numbertype);
 
-HDFFCLIBAPI FRETVAL(intf) ndsgnt(intf *pnumbertype);
+HDFFCLIBAPI intf ndsgnt(intf *pnumbertype);
 
-HDFFCLIBAPI FRETVAL(intf) ndsigdim(_fcd filename, intf *prank, intf sizes[], intf *maxrank, intf *lenfn);
+HDFFCLIBAPI intf ndsigdim(_fcd filename, intf *prank, intf sizes[], intf *maxrank, intf *lenfn);
 
-HDFFCLIBAPI FRETVAL(intf) ndsigdat(_fcd filename, intf *rank, intf maxsizes[], void *data, intf *fnlen);
+HDFFCLIBAPI intf ndsigdat(_fcd filename, intf *rank, intf maxsizes[], void *data, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndsipdat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen);
+HDFFCLIBAPI intf ndsipdat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndsiadat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen);
+HDFFCLIBAPI intf ndsiadat(_fcd filename, intf *rank, intf dimsizes[], void *data, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndsigslc(_fcd filename, intf winst[], intf windims[], void *data, intf dims[], intf *fnlen);
+HDFFCLIBAPI intf ndsigslc(_fcd filename, intf winst[], intf windims[], void *data, intf dims[], intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndsisslc(_fcd filename, intf *fnlen);
+HDFFCLIBAPI intf ndsisslc(_fcd filename, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndsirref(_fcd filename, intf *ref, intf *fnlen);
+HDFFCLIBAPI intf ndsirref(_fcd filename, intf *ref, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndslref(void);
+HDFFCLIBAPI intf ndslref(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndsinum(_fcd filename, intf *len);
+HDFFCLIBAPI intf ndsinum(_fcd filename, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) ndsip32s(_fcd filename, intf *ref, intf *ispre32, intf *len);
+HDFFCLIBAPI intf ndsip32s(_fcd filename, intf *ref, intf *ispre32, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetdatastrs(_fcd label, _fcd unit, _fcd format, _fcd coordsys);
+HDFFCLIBAPI intf ndfsdgetdatastrs(_fcd label, _fcd unit, _fcd format, _fcd coordsys);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format);
+HDFFCLIBAPI intf ndfsdgetdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetdimscale(intf *dim, intf *maxsize, void *scale);
+HDFFCLIBAPI intf ndfsdgetdimscale(intf *dim, intf *maxsize, void *scale);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetrange(void *pmax, void *pmin);
+HDFFCLIBAPI intf ndfsdgetrange(void *pmax, void *pmin);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdsetdims(intf *rank, intf dimsizes[]);
+HDFFCLIBAPI intf ndfsdsetdims(intf *rank, intf dimsizes[]);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdsetdimscale(intf *dim, intf *dimsize, void *scale);
+HDFFCLIBAPI intf ndfsdsetdimscale(intf *dim, intf *dimsize, void *scale);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdsetrange(void *max, void *min);
+HDFFCLIBAPI intf ndfsdsetrange(void *max, void *min);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdclear(void);
+HDFFCLIBAPI intf ndfsdclear(void);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndfsdsetlengths(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format, intf *maxlen_coordsys);
+HDFFCLIBAPI intf ndfsdsetlengths(intf *maxlen_label, intf *maxlen_unit, intf *maxlen_format,
+                                 intf *maxlen_coordsys);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetdimlen(intf *dim, intf *llabel, intf *lunit, intf *lformat);
+HDFFCLIBAPI intf ndfsdgetdimlen(intf *dim, intf *llabel, intf *lunit, intf *lformat);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetdatalen(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys);
+HDFFCLIBAPI intf ndfsdgetdatalen(intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdrestart(void);
+HDFFCLIBAPI intf ndfsdrestart(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdputslice(intf windims[], void *data, intf dims[]);
+HDFFCLIBAPI intf ndfsdputslice(intf windims[], void *data, intf dims[]);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdendslice(void);
+HDFFCLIBAPI intf ndfsdendslice(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdsetnt(intf *numbertype);
+HDFFCLIBAPI intf ndfsdsetnt(intf *numbertype);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdgetnt(intf *pnumbertype);
+HDFFCLIBAPI intf ndfsdgetnt(intf *pnumbertype);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsdlastref(void);
+HDFFCLIBAPI intf ndfsdlastref(void);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndsisdis(intf *dim, _fcd flabel, _fcd funit, _fcd fformat, intf *llabel, intf *lunit, intf *lformat);
+HDFFCLIBAPI intf ndsisdis(intf *dim, _fcd flabel, _fcd funit, _fcd fformat, intf *llabel, intf *lunit,
+                          intf *lformat);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndsigdis(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *lunit, intf *lformat);
+HDFFCLIBAPI intf ndsigdis(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *lunit,
+                          intf *lformat);
 
-HDFFCLIBAPI FRETVAL(intf) ndsisdas(_fcd flabel, _fcd funit, _fcd fformat, _fcd fcoordsys, intf *isfortran,
-                                   intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys);
+HDFFCLIBAPI intf ndsisdas(_fcd flabel, _fcd funit, _fcd fformat, _fcd fcoordsys, intf *isfortran,
+                          intf *llabel, intf *lunit, intf *lformat, intf *lcoordsys);
 
-HDFFCLIBAPI FRETVAL(intf) ndsigdas(_fcd label, _fcd unit, _fcd format, _fcd coordsys, intf *llabel,
-                                   intf *lunit, intf *lformat, intf *lcoord);
+HDFFCLIBAPI intf ndsigdas(_fcd label, _fcd unit, _fcd format, _fcd coordsys, intf *llabel, intf *lunit,
+                          intf *lformat, intf *lcoord);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndsscal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *cal_type);
+HDFFCLIBAPI intf ndsscal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *cal_type);
 
-HDFFCLIBAPI FRETVAL(intf)
-    ndsgcal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *cal_type);
+HDFFCLIBAPI intf ndsgcal(float64 *cal, float64 *cal_err, float64 *ioff, float64 *ioff_err, intf *cal_type);
 
-HDFFCLIBAPI FRETVAL(intf) ndswref(_fcd filename, intf *fnlen, intf *ref);
+HDFFCLIBAPI intf ndswref(_fcd filename, intf *fnlen, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) ndssfill(void *fill_value);
+HDFFCLIBAPI intf ndssfill(void *fill_value);
 
-HDFFCLIBAPI FRETVAL(intf) ndsgfill(void *fill_value);
+HDFFCLIBAPI intf ndsgfill(void *fill_value);
 
-HDFFCLIBAPI FRETVAL(intf) ndssslab(_fcd filename, intf *fnlen);
+HDFFCLIBAPI intf ndssslab(_fcd filename, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndswslab(intf start[], intf stride[], intf cont[], void *data);
+HDFFCLIBAPI intf ndswslab(intf start[], intf stride[], intf cont[], void *data);
 
-HDFFCLIBAPI FRETVAL(intf) ndseslab(void);
+HDFFCLIBAPI intf ndseslab(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndsiwref(_fcd filename, intf *fnlen, intf *ref);
+HDFFCLIBAPI intf ndsiwref(_fcd filename, intf *fnlen, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) ndsisslab(_fcd filename, intf *fnlen);
+HDFFCLIBAPI intf ndsisslab(_fcd filename, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndsirslab(_fcd filename, intf *fnlen, intf start[], intf slab_size[], intf stride[],
-                                    void *buffer, intf buffer_size[]);
+HDFFCLIBAPI intf ndsirslab(_fcd filename, intf *fnlen, intf start[], intf slab_size[], intf stride[],
+                           void *buffer, intf buffer_size[]);
 
 /*
  ** from dfpF.c
@@ -333,23 +327,23 @@ HDFFCLIBAPI FRETVAL(intf) ndsirslab(_fcd filename, intf *fnlen, intf start[], in
 #define ndfprestart H4_F77_FUNC(dfprestart, DFPRESTART)
 #define ndfplastref H4_F77_FUNC(dfplastref, DFPLASTREF)
 
-HDFFCLIBAPI FRETVAL(intf) ndpigpal(_fcd filename, _fcd pal, intf *fnlen);
+HDFFCLIBAPI intf ndpigpal(_fcd filename, _fcd pal, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndpippal(_fcd filename, _fcd pal, intf *overwrite, _fcd filemode, intf *fnlen);
+HDFFCLIBAPI intf ndpippal(_fcd filename, _fcd pal, intf *overwrite, _fcd filemode, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndpinpal(_fcd filename, intf *fnlen);
+HDFFCLIBAPI intf ndpinpal(_fcd filename, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndpirref(_fcd filename, intf *ref, intf *fnlen);
+HDFFCLIBAPI intf ndpirref(_fcd filename, intf *ref, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndpiwref(_fcd filename, intf *ref, intf *fnlen);
+HDFFCLIBAPI intf ndpiwref(_fcd filename, intf *ref, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) ndprest(void);
+HDFFCLIBAPI intf ndprest(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndplref(void);
+HDFFCLIBAPI intf ndplref(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfprestart(void);
+HDFFCLIBAPI intf ndfprestart(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfplastref(void);
+HDFFCLIBAPI intf ndfplastref(void);
 
 /*
  ** from df24F.c
@@ -373,42 +367,41 @@ HDFFCLIBAPI FRETVAL(intf) ndfplastref(void);
 #define nd2sjpeg       H4_F77_FUNC(d2sjpeg, D2SJPEG)
 #define ndf24sjpeg     H4_F77_FUNC(df24sjpeg, DF24SJPEG)
 
-HDFFCLIBAPI FRETVAL(intf) nd2reqil(intf *il);
+HDFFCLIBAPI intf nd2reqil(intf *il);
 
-HDFFCLIBAPI FRETVAL(intf) nd2sdims(intf *xdim, intf *ydim);
+HDFFCLIBAPI intf nd2sdims(intf *xdim, intf *ydim);
 
-HDFFCLIBAPI FRETVAL(intf) nd2igdim(_fcd filename, intf *pxdim, intf *pydim, intf *pil, intf *fnlen);
+HDFFCLIBAPI intf nd2igdim(_fcd filename, intf *pxdim, intf *pydim, intf *pil, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) nd2igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen);
+HDFFCLIBAPI intf nd2igimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nd2iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen, intf *newfile);
+HDFFCLIBAPI intf nd2iaimg(_fcd filename, _fcd image, intf *xdim, intf *ydim, intf *fnlen, intf *newfile);
 
-HDFFCLIBAPI FRETVAL(intf) nd2setil(intf *il);
+HDFFCLIBAPI intf nd2setil(intf *il);
 
-HDFFCLIBAPI FRETVAL(intf) nd2first(void);
+HDFFCLIBAPI intf nd2first(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndf24reqil(intf *il);
+HDFFCLIBAPI intf ndf24reqil(intf *il);
 
-HDFFCLIBAPI FRETVAL(intf) ndf24setdims(intf *xdim, intf *ydim);
+HDFFCLIBAPI intf ndf24setdims(intf *xdim, intf *ydim);
 
-HDFFCLIBAPI FRETVAL(intf) ndf24setil(intf *il);
+HDFFCLIBAPI intf ndf24setil(intf *il);
 
-HDFFCLIBAPI FRETVAL(intf) ndf24restart(void);
+HDFFCLIBAPI intf ndf24restart(void);
 
-HDFFCLIBAPI FRETVAL(intf) nd2irref(_fcd filename, intf *ref, intf *fnlen);
+HDFFCLIBAPI intf nd2irref(_fcd filename, intf *ref, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) nd2inimg(_fcd filename, intf *fnlen);
+HDFFCLIBAPI intf nd2inimg(_fcd filename, intf *fnlen);
 
-HDFFCLIBAPI FRETVAL(intf) nd2lref(void);
+HDFFCLIBAPI intf nd2lref(void);
 
-HDFFCLIBAPI FRETVAL(intf) nd2scomp(intf *scheme);
+HDFFCLIBAPI intf nd2scomp(intf *scheme);
 
-HDFFCLIBAPI FRETVAL(intf) ndf24scompress(intf *scheme);
+HDFFCLIBAPI intf ndf24scompress(intf *scheme);
 
-HDFFCLIBAPI FRETVAL(intf) nd2sjpeg(intf *quality, intf *force_baseline);
+HDFFCLIBAPI intf nd2sjpeg(intf *quality, intf *force_baseline);
 
-HDFFCLIBAPI FRETVAL(intf) ndf24sjpeg(intf *quality, intf *force_baseline);
+HDFFCLIBAPI intf ndf24sjpeg(intf *quality, intf *force_baseline);
 
 /*
  ** from dfF.c
@@ -434,45 +427,45 @@ HDFFCLIBAPI FRETVAL(intf) ndf24sjpeg(intf *quality, intf *force_baseline);
 #define ndfstat    H4_F77_FUNC(dfstat, DFSTAT)
 #define ndfiishdf  H4_F77_FUNC(dfiishdf, DFIISHDF)
 
-HDFFCLIBAPI FRETVAL(intf) ndfiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen);
+HDFFCLIBAPI intf ndfiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) ndfclose(intf *dfile);
+HDFFCLIBAPI intf ndfclose(intf *dfile);
 
-HDFFCLIBAPI FRETVAL(intf) ndfdesc(intf *dfile, intf ptr[][4], intf *begin, intf *num);
+HDFFCLIBAPI intf ndfdesc(intf *dfile, intf ptr[][4], intf *begin, intf *num);
 
-HDFFCLIBAPI FRETVAL(intf) ndfdup(intf *dfile, intf *tag, intf *ref, intf *otag, intf *oref);
+HDFFCLIBAPI intf ndfdup(intf *dfile, intf *tag, intf *ref, intf *otag, intf *oref);
 
-HDFFCLIBAPI FRETVAL(intf) ndfdel(intf *dfile, intf *tag, intf *ref);
+HDFFCLIBAPI intf ndfdel(intf *dfile, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) ndfiaccess(intf *dfile, intf *tag, intf *ref, _fcd acc_mode, intf *acclen);
+HDFFCLIBAPI intf ndfiaccess(intf *dfile, intf *tag, intf *ref, _fcd acc_mode, intf *acclen);
 
-HDFFCLIBAPI FRETVAL(intf) ndfstart(intf *dfile, intf *tag, intf *ref, char *acc_mode);
+HDFFCLIBAPI intf ndfstart(intf *dfile, intf *tag, intf *ref, char *acc_mode);
 
-HDFFCLIBAPI FRETVAL(intf) ndfread(intf *dfile, _fcd ptr, intf *len);
+HDFFCLIBAPI intf ndfread(intf *dfile, _fcd ptr, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) ndfseek(intf *dfile, intf *offset);
+HDFFCLIBAPI intf ndfseek(intf *dfile, intf *offset);
 
-HDFFCLIBAPI FRETVAL(intf) ndfwrite(intf *dfile, _fcd ptr, intf *len);
+HDFFCLIBAPI intf ndfwrite(intf *dfile, _fcd ptr, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) ndfupdate(intf *dfile);
+HDFFCLIBAPI intf ndfupdate(intf *dfile);
 
-HDFFCLIBAPI FRETVAL(intf) ndfget(intf *dfile, intf *tag, intf *ref, _fcd ptr);
+HDFFCLIBAPI intf ndfget(intf *dfile, intf *tag, intf *ref, _fcd ptr);
 
-HDFFCLIBAPI FRETVAL(intf) ndfput(intf *dfile, intf *tag, intf *ref, _fcd ptr, intf *len);
+HDFFCLIBAPI intf ndfput(intf *dfile, intf *tag, intf *ref, _fcd ptr, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) ndfsfind(intf *dfile, intf *tag, intf *ref);
+HDFFCLIBAPI intf ndfsfind(intf *dfile, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) ndffind(intf *dfile, intf *itag, intf *iref, intf *len);
+HDFFCLIBAPI intf ndffind(intf *dfile, intf *itag, intf *iref, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) ndferrno(void);
+HDFFCLIBAPI intf ndferrno(void);
 
-HDFFCLIBAPI FRETVAL(intf) ndfnewref(intf *dfile);
+HDFFCLIBAPI intf ndfnewref(intf *dfile);
 
-HDFFCLIBAPI FRETVAL(intf) ndfnumber(intf *dfile, intf *tag);
+HDFFCLIBAPI intf ndfnumber(intf *dfile, intf *tag);
 
-HDFFCLIBAPI FRETVAL(intf) ndfstat(intf *dfile, DFdata *dfinfo);
+HDFFCLIBAPI intf ndfstat(intf *dfile, DFdata *dfinfo);
 
-HDFFCLIBAPI FRETVAL(intf) ndfiishdf(_fcd name, intf *namelen);
+HDFFCLIBAPI intf ndfiishdf(_fcd name, intf *namelen);
 
 /*
  ** from dfutilF.c
@@ -480,9 +473,9 @@ HDFFCLIBAPI FRETVAL(intf) ndfiishdf(_fcd name, intf *namelen);
 #define ndfindnr       H4_F77_FUNC(dfindnr, DFINDNR)
 #define ndffindnextref H4_F77_FUNC(dffindnextref, DFFINDNEXTREF)
 
-HDFFCLIBAPI FRETVAL(intf) ndfindnr(intf *dfile, intf *tag, intf *lref);
+HDFFCLIBAPI intf ndfindnr(intf *dfile, intf *tag, intf *lref);
 
-HDFFCLIBAPI FRETVAL(intf) ndffindnextref(intf *dfile, intf *tag, intf *lref);
+HDFFCLIBAPI intf ndffindnextref(intf *dfile, intf *tag, intf *lref);
 
 /*
  ** from herrF.c
@@ -491,11 +484,11 @@ HDFFCLIBAPI FRETVAL(intf) ndffindnextref(intf *dfile, intf *tag, intf *lref);
 #define nheprntc   H4_F77_FUNC(heprntc, HEPRNTC)
 #define nhestringc H4_F77_FUNC(hestringc, HESTRINGC)
 
-HDFFCLIBAPI FRETVAL(void) nheprnt(intf *print_levels);
+HDFFCLIBAPI void nheprnt(intf *print_levels);
 
-HDFFCLIBAPI FRETVAL(intf) nheprntc(_fcd filename, intf *print_levels, intf *namelen);
+HDFFCLIBAPI intf nheprntc(_fcd filename, intf *print_levels, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nhestringc(intf *error_code, _fcd error_message, intf *len);
+HDFFCLIBAPI intf nhestringc(intf *error_code, _fcd error_message, intf *len);
 /*
  ** from hfilef.c
  */
@@ -518,38 +511,38 @@ HDFFCLIBAPI FRETVAL(intf) nhestringc(intf *error_code, _fcd error_message, intf 
 #define nhiishdf      H4_F77_FUNC(hiishdf, HIISHDF)
 #define nhconfinfc    H4_F77_FUNC(hconfinfc, HCONFINFC)
 
-HDFFCLIBAPI FRETVAL(intf) nhiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen);
+HDFFCLIBAPI intf nhiopen(_fcd name, intf *acc_mode, intf *defdds, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nhclose(intf *file_id);
+HDFFCLIBAPI intf nhclose(intf *file_id);
 
-HDFFCLIBAPI FRETVAL(intf) nhnumber(intf *file_id, intf *tag);
+HDFFCLIBAPI intf nhnumber(intf *file_id, intf *tag);
 
-HDFFCLIBAPI FRETVAL(intf) nhxisdir(_fcd dir, intf *dirlen);
+HDFFCLIBAPI intf nhxisdir(_fcd dir, intf *dirlen);
 
-HDFFCLIBAPI FRETVAL(intf) nhxiscdir(_fcd dir, intf *dirlen);
+HDFFCLIBAPI intf nhxiscdir(_fcd dir, intf *dirlen);
 
-HDFFCLIBAPI FRETVAL(intf) nhddontatexit(void);
+HDFFCLIBAPI intf nhddontatexit(void);
 
-HDFFCLIBAPI FRETVAL(intf) nhglibverc(intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len);
+HDFFCLIBAPI intf nhglibverc(intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nhgfilverc(intf *file_id, intf *major_v, intf *minor_v, intf *release, _fcd string, intf *len);
+HDFFCLIBAPI intf nhgfilverc(intf *file_id, intf *major_v, intf *minor_v, intf *release, _fcd string,
+                            intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) nhiishdf(_fcd name, intf *namelen);
+HDFFCLIBAPI intf nhiishdf(_fcd name, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nhiclose(intf *file_id);
+HDFFCLIBAPI intf nhiclose(intf *file_id);
 
-HDFFCLIBAPI FRETVAL(intf) nhinumbr(int32 file_id, uint16 tag);
+HDFFCLIBAPI intf nhinumbr(int32 file_id, uint16 tag);
 
-HDFFCLIBAPI FRETVAL(intf) nhconfinfc(intf *coder_type, intf *info);
+HDFFCLIBAPI intf nhconfinfc(intf *coder_type, intf *info);
 /*
  ** from dfufp2im.c
  */
 #define nduif2i H4_F77_FUNC(duif2i, DUIF2I)
 
-HDFFCLIBAPI FRETVAL(int) nduif2i(int32 *hdim, int32 *vdim, float32 *max, float32 *min, float32 hscale[],
-                                 float32 vscale[], float32 data[], _fcd palette, _fcd outfile, int *ct_method,
-                                 int32 *hres, int32 *vres, int *compress, int *lenfn);
+HDFFCLIBAPI int nduif2i(int32 *hdim, int32 *vdim, float32 *max, float32 *min, float32 hscale[],
+                        float32 vscale[], float32 data[], _fcd palette, _fcd outfile, int *ct_method,
+                        int32 *hres, int32 *vres, int *compress, int *lenfn);
 
 HDFFCLIBAPI int DFUfptoimage(int32 hdim, int32 vdim, float32 max, float32 min, float32 *hscale,
                              float32 *vscale, float32 *data, uint8 *palette, char *outfile, int ct_method,
@@ -585,78 +578,77 @@ HDFFCLIBAPI int DFUfptoimage(int32 hdim, int32 vdim, float32 max, float32 min, f
 
 /* Multi-file Annotation C-stubs for Fortran interface found in mfanf.c */
 
-HDFFCLIBAPI FRETVAL(intf) nafstart(intf *file_id);
+HDFFCLIBAPI intf nafstart(intf *file_id);
 
-HDFFCLIBAPI FRETVAL(intf)
-    naffileinfo(intf *an_id, intf *num_flabel, intf *num_fdesc, intf *num_olabel, intf *num_odesc);
+HDFFCLIBAPI intf naffileinfo(intf *an_id, intf *num_flabel, intf *num_fdesc, intf *num_olabel,
+                             intf *num_odesc);
 
-HDFFCLIBAPI FRETVAL(intf) nafend(intf *an_id);
+HDFFCLIBAPI intf nafend(intf *an_id);
 
-HDFFCLIBAPI FRETVAL(intf) nafcreate(intf *an_id, intf *etag, intf *eref, intf *atype);
+HDFFCLIBAPI intf nafcreate(intf *an_id, intf *etag, intf *eref, intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) naffcreate(intf *an_id, intf *atype);
+HDFFCLIBAPI intf naffcreate(intf *an_id, intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) nafselect(intf *an_id, intf *idx, intf *atype);
+HDFFCLIBAPI intf nafselect(intf *an_id, intf *idx, intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) nafnumann(intf *an_id, intf *atype, intf *etag, intf *eref);
+HDFFCLIBAPI intf nafnumann(intf *an_id, intf *atype, intf *etag, intf *eref);
 
-HDFFCLIBAPI FRETVAL(intf) nafannlist(intf *an_id, intf *atype, intf *etag, intf *eref, intf alist[]);
+HDFFCLIBAPI intf nafannlist(intf *an_id, intf *atype, intf *etag, intf *eref, intf alist[]);
 
-HDFFCLIBAPI FRETVAL(intf) nafannlen(intf *ann_id);
+HDFFCLIBAPI intf nafannlen(intf *ann_id);
 
-HDFFCLIBAPI FRETVAL(intf) nafwriteann(intf *ann_id, _fcd ann, intf *annlen);
+HDFFCLIBAPI intf nafwriteann(intf *ann_id, _fcd ann, intf *annlen);
 
-HDFFCLIBAPI FRETVAL(intf) nafreadann(intf *ann_id, _fcd ann, intf *maxlen);
+HDFFCLIBAPI intf nafreadann(intf *ann_id, _fcd ann, intf *maxlen);
 
-HDFFCLIBAPI FRETVAL(intf) nafendaccess(intf *ann_id);
+HDFFCLIBAPI intf nafendaccess(intf *ann_id);
 
-HDFFCLIBAPI FRETVAL(intf) nafgettagref(intf *an_id, intf *idx, intf *type, intf *tag, intf *ref);
+HDFFCLIBAPI intf nafgettagref(intf *an_id, intf *idx, intf *type, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nafidtagref(intf *ann_id, intf *tag, intf *ref);
+HDFFCLIBAPI intf nafidtagref(intf *ann_id, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) naftagrefid(intf *an_id, intf *tag, intf *ref);
+HDFFCLIBAPI intf naftagrefid(intf *an_id, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nafatypetag(intf *atype);
+HDFFCLIBAPI intf nafatypetag(intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) naftagatype(intf *tag);
+HDFFCLIBAPI intf naftagatype(intf *tag);
 
 /* if defined Windows */
 /* Multi-file Annotation C-stubs for Fortran interface found in mfanf.c */
 
-HDFFCLIBAPI FRETVAL(intf) nafistart(intf *file_id);
+HDFFCLIBAPI intf nafistart(intf *file_id);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nafifinf(intf *an_id, intf *num_flabel, intf *num_fdesc, intf *num_olabel, intf *num_odesc);
+HDFFCLIBAPI intf nafifinf(intf *an_id, intf *num_flabel, intf *num_fdesc, intf *num_olabel, intf *num_odesc);
 
-HDFFCLIBAPI FRETVAL(intf) nafiend(intf *an_id);
+HDFFCLIBAPI intf nafiend(intf *an_id);
 
-HDFFCLIBAPI FRETVAL(intf) naficreat(intf *an_id, intf *etag, intf *eref, intf *atype);
+HDFFCLIBAPI intf naficreat(intf *an_id, intf *etag, intf *eref, intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) nafifcreat(intf *an_id, intf *atype);
+HDFFCLIBAPI intf nafifcreat(intf *an_id, intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) nafiselct(intf *an_id, intf *index, intf *atype);
+HDFFCLIBAPI intf nafiselct(intf *an_id, intf *index, intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) nafinann(intf *an_id, intf *atype, intf *etag, intf *eref);
+HDFFCLIBAPI intf nafinann(intf *an_id, intf *atype, intf *etag, intf *eref);
 
-HDFFCLIBAPI FRETVAL(intf) nafialst(intf *an_id, intf *atype, intf *etag, intf *eref, intf alist[]);
+HDFFCLIBAPI intf nafialst(intf *an_id, intf *atype, intf *etag, intf *eref, intf alist[]);
 
-HDFFCLIBAPI FRETVAL(intf) nafialen(intf *ann_id);
+HDFFCLIBAPI intf nafialen(intf *ann_id);
 
-HDFFCLIBAPI FRETVAL(intf) nafiwann(intf *ann_id, _fcd ann, intf *annlen);
+HDFFCLIBAPI intf nafiwann(intf *ann_id, _fcd ann, intf *annlen);
 
-HDFFCLIBAPI FRETVAL(intf) nafirann(intf *ann_id, _fcd ann, intf *maxlen);
+HDFFCLIBAPI intf nafirann(intf *ann_id, _fcd ann, intf *maxlen);
 
-HDFFCLIBAPI FRETVAL(intf) nafiendac(intf *ann_id);
+HDFFCLIBAPI intf nafiendac(intf *ann_id);
 
-HDFFCLIBAPI FRETVAL(intf) nafigtr(intf *an_id, intf *index, intf *type, intf *tag, intf *ref);
+HDFFCLIBAPI intf nafigtr(intf *an_id, intf *index, intf *type, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nafiid2tr(intf *ann_id, intf *tag, intf *ref);
+HDFFCLIBAPI intf nafiid2tr(intf *ann_id, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nafitr2id(intf *an_id, intf *tag, intf *ref);
+HDFFCLIBAPI intf nafitr2id(intf *an_id, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nafitp2tg(intf *atype);
+HDFFCLIBAPI intf nafitp2tg(intf *atype);
 
-HDFFCLIBAPI FRETVAL(intf) nafitg2tp(intf *tag);
+HDFFCLIBAPI intf nafitg2tp(intf *tag);
 
 /* endif defined Windows */
 
@@ -752,99 +744,99 @@ HDFLIBAPI intn ANdestroy(void); */
 
 /* Multi-file GR C-stubs for FORTRAN interface found in mfgrf.c */
 
-HDFFCLIBAPI FRETVAL(intf) /* !sl */
-    nmgiwimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
+HDFFCLIBAPI intf /* !sl */
+nmgiwimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) /* !sl */
-    nmgirimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
+HDFFCLIBAPI intf /* !sl */
+nmgirimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) /* !sl */
-    nmgignat(intf *riid, intf *idx, void *data);
+HDFFCLIBAPI intf /* !sl */
+nmgignat(intf *riid, intf *idx, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgstart(intf *fid);
+HDFFCLIBAPI intf nmgstart(intf *fid);
 
-HDFFCLIBAPI FRETVAL(intf) nmgfinfo(intf *grid, intf *n_datasets, intf *n_attrs);
+HDFFCLIBAPI intf nmgfinfo(intf *grid, intf *n_datasets, intf *n_attrs);
 
-HDFFCLIBAPI FRETVAL(intf) nmgend(intf *grid);
+HDFFCLIBAPI intf nmgend(intf *grid);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nmgicreat(intf *grid, _fcd name, intf *ncomp, intf *nt, intf *il, intf dimsizes[2], intf *nlen);
+HDFFCLIBAPI intf nmgicreat(intf *grid, _fcd name, intf *ncomp, intf *nt, intf *il, intf dimsizes[2],
+                           intf *nlen);
 
-HDFFCLIBAPI FRETVAL(intf) nmgselct(intf *grid, intf *idx);
+HDFFCLIBAPI intf nmgselct(intf *grid, intf *idx);
 
-HDFFCLIBAPI FRETVAL(intf) nmgin2ndx(intf *grid, _fcd name, intf *nlen);
+HDFFCLIBAPI intf nmgin2ndx(intf *grid, _fcd name, intf *nlen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nmggiinf(intf *riid, _fcd name, intf *ncomp, intf *nt, intf *il, intf *dimsizes, intf *nattr);
+HDFFCLIBAPI intf nmggiinf(intf *riid, _fcd name, intf *ncomp, intf *nt, intf *il, intf *dimsizes,
+                          intf *nattr);
 
-HDFFCLIBAPI FRETVAL(intf) nmgwcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data);
+HDFFCLIBAPI intf nmgwcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgrcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data);
+HDFFCLIBAPI intf nmgrcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgwrimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
+HDFFCLIBAPI intf nmgwrimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgrdimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
+HDFFCLIBAPI intf nmgrdimg(intf *riid, intf *start, intf *stride, intf *count, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgendac(intf *riid);
+HDFFCLIBAPI intf nmgendac(intf *riid);
 
-HDFFCLIBAPI FRETVAL(intf) nmgid2rf(intf *riid);
+HDFFCLIBAPI intf nmgid2rf(intf *riid);
 
-HDFFCLIBAPI FRETVAL(intf) nmgr2idx(intf *grid, intf *ref);
+HDFFCLIBAPI intf nmgr2idx(intf *grid, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nmgrltil(intf *riid, intf *il);
+HDFFCLIBAPI intf nmgrltil(intf *riid, intf *il);
 
-HDFFCLIBAPI FRETVAL(intf) nmgrimil(intf *riid, intf *il);
+HDFFCLIBAPI intf nmgrimil(intf *riid, intf *il);
 
-HDFFCLIBAPI FRETVAL(intf) nmggltid(intf *riid, intf *lut_index);
+HDFFCLIBAPI intf nmggltid(intf *riid, intf *lut_index);
 
-HDFFCLIBAPI FRETVAL(intf) nmgglinf(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries);
+HDFFCLIBAPI intf nmgglinf(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries);
 
-HDFFCLIBAPI FRETVAL(intf) nmgwrlut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, void *data);
+HDFFCLIBAPI intf nmgwrlut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data);
+HDFFCLIBAPI intf nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgrdlut(intf *lutid, void *data);
+HDFFCLIBAPI intf nmgrdlut(intf *lutid, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgrclut(intf *lutid, _fcd data);
+HDFFCLIBAPI intf nmgrclut(intf *lutid, _fcd data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgisxfil(intf *riid, _fcd filename, intf *offset, intf *nlen);
+HDFFCLIBAPI intf nmgisxfil(intf *riid, _fcd filename, intf *offset, intf *nlen);
 
-HDFFCLIBAPI FRETVAL(intf) nmgsactp(intf *riid, intf *accesstype);
+HDFFCLIBAPI intf nmgsactp(intf *riid, intf *accesstype);
 
-HDFFCLIBAPI FRETVAL(intf) nmgiscatt(intf *riid, _fcd name, intf *nt, intf *count, _fcd data, intf *nlen);
+HDFFCLIBAPI intf nmgiscatt(intf *riid, _fcd name, intf *nt, intf *count, _fcd data, intf *nlen);
 
-HDFFCLIBAPI FRETVAL(intf) nmgisattr(intf *riid, _fcd name, intf *nt, intf *count, void *data, intf *nlen);
+HDFFCLIBAPI intf nmgisattr(intf *riid, _fcd name, intf *nt, intf *count, void *data, intf *nlen);
 
-HDFFCLIBAPI FRETVAL(intf) nmgatinf(intf *riid, intf *idx, _fcd name, intf *nt, intf *count);
+HDFFCLIBAPI intf nmgatinf(intf *riid, intf *idx, _fcd name, intf *nt, intf *count);
 
-HDFFCLIBAPI FRETVAL(intf) nmggcatt(intf *riid, intf *idx, _fcd data);
+HDFFCLIBAPI intf nmggcatt(intf *riid, intf *idx, _fcd data);
 
-HDFFCLIBAPI FRETVAL(intf) nmggnatt(intf *riid, intf *idx, void *data);
+HDFFCLIBAPI intf nmggnatt(intf *riid, intf *idx, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmggattr(intf *riid, intf *idx, void *data);
+HDFFCLIBAPI intf nmggattr(intf *riid, intf *idx, void *data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgifndat(intf *riid, _fcd name, intf *nlen);
+HDFFCLIBAPI intf nmgifndat(intf *riid, _fcd name, intf *nlen);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcgichnk(intf *id, intf *dim_length, intf *flags);
+HDFFCLIBAPI intf nmgcgichnk(intf *id, intf *dim_length, intf *flags);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcrcchnk(intf *id, intf *start, _fcd char_data);
+HDFFCLIBAPI intf nmgcrcchnk(intf *id, intf *start, _fcd char_data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcrchnk(intf *id, intf *start, void *num_data);
+HDFFCLIBAPI intf nmgcrchnk(intf *id, intf *start, void *num_data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcscchnk(intf *id, intf *maxcache, intf *flags);
+HDFFCLIBAPI intf nmgcscchnk(intf *id, intf *maxcache, intf *flags);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm);
-HDFFCLIBAPI FRETVAL(intf) nmgcwcchnk(intf *id, intf *start, _fcd char_data);
+HDFFCLIBAPI intf nmgcschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm);
+HDFFCLIBAPI intf nmgcwcchnk(intf *id, intf *start, _fcd char_data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcwchnk(intf *id, intf *start, void *num_data);
+HDFFCLIBAPI intf nmgcwchnk(intf *id, intf *start, void *num_data);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcscompress(intf *id, intf *comp_type, intf *comp_prm);
+HDFFCLIBAPI intf nmgcscompress(intf *id, intf *comp_type, intf *comp_prm);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcgcompress(intf *id, intf *comp_type, intf *comp_prm);
+HDFFCLIBAPI intf nmgcgcompress(intf *id, intf *comp_type, intf *comp_prm);
 
-HDFFCLIBAPI FRETVAL(intf) nmglt2rf(intf *id);
+HDFFCLIBAPI intf nmglt2rf(intf *id);
 
-HDFFCLIBAPI FRETVAL(intf) nmgcgnluts(intf *id);
+HDFFCLIBAPI intf nmgcgnluts(intf *id);
 
 /*
  ** from vgF.c
@@ -944,229 +936,227 @@ HDFFCLIBAPI FRETVAL(intf) nmgcgnluts(intf *id);
 #define nvcgvgrp    H4_F77_FUNC(vcgvgrp, VCGVGRP)
 #define nvscgvdatas H4_F77_FUNC(vscgvdatas, VSCGVDATAS)
 
-HDFFCLIBAPI FRETVAL(intf) ndfivopn(_fcd filename, intf *acc_mode, intf *defdds, intf *namelen);
+HDFFCLIBAPI intf ndfivopn(_fcd filename, intf *acc_mode, intf *defdds, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) ndfvclos(intf *file_id);
+HDFFCLIBAPI intf ndfvclos(intf *file_id);
 
-HDFFCLIBAPI FRETVAL(intf) nvatchc(intf *f, intf *vgid, _fcd accesstype);
+HDFFCLIBAPI intf nvatchc(intf *f, intf *vgid, _fcd accesstype);
 
-HDFFCLIBAPI FRETVAL(intf) nvdtchc(intf *vkey);
+HDFFCLIBAPI intf nvdtchc(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvgnamc(intf *vkey, _fcd vgname);
+HDFFCLIBAPI intf nvgnamc(intf *vkey, _fcd vgname);
 
-HDFFCLIBAPI FRETVAL(intf) nvgclsc(intf *vkey, _fcd vgclass);
+HDFFCLIBAPI intf nvgclsc(intf *vkey, _fcd vgclass);
 
-HDFFCLIBAPI FRETVAL(intf) nvinqc(intf *vkey, intf *nentries, _fcd vgname);
+HDFFCLIBAPI intf nvinqc(intf *vkey, intf *nentries, _fcd vgname);
 
-HDFFCLIBAPI FRETVAL(intf) nvdeletec(intf *f, intf *vkey);
+HDFFCLIBAPI intf nvdeletec(intf *f, intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvgidc(intf *f, intf *vgid);
+HDFFCLIBAPI intf nvgidc(intf *f, intf *vgid);
 
-HDFFCLIBAPI FRETVAL(intf) nvgnxtc(intf *vkey, intf *id);
+HDFFCLIBAPI intf nvgnxtc(intf *vkey, intf *id);
 
-HDFFCLIBAPI FRETVAL(intf) nvsnamc(intf *vkey, _fcd vgname, intf *vgnamelen);
+HDFFCLIBAPI intf nvsnamc(intf *vkey, _fcd vgname, intf *vgnamelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsclsc(intf *vkey, _fcd vgclass, intf *vgclasslen);
+HDFFCLIBAPI intf nvsclsc(intf *vkey, _fcd vgclass, intf *vgclasslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvinsrtc(intf *vkey, intf *vobjptr);
+HDFFCLIBAPI intf nvinsrtc(intf *vkey, intf *vobjptr);
 
-HDFFCLIBAPI FRETVAL(intf) nvisvgc(intf *vkey, intf *id);
+HDFFCLIBAPI intf nvisvgc(intf *vkey, intf *id);
 
-HDFFCLIBAPI FRETVAL(intf) nvfstart(intf *f);
+HDFFCLIBAPI intf nvfstart(intf *f);
 
-HDFFCLIBAPI FRETVAL(intf) nvfend(intf *f);
+HDFFCLIBAPI intf nvfend(intf *f);
 
-HDFFCLIBAPI FRETVAL(intf) nvisvsc(intf *vkey, intf *id);
+HDFFCLIBAPI intf nvisvsc(intf *vkey, intf *id);
 
-HDFFCLIBAPI FRETVAL(intf) nvsatchc(intf *f, intf *vsref, _fcd accesstype);
+HDFFCLIBAPI intf nvsatchc(intf *f, intf *vsref, _fcd accesstype);
 
-HDFFCLIBAPI FRETVAL(intf) nvsdtchc(intf *vkey);
+HDFFCLIBAPI intf nvsdtchc(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqref(intf *vkey);
+HDFFCLIBAPI intf nvsqref(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqtag(intf *vkey);
+HDFFCLIBAPI intf nvsqtag(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsgver(intf *vkey);
+HDFFCLIBAPI intf nvsgver(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsseekc(intf *vkey, intf *eltpos);
+HDFFCLIBAPI intf nvsseekc(intf *vkey, intf *eltpos);
 
-HDFFCLIBAPI FRETVAL(intf) nvsgnamc(intf *vkey, _fcd vsname, intf *vsnamelen);
+HDFFCLIBAPI intf nvsgnamc(intf *vkey, _fcd vsname, intf *vsnamelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsgclsc(intf *vkey, _fcd vsclass, intf *vsclasslen);
+HDFFCLIBAPI intf nvsgclsc(intf *vkey, _fcd vsclass, intf *vsclasslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsinqc(intf *vkey, intf *nelt, intf *interlace, _fcd fields, intf *eltsize,
-                                  _fcd vsname, intf *fieldslen, intf *vsnamelen);
+HDFFCLIBAPI intf nvsinqc(intf *vkey, intf *nelt, intf *interlace, _fcd fields, intf *eltsize, _fcd vsname,
+                         intf *fieldslen, intf *vsnamelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfexc(intf *vkey, _fcd fields, intf *fieldslen);
+HDFFCLIBAPI intf nvsfexc(intf *vkey, _fcd fields, intf *fieldslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfndc(intf *f, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nvsfndc(intf *f, _fcd name, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsgidc(intf *f, intf *vsref);
+HDFFCLIBAPI intf nvsgidc(intf *f, intf *vsref);
 
-HDFFCLIBAPI FRETVAL(intf) nvsdltc(intf *f, intf *vsref);
+HDFFCLIBAPI intf nvsdltc(intf *f, intf *vsref);
 
-HDFFCLIBAPI FRETVAL(intf) nvsapp(intf *vkey, intf *blk);
+HDFFCLIBAPI intf nvsapp(intf *vkey, intf *blk);
 
-HDFFCLIBAPI FRETVAL(intf) nvssnamc(intf *vkey, _fcd vsname, intf *vsnamelen);
+HDFFCLIBAPI intf nvssnamc(intf *vkey, _fcd vsname, intf *vsnamelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvssclsc(intf *vkey, _fcd vsclass, intf *vsclasslen);
+HDFFCLIBAPI intf nvssclsc(intf *vkey, _fcd vsclass, intf *vsclasslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvssfldc(intf *vkey, _fcd fields, intf *fieldslen);
+HDFFCLIBAPI intf nvssfldc(intf *vkey, _fcd fields, intf *fieldslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvssintc(intf *vkey, intf *interlace);
+HDFFCLIBAPI intf nvssintc(intf *vkey, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfdefc(intf *vkey, _fcd field, intf *localtype, intf *order, intf *fieldlen);
+HDFFCLIBAPI intf nvsfdefc(intf *vkey, _fcd field, intf *localtype, intf *order, intf *fieldlen);
 
-HDFFCLIBAPI FRETVAL(intf) nvssextfc(intf *vkey, _fcd fname, intf *offset, intf *fnamelen);
+HDFFCLIBAPI intf nvssextfc(intf *vkey, _fcd fname, intf *offset, intf *fnamelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvfnflds(intf *vkey);
+HDFFCLIBAPI intf nvfnflds(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvffnamec(intf *vkey, intf *idx, _fcd fname, intf *len);
+HDFFCLIBAPI intf nvffnamec(intf *vkey, intf *idx, _fcd fname, intf *len);
 
-HDFFCLIBAPI FRETVAL(intf) nvfftype(intf *vkey, intf *idx);
+HDFFCLIBAPI intf nvfftype(intf *vkey, intf *idx);
 
-HDFFCLIBAPI FRETVAL(intf) nvffisiz(intf *vkey, intf *idx);
+HDFFCLIBAPI intf nvffisiz(intf *vkey, intf *idx);
 
-HDFFCLIBAPI FRETVAL(intf) nvffesiz(intf *vkey, intf *idx);
+HDFFCLIBAPI intf nvffesiz(intf *vkey, intf *idx);
 
-HDFFCLIBAPI FRETVAL(intf) nvffordr(intf *vkey, intf *idx);
+HDFFCLIBAPI intf nvffordr(intf *vkey, intf *idx);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfrdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfrdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfrd(intf *vkey, intf *buf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfrd(intf *vkey, intf *buf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsreadc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsreadc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfwrtc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfwrtc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfwrt(intf *vkey, intf *buf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfwrt(intf *vkey, intf *buf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvswritc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvswritc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsgintc(intf *vkey);
+HDFFCLIBAPI intf nvsgintc(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvseltsc(intf *vkey);
+HDFFCLIBAPI intf nvseltsc(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsgfldc(intf *vkey, _fcd fields);
+HDFFCLIBAPI intf nvsgfldc(intf *vkey, _fcd fields);
 
-HDFFCLIBAPI FRETVAL(intf) nvssizc(intf *vkey, _fcd fields, intf *fieldslen);
+HDFFCLIBAPI intf nvssizc(intf *vkey, _fcd fields, intf *fieldslen);
 
-HDFFCLIBAPI FRETVAL(intf) nventsc(intf *f, intf *vgid);
+HDFFCLIBAPI intf nventsc(intf *f, intf *vgid);
 
-HDFFCLIBAPI FRETVAL(intf) nvlonec(intf *f, intf *idarray, intf *asize);
+HDFFCLIBAPI intf nvlonec(intf *f, intf *idarray, intf *asize);
 
-HDFFCLIBAPI FRETVAL(intf) nvslonec(intf *f, intf *idarray, intf *asize);
+HDFFCLIBAPI intf nvslonec(intf *f, intf *idarray, intf *asize);
 
-HDFFCLIBAPI FRETVAL(intf) nvfindc(intf *f, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nvfindc(intf *f, _fcd name, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvfndclsc(intf *f, _fcd vgclass, intf *classlen);
+HDFFCLIBAPI intf nvfndclsc(intf *f, _fcd vgclass, intf *classlen);
 
-HDFFCLIBAPI FRETVAL(intf) nvhscdc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname,
-                                  _fcd vsclass, intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
+HDFFCLIBAPI intf nvhscdc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass,
+                         intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvhsdc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname,
-                                 _fcd vsclass, intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
+HDFFCLIBAPI intf nvhsdc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass,
+                        intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nvhscdmc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass, intf *order,
-             intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
+HDFFCLIBAPI intf nvhscdmc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass,
+                          intf *order, intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nvhsdmc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass, intf *order,
-            intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
+HDFFCLIBAPI intf nvhsdmc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass,
+                         intf *order, intf *fieldlen, intf *vsnamelen, intf *vsclasslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvhmkgpc(intf *f, intf *tagarray, intf *refarray, intf *n, _fcd vgname,
-                                   _fcd vgclass, intf *vgnamelen, intf *vgclasslen);
+HDFFCLIBAPI intf nvhmkgpc(intf *f, intf *tagarray, intf *refarray, intf *n, _fcd vgname, _fcd vgclass,
+                          intf *vgnamelen, intf *vgclasslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvflocc(intf *vkey, _fcd field, intf *fieldlen);
+HDFFCLIBAPI intf nvflocc(intf *vkey, _fcd field, intf *fieldlen);
 
-HDFFCLIBAPI FRETVAL(intf) nvinqtrc(intf *vkey, intf *tag, intf *ref);
+HDFFCLIBAPI intf nvinqtrc(intf *vkey, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nvntrc(intf *vkey);
+HDFFCLIBAPI intf nvntrc(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvnrefs(intf *vkey, intf *tag);
+HDFFCLIBAPI intf nvnrefs(intf *vkey, intf *tag);
 
-HDFFCLIBAPI FRETVAL(intf) nvqref(intf *vkey);
+HDFFCLIBAPI intf nvqref(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvqtag(intf *vkey);
+HDFFCLIBAPI intf nvqtag(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvgttrsc(intf *vkey, intf *tagarray, intf *refarray, intf *n);
+HDFFCLIBAPI intf nvgttrsc(intf *vkey, intf *tagarray, intf *refarray, intf *n);
 
-HDFFCLIBAPI FRETVAL(intf) nvgttrc(intf *vkey, intf *which, intf *tag, intf *ref);
+HDFFCLIBAPI intf nvgttrc(intf *vkey, intf *which, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nvadtrc(intf *vkey, intf *tag, intf *ref);
+HDFFCLIBAPI intf nvadtrc(intf *vkey, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nvdtrc(intf *vkey, intf *tag, intf *ref);
+HDFFCLIBAPI intf nvdtrc(intf *vkey, intf *tag, intf *ref);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqfnelt(intf *vkey, intf *nelt);
+HDFFCLIBAPI intf nvsqfnelt(intf *vkey, intf *nelt);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqfintr(intf *vkey, intf *interlace);
+HDFFCLIBAPI intf nvsqfintr(intf *vkey, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen);
+HDFFCLIBAPI intf nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqfvsiz(intf *vkey, intf *size);
+HDFFCLIBAPI intf nvsqfvsiz(intf *vkey, intf *size);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqnamec(intf *vkey, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nvsqnamec(intf *vkey, _fcd name, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nrecs,
-                                   _fcd pckfld, _fcd fldbuf, intf *buflds_len, intf *fld_len);
+HDFFCLIBAPI intf nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nrecs,
+                          _fcd pckfld, _fcd fldbuf, intf *buflds_len, intf *fld_len);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nrecs,
-                                   _fcd pckfld, intf *fldbuf, intf *buflds_len, intf *fld_len);
+HDFFCLIBAPI intf nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nrecs,
+                          _fcd pckfld, intf *fldbuf, intf *buflds_len, intf *fld_len);
 
-HDFFCLIBAPI FRETVAL(intf) nvscsetblsz(intf *id, intf *block_size);
+HDFFCLIBAPI intf nvscsetblsz(intf *id, intf *block_size);
 
-HDFFCLIBAPI FRETVAL(intf) nvscsetnmbl(intf *id, intf *num_blocks);
+HDFFCLIBAPI intf nvscsetnmbl(intf *id, intf *num_blocks);
 
-HDFFCLIBAPI FRETVAL(intf) nvscgblinfo(intf *id, intf *block_size, intf *num_blocks);
+HDFFCLIBAPI intf nvscgblinfo(intf *id, intf *block_size, intf *num_blocks);
 
-HDFFCLIBAPI FRETVAL(intf) nvcgvgrp(intf *id, intf *start_vg, intf *vg_count, intf *refarray);
+HDFFCLIBAPI intf nvcgvgrp(intf *id, intf *start_vg, intf *vg_count, intf *refarray);
 
-HDFFCLIBAPI FRETVAL(intf) nvscgvdatas(intf *id, intf *start_vd, intf *vd_count, intf *refarray);
+HDFFCLIBAPI intf nvscgvdatas(intf *id, intf *start_vd, intf *vd_count, intf *refarray);
 
-HDFFCLIBAPI FRETVAL(intf) nvscfcls(intf *id, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nvscfcls(intf *id, _fcd name, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nvfistart(intf *f);
+HDFFCLIBAPI intf nvfistart(intf *f);
 
-HDFFCLIBAPI FRETVAL(intf) nvfiend(intf *f);
+HDFFCLIBAPI intf nvfiend(intf *f);
 
-HDFFCLIBAPI FRETVAL(intf) nvsiqref(intf *vkey);
+HDFFCLIBAPI intf nvsiqref(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsiqtag(intf *vkey);
+HDFFCLIBAPI intf nvsiqtag(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsigver(intf *vkey);
+HDFFCLIBAPI intf nvsigver(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvfinflds(intf *vkey);
+HDFFCLIBAPI intf nvfinflds(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvfifnm(intf *vkey, intf *index, _fcd fname);
+HDFFCLIBAPI intf nvfifnm(intf *vkey, intf *index, _fcd fname);
 
-HDFFCLIBAPI FRETVAL(intf) nvfiftp(intf *vkey, intf *index);
+HDFFCLIBAPI intf nvfiftp(intf *vkey, intf *index);
 
-HDFFCLIBAPI FRETVAL(intf) nvfifisz(intf *vkey, intf *index);
-HDFFCLIBAPI FRETVAL(intf) nvfifesz(intf *vkey, intf *index);
-HDFFCLIBAPI FRETVAL(intf) nvfifodr(intf *vkey, intf *index);
+HDFFCLIBAPI intf nvfifisz(intf *vkey, intf *index);
+HDFFCLIBAPI intf nvfifesz(intf *vkey, intf *index);
+HDFFCLIBAPI intf nvfifodr(intf *vkey, intf *index);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfirdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfirdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfird(intf *vkey, intf *buf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfird(intf *vkey, intf *buf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfiwrc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfiwrc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfiwr(intf *vkey, intf *buf, intf *nelt, intf *interlace);
+HDFFCLIBAPI intf nvsfiwr(intf *vkey, intf *buf, intf *nelt, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvfirefs(intf *vkey, intf *tag);
+HDFFCLIBAPI intf nvfirefs(intf *vkey, intf *tag);
 
-HDFFCLIBAPI FRETVAL(intf) nvfiqref(intf *vkey);
+HDFFCLIBAPI intf nvfiqref(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvfiqtag(intf *vkey);
+HDFFCLIBAPI intf nvfiqtag(intf *vkey);
 
-HDFFCLIBAPI FRETVAL(intf) nvsiqnelt(intf *vkey, intf *nelt);
+HDFFCLIBAPI intf nvsiqnelt(intf *vkey, intf *nelt);
 
-HDFFCLIBAPI FRETVAL(intf) nvsiqintr(intf *vkey, intf *interlace);
+HDFFCLIBAPI intf nvsiqintr(intf *vkey, intf *interlace);
 
-HDFFCLIBAPI FRETVAL(intf) nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen);
+HDFFCLIBAPI intf nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen);
 
-HDFFCLIBAPI FRETVAL(intf) nvsiqvsz(intf *vkey, intf *ret_size);
+HDFFCLIBAPI intf nvsiqvsz(intf *vkey, intf *ret_size);
 
 /*
  ** from vattrf.c
@@ -1198,58 +1188,54 @@ HDFFCLIBAPI FRETVAL(intf) nvsiqvsz(intf *vkey, intf *ret_size);
 #define nvfgcatt H4_F77_FUNC(vfgcatt, VFGCATT)
 #define nvfgver  H4_F77_FUNC(vfgver, VFGVER)
 
-HDFFCLIBAPI FRETVAL(intf) nvsfcfdx(intf *vsid, _fcd fldnm, intf *findex, intf *fldnmlen);
-HDFFCLIBAPI FRETVAL(intf)
-    nvsfcsat(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *attrnmlen);
-HDFFCLIBAPI FRETVAL(intf)
-    nvsfcsca(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *attrnmlen);
-HDFFCLIBAPI FRETVAL(intf) nvsfnats(intf *vsid);
-HDFFCLIBAPI FRETVAL(intf) nvsffnas(intf *vsid, intf *findex);
-HDFFCLIBAPI FRETVAL(intf) nvsfcfda(intf *vsid, intf *findex, _fcd attrnm, intf *attrnmlen);
-HDFFCLIBAPI FRETVAL(intf) nvsfcain(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype,
-                                   intf *count, intf *size, intf *attrnamelen);
-HDFFCLIBAPI FRETVAL(intf) nvsfgnat(intf *vsid, intf *findex, intf *aindex, intf *values);
-HDFFCLIBAPI FRETVAL(intf) nvsfgcat(intf *vsid, intf *findex, intf *aindex, _fcd values);
-HDFFCLIBAPI FRETVAL(intf) nvsfisat(intf *vsid);
-HDFFCLIBAPI FRETVAL(intf)
-    nvfcsatt(intf *vgid, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *attrnmlen);
-HDFFCLIBAPI FRETVAL(intf)
-    nvfcscat(intf *vgid, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *attrnmlen);
-HDFFCLIBAPI FRETVAL(intf) nvfnatts(intf *vgid);
-HDFFCLIBAPI FRETVAL(intf) nvfcfdat(intf *vgid, _fcd attrnm, intf *attrnmlen);
-HDFFCLIBAPI FRETVAL(intf)
-    nvfainfo(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size);
-HDFFCLIBAPI FRETVAL(intf) nvfgnatt(intf *vgid, intf *aindex, intf *values);
-HDFFCLIBAPI FRETVAL(intf) nvfgcatt(intf *vgid, intf *aindex, _fcd values);
-HDFFCLIBAPI FRETVAL(intf) nvfgver(intf *vgid);
+HDFFCLIBAPI intf nvsfcfdx(intf *vsid, _fcd fldnm, intf *findex, intf *fldnmlen);
+HDFFCLIBAPI intf nvsfcsat(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, intf *values,
+                          intf *attrnmlen);
+HDFFCLIBAPI intf nvsfcsca(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, _fcd values,
+                          intf *attrnmlen);
+HDFFCLIBAPI intf nvsfnats(intf *vsid);
+HDFFCLIBAPI intf nvsffnas(intf *vsid, intf *findex);
+HDFFCLIBAPI intf nvsfcfda(intf *vsid, intf *findex, _fcd attrnm, intf *attrnmlen);
+HDFFCLIBAPI intf nvsfcain(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, intf *count,
+                          intf *size, intf *attrnamelen);
+HDFFCLIBAPI intf nvsfgnat(intf *vsid, intf *findex, intf *aindex, intf *values);
+HDFFCLIBAPI intf nvsfgcat(intf *vsid, intf *findex, intf *aindex, _fcd values);
+HDFFCLIBAPI intf nvsfisat(intf *vsid);
+HDFFCLIBAPI intf nvfcsatt(intf *vgid, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *attrnmlen);
+HDFFCLIBAPI intf nvfcscat(intf *vgid, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *attrnmlen);
+HDFFCLIBAPI intf nvfnatts(intf *vgid);
+HDFFCLIBAPI intf nvfcfdat(intf *vgid, _fcd attrnm, intf *attrnmlen);
+HDFFCLIBAPI intf nvfainfo(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size);
+HDFFCLIBAPI intf nvfgnatt(intf *vgid, intf *aindex, intf *values);
+HDFFCLIBAPI intf nvfgcatt(intf *vgid, intf *aindex, _fcd values);
+HDFFCLIBAPI intf nvfgver(intf *vgid);
 
 /* Added for windows */
-HDFFCLIBAPI FRETVAL(intf)
-    nvsfainf(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size);
+HDFFCLIBAPI intf nvsfainf(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, intf *count,
+                          intf *size);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfcnats(intf *vsid);
+HDFFCLIBAPI intf nvsfcnats(intf *vsid);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfcfnas(intf *vsid, intf *findex);
+HDFFCLIBAPI intf nvsfcfnas(intf *vsid, intf *findex);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nvsfcainf(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size);
+HDFFCLIBAPI intf nvsfcainf(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, intf *count,
+                           intf *size);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfcgna(intf *vsid, intf *findex, intf *aindex, intf *values);
+HDFFCLIBAPI intf nvsfcgna(intf *vsid, intf *findex, intf *aindex, intf *values);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfcgca(intf *vsid, intf *findex, intf *aindex, _fcd values);
+HDFFCLIBAPI intf nvsfcgca(intf *vsid, intf *findex, intf *aindex, _fcd values);
 
-HDFFCLIBAPI FRETVAL(intf) nvsfcisa(intf *vsid);
+HDFFCLIBAPI intf nvsfcisa(intf *vsid);
 
-HDFFCLIBAPI FRETVAL(intf) nvfcnats(intf *vgid);
+HDFFCLIBAPI intf nvfcnats(intf *vgid);
 
-HDFFCLIBAPI FRETVAL(intf)
-    nvfcainf(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size);
+HDFFCLIBAPI intf nvfcainf(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size);
 
-HDFFCLIBAPI FRETVAL(intf) nvfcgnat(intf *vgid, intf *aindex, intf *values);
+HDFFCLIBAPI intf nvfcgnat(intf *vgid, intf *aindex, intf *values);
 
-HDFFCLIBAPI FRETVAL(intf) nvfcgcat(intf *vgid, intf *aindex, _fcd values);
+HDFFCLIBAPI intf nvfcgcat(intf *vgid, intf *aindex, _fcd values);
 
-HDFFCLIBAPI FRETVAL(intf) nvfcgver(intf *vgid);
+HDFFCLIBAPI intf nvfcgver(intf *vgid);
 /* End of windows */
 
 /*
@@ -1258,9 +1244,9 @@ HDFFCLIBAPI FRETVAL(intf) nvfcgver(intf *vgid);
 
 #define nduif2i H4_F77_FUNC(duif2i, DUIF2I)
 
-HDFFCLIBAPI FRETVAL(int) nduif2i(int32 *hdim, int32 *vdim, float32 *max, float32 *min, float32 hscale[],
-                                 float32 vscale[], float32 data[], _fcd palette, _fcd outfile, int *ct_method,
-                                 int32 *hres, int32 *vres, int *compress, int *lenfn);
+HDFFCLIBAPI int nduif2i(int32 *hdim, int32 *vdim, float32 *max, float32 *min, float32 hscale[],
+                        float32 vscale[], float32 data[], _fcd palette, _fcd outfile, int *ct_method,
+                        int32 *hres, int32 *vres, int *compress, int *lenfn);
 
 #ifdef __cplusplus
 }

--- a/hdf/src/mfanf.c
+++ b/hdf/src/mfanf.c
@@ -68,7 +68,7 @@
  * Users:
  * Invokes: ANstart()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafstart(intf *file_id)
 {
     intf ret;
@@ -90,7 +90,7 @@ nafstart(intf *file_id)
  * Users:   Fortran Users
  * Invokes: ANfileinfo()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 naffileinfo(intf *an_id, intf *num_flabel, intf *num_fdesc, intf *num_olabel, intf *num_odesc)
 {
     intf  ret;
@@ -115,7 +115,7 @@ naffileinfo(intf *an_id, intf *num_flabel, intf *num_fdesc, intf *num_olabel, in
  * Users:   Fortran Users
  * Invokes: ANend()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafend(intf *an_id)
 {
     return (intf)ANend((int32)*an_id);
@@ -132,7 +132,7 @@ nafend(intf *an_id)
  * Users:   Fortran Users
  * Invokes: ANcreate()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafcreate(intf *an_id, intf *etag, intf *eref, intf *atype)
 {
     return (intf)ANcreate((int32)*an_id, (uint16)*etag, (uint16)*eref, (ann_type)*atype);
@@ -147,7 +147,7 @@ nafcreate(intf *an_id, intf *etag, intf *eref, intf *atype)
  * Users:   Fortran Users
  * Invokes: ANcreatf()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 naffcreate(intf *an_id, intf *atype)
 {
     return (intf)ANcreatef((int32)*an_id, (ann_type)*atype);
@@ -168,7 +168,7 @@ naffcreate(intf *an_id, intf *atype)
  * Users:   Fortran Users
  * Invokes: ANselect()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafselect(intf *an_id, intf *index, intf *atype)
 {
     return (intf)ANselect((int32)*an_id, (int32)*index, (ann_type)*atype);
@@ -185,7 +185,7 @@ nafselect(intf *an_id, intf *index, intf *atype)
  * Users:   Fortran Users
  * Invokes: ANnumann()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafnumann(intf *an_id, intf *atype, intf *etag, intf *eref)
 {
     return (intf)ANnumann((int32)*an_id, (ann_type)*atype, (uint16)*etag, (uint16)*eref);
@@ -203,7 +203,7 @@ nafnumann(intf *an_id, intf *atype, intf *etag, intf *eref)
  * Users:   Fortran Users
  * Invokes: ANnumann(), ANannlist()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafannlist(intf *an_id, intf *atype, intf *etag, intf *eref, intf alist[])
 {
     intf   ret;
@@ -243,7 +243,7 @@ nafannlist(intf *an_id, intf *atype, intf *etag, intf *eref, intf alist[])
  * Users:   Fortran Users
  * Invokes: ANannlen()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafannlen(intf *an_id)
 {
     return (intf)ANannlen((int32)*an_id);
@@ -259,7 +259,7 @@ nafannlen(intf *an_id)
  * Users:   Fortran Users
  * Invokes: ANwriteann()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafwriteann(intf *ann_id, _fcd ann, intf *annlen)
 {
     char *iann = NULL;
@@ -287,7 +287,7 @@ nafwriteann(intf *ann_id, _fcd ann, intf *annlen)
  * Users:   Fortran Users
  * Invokes: ANreadann()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafreadann(intf *ann_id, _fcd ann, intf *maxlen)
 {
     char *iann = NULL;
@@ -318,7 +318,7 @@ nafreadann(intf *ann_id, _fcd ann, intf *maxlen)
  * Users:   Fortran Users
  * Invokes: ANendaccess()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafendaccess(intf *ann_id)
 {
     return (intf)ANendaccess((int32)*ann_id);
@@ -332,7 +332,7 @@ nafendaccess(intf *ann_id)
  * Users:   Fortran Users
  * Invokes: ANget_tagref()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafgettagref(intf *an_id, intf *index, intf *type, intf *tag, intf *ref)
 {
     intf   ret;
@@ -354,7 +354,7 @@ nafgettagref(intf *an_id, intf *index, intf *type, intf *tag, intf *ref)
  * Users:   Fortran Users
  * Invokes: ANid2tagerf()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafidtagref(intf *ann_id, intf *tag, intf *ref)
 {
     intf   ret;
@@ -376,7 +376,7 @@ nafidtagref(intf *ann_id, intf *tag, intf *ref)
  * Users:   Fortran Users
  * Invokes: ANtagref2id()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 naftagrefid(intf *an_id, intf *tag, intf *ref)
 {
     return (intf)ANtagref2id((int32)*an_id, (uint16)*tag, (uint16)*ref);
@@ -390,7 +390,7 @@ naftagrefid(intf *an_id, intf *tag, intf *ref)
  * Users:   Fortran Users
  * Invokes: ANatype2tag()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nafatypetag(intf *atype)
 {
     return (intf)ANatype2tag((ann_type)*atype);
@@ -404,7 +404,7 @@ nafatypetag(intf *atype)
  * Users:   Fortran Users
  * Invokes: ANtag2atype()
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 naftagatype(intf *tag)
 {
     return (intf)ANtag2atype((uint16)*tag);

--- a/hdf/src/mfgrf.c
+++ b/hdf/src/mfgrf.c
@@ -71,7 +71,7 @@
  * Invokes: GRstart
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgstart(intf *fid)
 {
     return (intf)GRstart((int32)*fid);
@@ -88,7 +88,7 @@ nmgstart(intf *fid)
  * Invokes: GRfileinfo
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgfinfo(intf *grid, intf *n_datasets, intf *n_attrs)
 {
     int32 n_data, n_attr;
@@ -109,7 +109,7 @@ nmgfinfo(intf *grid, intf *n_datasets, intf *n_attrs)
  * Invokes: GRend
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgend(intf *grid)
 {
     return (intf)GRend((int32)*grid);
@@ -131,7 +131,7 @@ nmgend(intf *grid)
  * Invokes: GRcreate
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgicreat(intf *grid, _fcd name, intf *ncomp, intf *nt, intf *il, intf dimsizes[2], intf *nlen)
 {
     char *fn;
@@ -163,7 +163,7 @@ nmgicreat(intf *grid, _fcd name, intf *ncomp, intf *nt, intf *il, intf dimsizes[
  * Invokes: GRselect
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgselct(intf *grid, intf *index)
 {
     return (intf)GRselect((int32)*grid, (int32)*index);
@@ -181,7 +181,7 @@ nmgselct(intf *grid, intf *index)
  * Invokes: GRnametoindex
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgin2ndx(intf *grid, _fcd name, intf *nlen)
 {
     char *fn;
@@ -215,7 +215,7 @@ nmgin2ndx(intf *grid, _fcd name, intf *nlen)
  * Invokes: GRgetiminfo
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmggiinf(intf *riid, _fcd name, intf *ncomp, intf *nt, intf *il, intf *dimsizes, intf *nattr)
 {
     int32 t_ncomp, t_nt, t_il, t_dimsizes[2], t_nattr;
@@ -248,7 +248,7 @@ nmggiinf(intf *riid, _fcd name, intf *ncomp, intf *nt, intf *il, intf *dimsizes,
  * Invokes: GRwriteimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgwcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data)
 {
     return nmgwrimg(riid, start, stride, count, (void *)_fcdtocp(data));
@@ -268,7 +268,7 @@ nmgwcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data)
  * Invokes: GRwriteimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgwrimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
 {
     int32 t_start[2], t_stride[2], t_count[2];
@@ -298,7 +298,7 @@ nmgwrimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
  * Invokes: GRreadimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgrcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data)
 {
     return nmgrdimg(riid, start, stride, count, (void *)_fcdtocp(data));
@@ -318,7 +318,7 @@ nmgrcimg(intf *riid, intf *start, intf *stride, intf *count, _fcd data)
  * Invokes: GRreadimage
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgrdimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
 {
     int32 t_start[2], t_stride[2], t_count[2];
@@ -344,7 +344,7 @@ nmgrdimg(intf *riid, intf *start, intf *stride, intf *count, void *data)
  * Invokes: GRendaccess
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgendac(intf *riid)
 {
     return (intf)GRendaccess((int32)*riid);
@@ -360,7 +360,7 @@ nmgendac(intf *riid)
  * Invokes: GRidtoref
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgid2rf(intf *riid)
 {
     return (intf)GRidtoref((int32)*riid);
@@ -377,7 +377,7 @@ nmgid2rf(intf *riid)
  * Invokes: GRreftoindex
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgr2idx(intf *grid, intf *ref)
 {
     return (intf)GRreftoindex((int32)*grid, (uint16)*ref);
@@ -394,7 +394,7 @@ nmgr2idx(intf *grid, intf *ref)
  * Invokes: GRreqlutil
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgrltil(intf *riid, intf *il)
 {
     return (intf)GRreqlutil((int32)*riid, (intn)*il);
@@ -411,7 +411,7 @@ nmgrltil(intf *riid, intf *il)
  * Invokes: GRreqimageil
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgrimil(intf *riid, intf *il)
 {
     return (intf)GRreqimageil((int32)*riid, (intn)*il);
@@ -428,7 +428,7 @@ nmgrimil(intf *riid, intf *il)
  * Invokes: GRgetlutid
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmggltid(intf *riid, intf *lut_index)
 {
     return (intf)GRgetlutid((int32)*riid, (intn)*lut_index);
@@ -448,7 +448,7 @@ nmggltid(intf *riid, intf *lut_index)
  * Invokes: GRgetlutinfo
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgglinf(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries)
 {
     int32 t_ncomp, t_nt, t_il, t_nentries;
@@ -477,7 +477,7 @@ nmgglinf(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries)
  * Invokes: GRwritelut
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data)
 {
     return (intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries,
@@ -499,7 +499,7 @@ nmgwclut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, _fcd data
  * Invokes: GRwritelut
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgwrlut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, void *data)
 {
     return (intf)GRwritelut((int32)*lutid, (int32)*ncomp, (int32)*nt, (int32)*il, (int32)*nentries, data);
@@ -516,7 +516,7 @@ nmgwrlut(intf *lutid, intf *ncomp, intf *nt, intf *il, intf *nentries, void *dat
  * Invokes: GRreadlut
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgrclut(intf *lutid, _fcd data)
 {
     return (intf)GRreadlut((int32)*lutid, (void *)_fcdtocp(data));
@@ -533,7 +533,7 @@ nmgrclut(intf *lutid, _fcd data)
  * Invokes: GRreadlut
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgrdlut(intf *lutid, void *data)
 {
     return (intf)GRreadlut((int32)*lutid, data);
@@ -552,7 +552,7 @@ nmgrdlut(intf *lutid, void *data)
  * Invokes: GRsetexternalfile
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgisxfil(intf *riid, _fcd filename, intf *offset, intf *nlen)
 {
     char *fn;
@@ -580,7 +580,7 @@ nmgisxfil(intf *riid, _fcd filename, intf *offset, intf *nlen)
  * Invokes: GRsetaccesstype
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgsactp(intf *riid, intf *accesstype)
 {
     return (intf)GRsetaccesstype((int32)*riid, (uintn)*accesstype);
@@ -600,7 +600,7 @@ nmgsactp(intf *riid, intf *accesstype)
  * Users:   HDF Fortran programmers
  * Invokes: GRsetattr
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgiscatt(intf *riid, _fcd name, intf *nt, intf *count, _fcd data, intf *nlen)
 {
     return nmgisattr(riid, name, nt, count, (void *)_fcdtocp(data), nlen);
@@ -620,7 +620,7 @@ nmgiscatt(intf *riid, _fcd name, intf *nt, intf *count, _fcd data, intf *nlen)
  * Invokes: GRsetattr
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgisattr(intf *riid, _fcd name, intf *nt, intf *count, void *data, intf *nlen)
 {
     char *fn;
@@ -651,7 +651,7 @@ nmgisattr(intf *riid, _fcd name, intf *nt, intf *count, void *data, intf *nlen)
  * Invokes: GRattrinfo
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgatinf(intf *riid, intf *index, _fcd name, intf *nt, intf *count)
 {
     int32 t_nt, t_count;
@@ -676,7 +676,7 @@ nmgatinf(intf *riid, intf *index, _fcd name, intf *nt, intf *count)
  * Invokes: GRgetattr
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmggcatt(intf *riid, intf *index, _fcd data)
 {
     return nmggnatt(riid, index, (void *)_fcdtocp(data));
@@ -694,7 +694,7 @@ nmggcatt(intf *riid, intf *index, _fcd data)
  * Invokes: GRgetattr
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmggnatt(intf *riid, intf *index, void *data)
 {
     return (intf)GRgetattr((int32)*riid, (int32)*index, data);
@@ -713,7 +713,7 @@ nmggnatt(intf *riid, intf *index, void *data)
  * Remarks: This routine is replaced by mggcatt and mggmatt
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmggattr(intf *riid, intf *index, void *data)
 {
     return (intf)GRgetattr((int32)*riid, (int32)*index, data);
@@ -731,7 +731,7 @@ nmggattr(intf *riid, intf *index, void *data)
  * Invokes: GRfindattr
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nmgifndat(intf *riid, _fcd name, intf *nlen)
 {
     char *fn;
@@ -759,7 +759,7 @@ nmgifndat(intf *riid, _fcd name, intf *nlen)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcgichnk(intf *id, intf *dim_length, intf *flags)
 {
 
@@ -818,7 +818,7 @@ nmgcgichnk(intf *id, intf *dim_length, intf *flags)
  * Reamrks:  dimensions will be flipped in scrchnk function
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcrcchnk(intf *id, intf *start, _fcd char_data)
 {
     intf ret;
@@ -840,7 +840,7 @@ nmgcrcchnk(intf *id, intf *start, _fcd char_data)
  *           If performance becomes an issue, use static cstart
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcrchnk(intf *id, intf *start, void *num_data)
 {
     intf   ret;
@@ -880,7 +880,7 @@ nmgcrchnk(intf *id, intf *start, void *num_data)
  * Calls:    GRsetchunkcache
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcscchnk(intf *id, intf *maxcache, intf *flags)
 {
     intf ret;
@@ -908,7 +908,7 @@ nmgcscchnk(intf *id, intf *maxcache, intf *flags)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm)
 {
 
@@ -992,7 +992,7 @@ nmgcschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm)
  * Reamrks:  dimensions will be flipped in scrchnk function
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcwcchnk(intf *id, intf *start, _fcd char_data)
 {
     intf ret;
@@ -1014,7 +1014,7 @@ nmgcwcchnk(intf *id, intf *start, _fcd char_data)
  *           If performance becomes an issue, use static cstart
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcwchnk(intf *id, intf *start, void *num_data)
 {
     intf   ret;
@@ -1063,7 +1063,7 @@ nmgcwchnk(intf *id, intf *start, void *num_data)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcscompress(intf *id, intf *comp_type, intf *comp_prm)
 {
     int32        riid;   /*  GR id               */
@@ -1126,7 +1126,7 @@ nmgcscompress(intf *id, intf *comp_type, intf *comp_prm)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcgcompress(intf *id, intf *comp_type, intf *comp_prm)
 {
     comp_info    c_info; /* compression info     */
@@ -1185,7 +1185,7 @@ nmgcgcompress(intf *id, intf *comp_type, intf *comp_prm)
  *          if one doesn't / FAIL
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmglt2rf(intf *id)
 {
     intf ret;
@@ -1200,7 +1200,7 @@ nmglt2rf(intf *id)
  * Returns: number of palettes on success and -1 if fails.
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nmgcgnluts(intf *id)
 {
     intf ret = -1;

--- a/hdf/src/vattrf.c
+++ b/hdf/src/vattrf.c
@@ -30,7 +30,7 @@
  *  VSfindex -- vsfcfdx -- vsffidx
  */
 
-FRETVAL(intf)
+intf
 nvsfcfdx(intf *vsid, _fcd fldnm, intf *findex, intf *fldnmlen)
 {
     intf  ret;
@@ -50,7 +50,7 @@ nvsfcfdx(intf *vsid, _fcd fldnm, intf *findex, intf *fldnmlen)
  * VSsetattr -- vsfcsat -- vsfsnat
  */
 
-FRETVAL(intf)
+intf
 nvsfcsat(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *attrnmlen)
 {
     intf  ret;
@@ -73,7 +73,7 @@ nvsfcsat(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, intf *
  * VSsetattr -- vsfcsca -- vsfscat
  */
 
-FRETVAL(intf)
+intf
 nvsfcsca(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *attrnmlen)
 {
     intf  ret;
@@ -96,7 +96,7 @@ nvsfcsca(intf *vsid, intf *findex, _fcd attrnm, intf *dtype, intf *count, _fcd v
  * VSnattrs -- vsfnats
  */
 
-FRETVAL(intf)
+intf
 nvsfnats(intf *vsid)
 {
     intf ret;
@@ -111,7 +111,7 @@ nvsfnats(intf *vsid)
  * VSfnattrs -- vsffnas
  */
 
-FRETVAL(intf)
+intf
 nvsffnas(intf *vsid, intf *findex)
 {
     intf  ret;
@@ -128,7 +128,7 @@ nvsffnas(intf *vsid, intf *findex)
  *    VSfindattr -- vsfcfda -- vsffdat
  */
 
-FRETVAL(intf)
+intf
 nvsfcfda(intf *vsid, intf *findex, _fcd attrnm, intf *attrnmlen)
 {
     intf  ret;
@@ -150,7 +150,7 @@ nvsfcfda(intf *vsid, intf *findex, _fcd attrnm, intf *attrnmlen)
  * VSattrinfo -- vsfcain -- vsfainf
  */
 
-FRETVAL(intf)
+intf
 nvsfcain(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size,
          intf *attrnamelen)
 {
@@ -184,7 +184,7 @@ nvsfcain(intf *vsid, intf *findex, intf *aindex, _fcd attrname, intf *dtype, int
  * VSgetattr -- vsfgnat
  */
 
-FRETVAL(intf)
+intf
 nvsfgnat(intf *vsid, intf *findex, intf *aindex, intf *values)
 {
     intf  ret;
@@ -200,7 +200,7 @@ nvsfgnat(intf *vsid, intf *findex, intf *aindex, intf *values)
  * VSgetattr -- vsfgcat
  */
 
-FRETVAL(intf)
+intf
 nvsfgcat(intf *vsid, intf *findex, intf *aindex, _fcd values)
 {
     intf  ret;
@@ -216,7 +216,7 @@ nvsfgcat(intf *vsid, intf *findex, intf *aindex, _fcd values)
  * VSisattr -- vsfisat
  */
 
-FRETVAL(intf)
+intf
 nvsfisat(intf *vsid)
 {
     intf ret;
@@ -229,7 +229,7 @@ nvsfisat(intf *vsid)
  * Vsetattr -- vfcsatt -- vfsnatt
  */
 
-FRETVAL(intf)
+intf
 nvfcsatt(intf *vgid, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *attrnmlen)
 {
     intf  ret;
@@ -249,7 +249,7 @@ nvfcsatt(intf *vgid, _fcd attrnm, intf *dtype, intf *count, intf *values, intf *
  * Vsetattr -- vfcscat -- vfscatt
  */
 
-FRETVAL(intf)
+intf
 nvfcscat(intf *vgid, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *attrnmlen)
 {
     intf  ret;
@@ -268,7 +268,7 @@ nvfcscat(intf *vgid, _fcd attrnm, intf *dtype, intf *count, _fcd values, intf *a
  * Vnattrs -- vfnatts
  */
 
-FRETVAL(intf)
+intf
 nvfnatts(intf *vgid)
 {
     intf ret;
@@ -282,7 +282,7 @@ nvfnatts(intf *vgid)
  * Vfindattr -- vfcfdat -- vffdatt
  */
 
-FRETVAL(intf)
+intf
 nvfcfdat(intf *vgid, _fcd attrnm, intf *attrnmlen)
 {
     intf  ret;
@@ -301,7 +301,7 @@ nvfcfdat(intf *vgid, _fcd attrnm, intf *attrnmlen)
  * Vattrinfo -- vfainfo
  */
 
-FRETVAL(intf)
+intf
 nvfainfo(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf *size)
 {
     intf ret;
@@ -315,7 +315,7 @@ nvfainfo(intf *vgid, intf *aindex, _fcd attrname, intf *dtype, intf *count, intf
  * Vgetattr -- vfgnatt
  */
 
-FRETVAL(intf)
+intf
 nvfgnatt(intf *vgid, intf *aindex, intf *values)
 {
     intf ret;
@@ -328,7 +328,7 @@ nvfgnatt(intf *vgid, intf *aindex, intf *values)
  * Vgetattr -- vfgcatt
  */
 
-FRETVAL(intf)
+intf
 nvfgcatt(intf *vgid, intf *aindex, _fcd values)
 {
     intf ret;
@@ -341,7 +341,7 @@ nvfgcatt(intf *vgid, intf *aindex, _fcd values)
  * Vgetversion -- vfgver
  */
 
-FRETVAL(intf)
+intf
 nvfgver(intf *vgid)
 {
     intf ret;

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -73,7 +73,7 @@ trimendblanks(char *ss)
  * Method:  Convert filename to C string, call Hopen
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfivopn(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
 {
     char *fn;
@@ -96,7 +96,7 @@ ndfivopn(_fcd name, intf *acc_mode, intf *defdds, intf *namelen)
  * Invokes: Hclose
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ndfvclos(intf *file_id)
 {
     return Vclose((int32)*file_id);
@@ -107,7 +107,7 @@ ndfvclos(intf *file_id)
  **  related: Vattach--vatchc--VFATCH
  */
 
-FRETVAL(intf)
+intf
 nvatchc(intf *f, intf *vgid, _fcd accesstype)
 {
     int32 vkey;
@@ -130,7 +130,7 @@ nvatchc(intf *f, intf *vgid, _fcd accesstype)
  **  related: Vdetach--vdtchc--VFDTCH
  */
 
-FRETVAL(intf)
+intf
 nvdtchc(intf *vkey)
 {
     return Vdetach(*vkey);
@@ -142,7 +142,7 @@ nvdtchc(intf *vkey)
  **  related: Vgetname--vgnamc--VFGNAM
  */
 
-FRETVAL(intf)
+intf
 nvgnamc(intf *vkey, _fcd vgname)
 {
     return Vgetname(*vkey, _fcdtocp(vgname));
@@ -154,7 +154,7 @@ nvgnamc(intf *vkey, _fcd vgname)
  **  related: Vgetclass--vgclsc--VFGCLS
  */
 
-FRETVAL(intf)
+intf
 nvgclsc(intf *vkey, _fcd vgclass)
 {
     return Vgetclass(*vkey, _fcdtocp(vgclass));
@@ -166,7 +166,7 @@ nvgclsc(intf *vkey, _fcd vgclass)
  **  related: Vinquire--vinqc--VFINQ
  */
 
-FRETVAL(intf)
+intf
 nvinqc(intf *vkey, intf *nentries, _fcd vgname)
 {
     return (intf)Vinquire(*vkey, (int32 *)nentries, _fcdtocp(vgname));
@@ -178,7 +178,7 @@ nvinqc(intf *vkey, intf *nentries, _fcd vgname)
  **  related: Vdelete--vdelete--
  */
 
-FRETVAL(intf)
+intf
 nvdelete(intf *f, intf *vkey)
 {
     return (intf)Vdelete((int32)*f, (int32)*vkey);
@@ -190,7 +190,7 @@ nvdelete(intf *f, intf *vkey)
  **  related: Vgetid--vgidc--VFGID
  */
 
-FRETVAL(intf)
+intf
 nvgidc(intf *f, intf *vgid)
 {
     return (intf)Vgetid((int32)*f, *vgid);
@@ -202,7 +202,7 @@ nvgidc(intf *f, intf *vgid)
  **  related: Vgetnext--vgnxtc--VFGNXT
  */
 
-FRETVAL(intf)
+intf
 nvgnxtc(intf *vkey, intf *id)
 {
     return Vgetnext(*vkey, *id);
@@ -214,7 +214,7 @@ nvgnxtc(intf *vkey, intf *id)
  **  related: Vsetname--vsnamc--VFSNAM
  */
 
-FRETVAL(intf)
+intf
 nvsnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
 {
     char *name;
@@ -236,7 +236,7 @@ nvsnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
  **  related: Vsetclass--vsclsc--VFSCLS
  */
 
-FRETVAL(intf)
+intf
 nvsclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 {
     char *tclass;
@@ -258,7 +258,7 @@ nvsclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
  **  related: Vinsert--vinsrtc--VFINSRT
  */
 
-FRETVAL(intf)
+intf
 nvinsrtc(intf *vkey, intf *vobjptr)
 {
     return (intf)Vinsert(*vkey, *vobjptr);
@@ -270,7 +270,7 @@ nvinsrtc(intf *vkey, intf *vobjptr)
  **  related: Visvg--visvgc--VFISVG
  */
 
-FRETVAL(intf)
+intf
 nvisvgc(intf *vkey, intf *id)
 {
     return (intf)Visvg(*vkey, *id);
@@ -281,7 +281,7 @@ nvisvgc(intf *vkey, intf *id)
  **  wrapper for Vstart
  */
 
-FRETVAL(intf)
+intf
 nvfstart(intf *f)
 {
     return Vstart((int32)*f);
@@ -292,7 +292,7 @@ nvfstart(intf *f)
  **  wrapper for Vend
  */
 
-FRETVAL(intf)
+intf
 nvfend(intf *f)
 {
     return (intf)Vend((int32)*f);
@@ -304,7 +304,7 @@ nvfend(intf *f)
  **  related: Visvs--visvsc--VFISVS
  */
 
-FRETVAL(intf)
+intf
 nvisvsc(intf *vkey, intf *id)
 {
     return (intf)Visvs(*vkey, *id);
@@ -319,7 +319,7 @@ nvisvsc(intf *vkey, intf *id)
  **  related: VSattach--vsatchc--VFATCH
  */
 
-FRETVAL(intf)
+intf
 nvsatchc(intf *f, intf *vsid, _fcd accesstype)
 {
     /* need not HDf2cstring since only first char is accessed. */
@@ -332,7 +332,7 @@ nvsatchc(intf *f, intf *vsid, _fcd accesstype)
  **  related: VSdetach--vsdtchc--VFDTCH
  */
 
-FRETVAL(intf)
+intf
 nvsdtchc(intf *vkey)
 {
     return VSdetach(*vkey);
@@ -344,7 +344,7 @@ nvsdtchc(intf *vkey)
  **  related: VSQueryref--vsqref--
  */
 
-FRETVAL(intf)
+intf
 nvsqref(intf *vkey)
 {
     return (intf)VSQueryref((int32)*vkey);
@@ -356,7 +356,7 @@ nvsqref(intf *vkey)
  **  related: VSQuerytag--vsqtag--
  */
 
-FRETVAL(intf)
+intf
 nvsqtag(intf *vkey)
 {
     return (intf)VSQuerytag((int32)*vkey);
@@ -368,7 +368,7 @@ nvsqtag(intf *vkey)
  **  related: VSgetversion--vsgver--
  */
 
-FRETVAL(intf)
+intf
 nvsgver(intf *vkey)
 {
     return (intf)VSgetversion((int32)*vkey);
@@ -380,7 +380,7 @@ nvsgver(intf *vkey)
  **  related: VSseek--vsseekc--VSFSEEK
  */
 
-FRETVAL(intf)
+intf
 nvsseekc(intf *vkey, intf *eltpos)
 {
     return (intf)VSseek(*vkey, *eltpos);
@@ -392,7 +392,7 @@ nvsseekc(intf *vkey, intf *eltpos)
  **  related: VSgetname--vsgnamc--VSFGNAM
  */
 
-FRETVAL(intf)
+intf
 nvsgnamc(intf *vkey, _fcd vsname, intf *vsnamelen)
 {
     char *tvsname = NULL;
@@ -418,7 +418,7 @@ nvsgnamc(intf *vkey, _fcd vsname, intf *vsnamelen)
  **  related: VSgetclass--vsgclsc--VSFGCLS
  */
 
-FRETVAL(intf)
+intf
 nvsgclsc(intf *vkey, _fcd vsclass, intf *vsclasslen)
 {
     char *tvsclass = NULL;
@@ -444,7 +444,7 @@ nvsgclsc(intf *vkey, _fcd vsclass, intf *vsclasslen)
  **  related: VSinquire--vsinqc--VSFINQ
  */
 
-FRETVAL(intf)
+intf
 nvsinqc(intf *vkey, intf *nelt, intf *interlace, _fcd fields, intf *eltsize, _fcd vsname, intf *fieldslen,
         intf *vsnamelen)
 {
@@ -486,7 +486,7 @@ nvsinqc(intf *vkey, intf *nelt, intf *interlace, _fcd fields, intf *eltsize, _fc
  **  related: VSfexist--vsfexc--VSFEX
  */
 
-FRETVAL(intf)
+intf
 nvsfexc(intf *vkey, _fcd fields, intf *fieldslen)
 {
     intf  ret;
@@ -508,7 +508,7 @@ nvsfexc(intf *vkey, _fcd fields, intf *fieldslen)
  **  related: VSfind--vsfndc--VSFFND
  */
 
-FRETVAL(intf)
+intf
 nvsfndc(intf *f, _fcd name, intf *namelen)
 {
     intf  ret;
@@ -530,7 +530,7 @@ nvsfndc(intf *f, _fcd name, intf *namelen)
  **  related: VSgetid--vsgidc--VSFGID
  */
 
-FRETVAL(intf)
+intf
 nvsgidc(intf *f, intf *vsid)
 {
     return (intf)VSgetid(*f, *vsid);
@@ -542,7 +542,7 @@ nvsgidc(intf *f, intf *vsid)
  **  related: VSdelete--vsdltc--VSFDLTE
  */
 
-FRETVAL(intf)
+intf
 nvsdltc(intf *f, intf *vsid)
 {
     return (intf)VSdelete(*f, *vsid);
@@ -554,7 +554,7 @@ nvsdltc(intf *f, intf *vsid)
  **  related: VSappendable--vsapp--
  */
 
-FRETVAL(intf)
+intf
 nvsapp(intf *vkey, intf *blk)
 {
     return (intf)VSappendable((int32)*vkey, (int32)*blk);
@@ -566,7 +566,7 @@ nvsapp(intf *vkey, intf *blk)
  **  related: VSsetname--vssnamc--VSFSNAM
  */
 
-FRETVAL(intf)
+intf
 nvssnamc(intf *vkey, _fcd vsname, intf *vsnamelen)
 {
     char *name;
@@ -588,7 +588,7 @@ nvssnamc(intf *vkey, _fcd vsname, intf *vsnamelen)
  **  related: VSsetclass--vssclsc--VSFSCLS
  */
 
-FRETVAL(intf)
+intf
 nvssclsc(intf *vkey, _fcd vsclass, intf *vsclasslen)
 {
     char *tclass;
@@ -610,7 +610,7 @@ nvssclsc(intf *vkey, _fcd vsclass, intf *vsclasslen)
  **  related: VSsetfields--vssfldc--VSFSFLD
  */
 
-FRETVAL(intf)
+intf
 nvssfldc(intf *vkey, _fcd fields, intf *fieldslen)
 {
     char *flds;
@@ -632,7 +632,7 @@ nvssfldc(intf *vkey, _fcd fields, intf *fieldslen)
  **  related: VSsetinterlace--vssintc--VSFSINT
  */
 
-FRETVAL(intf)
+intf
 nvssintc(intf *vkey, intf *interlace)
 {
     return (intf)VSsetinterlace(*vkey, *interlace);
@@ -644,7 +644,7 @@ nvssintc(intf *vkey, intf *interlace)
  **  related: VSfdefine--vsfdefc--VSFFDEF
  */
 
-FRETVAL(intf)
+intf
 nvsfdefc(intf *vkey, _fcd field, intf *localtype, intf *order, intf *fieldlen)
 {
     intf  ret;
@@ -670,7 +670,7 @@ nvsfdefc(intf *vkey, _fcd field, intf *localtype, intf *order, intf *fieldlen)
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nvssextfc(intf *id, _fcd name, intf *offset, intf *namelen)
 {
     char *fn;
@@ -690,7 +690,7 @@ nvssextfc(intf *id, _fcd name, intf *offset, intf *namelen)
  **  related: VFnfields--vfnflds--
  */
 
-FRETVAL(intf)
+intf
 nvfnflds(intf *vkey)
 {
     return (intf)VFnfields((int32)*vkey);
@@ -702,7 +702,7 @@ nvfnflds(intf *vkey)
  **  related: VFfieldname--vffname--vffnamec
  */
 
-FRETVAL(intf)
+intf
 nvffnamec(intf *vkey, intf *index, _fcd fname, intf *len)
 {
     char *fieldname = NULL;
@@ -723,7 +723,7 @@ nvffnamec(intf *vkey, intf *index, _fcd fname, intf *len)
  **  related: VFfieldtype--vfftype--
  */
 
-FRETVAL(intf)
+intf
 nvfftype(intf *vkey, intf *index)
 {
     return (intf)VFfieldtype((int32)*vkey, (int32)*index);
@@ -735,7 +735,7 @@ nvfftype(intf *vkey, intf *index)
  **  related: VFfieldisize--vffisiz--
  */
 
-FRETVAL(intf)
+intf
 nvffisiz(intf *vkey, intf *index)
 {
     return (intf)VFfieldisize((int32)*vkey, (int32)*index);
@@ -747,7 +747,7 @@ nvffisiz(intf *vkey, intf *index)
  **  related: VFfieldesize--vffesiz--
  */
 
-FRETVAL(intf)
+intf
 nvffesiz(intf *vkey, intf *index)
 {
     return (intf)VFfieldesize((int32)*vkey, (int32)*index);
@@ -759,7 +759,7 @@ nvffesiz(intf *vkey, intf *index)
  **  related: VFfieldorder--vffordr--
  */
 
-FRETVAL(intf)
+intf
 nvffordr(intf *vkey, intf *index)
 {
     return (intf)VFfieldorder((int32)*vkey, (int32)*index);
@@ -771,7 +771,7 @@ nvffordr(intf *vkey, intf *index)
  **  related: VSread--vsfrdc
  */
 
-FRETVAL(intf)
+intf
 nvsfrdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
 {
     return (intf)VSread(*vkey, (uint8 *)_fcdtocp(cbuf), *nelt, *interlace);
@@ -782,7 +782,7 @@ nvsfrdc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
  **  related: VSread--vsfrd
  */
 
-FRETVAL(intf)
+intf
 nvsfrd(intf *vkey, intf *buf, intf *nelt, intf *interlace)
 {
     return (intf)VSread(*vkey, (uint8 *)buf, *nelt, *interlace);
@@ -794,7 +794,7 @@ nvsfrd(intf *vkey, intf *buf, intf *nelt, intf *interlace)
  **  related: VSread--vsreadc--VSFREAD
  */
 
-FRETVAL(intf)
+intf
 nvsreadc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
 {
     return (intf)VSread(*vkey, buf, *nelt, *interlace);
@@ -806,7 +806,7 @@ nvsreadc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
  **  related: VSwrite--vsfwrtc
  */
 
-FRETVAL(intf)
+intf
 nvsfwrtc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
 {
     return (intf)VSwrite(*vkey, (uint8 *)_fcdtocp(cbuf), *nelt, *interlace);
@@ -818,7 +818,7 @@ nvsfwrtc(intf *vkey, _fcd cbuf, intf *nelt, intf *interlace)
  **  related: VSwrite--vsfwrt
  */
 
-FRETVAL(intf)
+intf
 nvsfwrt(intf *vkey, intf *buf, intf *nelt, intf *interlace)
 {
     return (intf)VSwrite(*vkey, (uint8 *)buf, *nelt, *interlace);
@@ -830,7 +830,7 @@ nvsfwrt(intf *vkey, intf *buf, intf *nelt, intf *interlace)
  **  related: VSwrite--vswritc--VSFWRIT
  */
 
-FRETVAL(intf)
+intf
 nvswritc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
 {
     return (intf)VSwrite(*vkey, buf, *nelt, *interlace);
@@ -847,7 +847,7 @@ nvswritc(intf *vkey, uint8 *buf, intf *nelt, intf *interlace)
  **  related: VSgetinterlace--vsgintc--VSFGINT
  */
 
-FRETVAL(intf)
+intf
 nvsgintc(intf *vkey)
 {
     return (intf)VSgetinterlace(*vkey);
@@ -859,7 +859,7 @@ nvsgintc(intf *vkey)
  **  related: VSelts--vseltsc--VSFELTS
  */
 
-FRETVAL(intf)
+intf
 nvseltsc(intf *vkey)
 {
     return (intf)VSelts(*vkey);
@@ -871,7 +871,7 @@ nvseltsc(intf *vkey)
  **  related: VSgetfields--vsgfldc--VSFGFLD
  */
 
-FRETVAL(intf)
+intf
 nvsgfldc(intf *vkey, _fcd fields)
 {
     return (intf)VSgetfields(*vkey, _fcdtocp(fields));
@@ -883,7 +883,7 @@ nvsgfldc(intf *vkey, _fcd fields)
  **  related: VSsizeof--vssizc--VSFSIZ
  */
 
-FRETVAL(intf)
+intf
 nvssizc(intf *vkey, _fcd fields, intf *fieldslen)
 {
     char *flds;
@@ -904,7 +904,7 @@ nvssizc(intf *vkey, _fcd fields, intf *fieldslen)
  **  related: Ventries--ventsc--VFENTS
  */
 
-FRETVAL(intf)
+intf
 nventsc(intf *f, intf *vgid)
 {
     return (intf)Ventries(*f, *vgid);
@@ -916,7 +916,7 @@ nventsc(intf *f, intf *vgid)
  **  related: Vlone--vlonec--VFLONE
  */
 
-FRETVAL(intf)
+intf
 nvlonec(intf *f, intf *idarray, intf *asize)
 {
     return (intf)Vlone(*f, (int32 *)idarray, (int32)*asize);
@@ -928,7 +928,7 @@ nvlonec(intf *f, intf *idarray, intf *asize)
  **  related: VSlone--vslonec--VSFLONE
  */
 
-FRETVAL(intf)
+intf
 nvslonec(intf *f, intf *idarray, intf *asize)
 {
     return VSlone(*f, (int32 *)idarray, (int32)*asize);
@@ -940,7 +940,7 @@ nvslonec(intf *f, intf *idarray, intf *asize)
  **  related: Vfind--vfindc--VFIND
  */
 
-FRETVAL(intf)
+intf
 nvfindc(intf *f, _fcd name, intf *namelen)
 {
     char *tmp_name;
@@ -962,7 +962,7 @@ nvfindc(intf *f, _fcd name, intf *namelen)
  **  related: Vfindclass--vfclassc--VFNDCLS
  */
 
-FRETVAL(intf)
+intf
 nvfndclsc(intf *f, _fcd vgclass, intf *classlen)
 {
     char *t_class;
@@ -989,7 +989,7 @@ nvfndclsc(intf *f, _fcd vgclass, intf *classlen)
  **  related: VHstoredata--vhsdc--vhfsd
  */
 
-FRETVAL(intf)
+intf
 nvhsdc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass, intf *fieldlen,
        intf *vsnamelen, intf *vsclasslen)
 {
@@ -1024,7 +1024,7 @@ nvhsdc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _f
  **  related: VHstoredata--vhscdc--vhfscd
  */
 
-FRETVAL(intf)
+intf
 nvhscdc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass, intf *fieldlen,
         intf *vsnamelen, intf *vsclasslen)
 {
@@ -1040,7 +1040,7 @@ nvhscdc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _f
  **  related: VHstoredatam--vhscdmc--vhfscdm
  */
 
-FRETVAL(intf)
+intf
 nvhscdmc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass, intf *order,
          intf *fieldlen, intf *vsnamelen, intf *vsclasslen)
 {
@@ -1056,7 +1056,7 @@ nvhscdmc(intf *f, _fcd field, _fcd cbuf, intf *n, intf *datatype, _fcd vsname, _
  **  related: VHstoredatam--vhsdmc--vhfsdm
  */
 
-FRETVAL(intf)
+intf
 nvhsdmc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _fcd vsclass, intf *order,
         intf *fieldlen, intf *vsnamelen, intf *vsclasslen)
 {
@@ -1092,7 +1092,7 @@ nvhsdmc(intf *f, _fcd field, uint8 *buf, intf *n, intf *datatype, _fcd vsname, _
  **  related: VHmakegroup--vhmkgpc--vhfmkgp
  */
 
-FRETVAL(intf)
+intf
 nvhmkgpc(intf *f, intf *tagarray, intf *refarray, intf *n, _fcd vgname, _fcd vgclass, intf *vgnamelen,
          intf *vgclasslen)
 {
@@ -1121,7 +1121,7 @@ nvhmkgpc(intf *f, intf *tagarray, intf *refarray, intf *n, _fcd vgname, _fcd vgc
  **  related: Vflocate--vffloc--vflocc
  */
 
-FRETVAL(intf)
+intf
 nvflocc(intf *vkey, _fcd field, intf *fieldlen)
 {
     char *fld;
@@ -1143,7 +1143,7 @@ nvflocc(intf *vkey, _fcd field, intf *fieldlen)
  **  related: Vinqtagref--vinqtrc--vfinqtr
  */
 
-FRETVAL(intf)
+intf
 nvinqtrc(intf *vkey, intf *tag, intf *ref)
 {
     return (intf)Vinqtagref(*vkey, *tag, *ref);
@@ -1154,7 +1154,7 @@ nvinqtrc(intf *vkey, intf *tag, intf *ref)
  **  related: Vntagrefs--vntrc--VFNTR
  */
 
-FRETVAL(intf)
+intf
 nvntrc(intf *vkey)
 {
     return (intf)Vntagrefs(*vkey);
@@ -1166,7 +1166,7 @@ nvntrc(intf *vkey)
  **  related: Vnrefs--vnrefs--
  */
 
-FRETVAL(intf)
+intf
 nvnrefs(intf *vkey, intf *tag)
 {
     return (intf)Vnrefs((int32)*vkey, (int32)*tag);
@@ -1178,7 +1178,7 @@ nvnrefs(intf *vkey, intf *tag)
  **  related: VQueryref--vqref--
  */
 
-FRETVAL(intf)
+intf
 nvqref(intf *vkey)
 {
     return (intf)VQueryref((int32)*vkey);
@@ -1190,7 +1190,7 @@ nvqref(intf *vkey)
  **  related: VQuerytag--vqtag--
  */
 
-FRETVAL(intf)
+intf
 nvqtag(intf *vkey)
 {
     return (intf)VQuerytag((int32)*vkey);
@@ -1203,7 +1203,7 @@ nvqtag(intf *vkey)
  **  related: Vgettagrefs--vgttrsc--vfgttrs
  */
 
-FRETVAL(intf)
+intf
 nvgttrsc(intf *vkey, intf *tagarray, intf *refarray, intf *n)
 {
     return (intf)Vgettagrefs(*vkey, (int32 *)tagarray, (int32 *)refarray, *n);
@@ -1215,7 +1215,7 @@ nvgttrsc(intf *vkey, intf *tagarray, intf *refarray, intf *n)
  **  related: Vgettagref--vgttrc--vfgttr
  */
 
-FRETVAL(intf)
+intf
 nvgttrc(intf *vkey, intf *which, intf *tag, intf *ref)
 {
     return (intf)Vgettagref(*vkey, *which, (int32 *)tag, (int32 *)ref);
@@ -1227,7 +1227,7 @@ nvgttrc(intf *vkey, intf *which, intf *tag, intf *ref)
  **  related: Vinqtagref--vinqtrc--vfinqtr
  */
 
-FRETVAL(intf)
+intf
 nvadtrc(intf *vkey, intf *tag, intf *ref)
 {
     return (intf)Vaddtagref(*vkey, *tag, *ref);
@@ -1239,7 +1239,7 @@ nvadtrc(intf *vkey, intf *tag, intf *ref)
  **  related: VSQuerycount--vsqfnelt
  */
 
-FRETVAL(intf)
+intf
 nvsqfnelt(intf *vkey, intf *nelt)
 {
     int32 ret_nelt = 0;
@@ -1257,7 +1257,7 @@ nvsqfnelt(intf *vkey, intf *nelt)
  **  related: VSQueryinterlace--vsqfintr
  */
 
-FRETVAL(intf)
+intf
 nvsqfintr(intf *vkey, intf *interlace)
 {
     int32 ret_inter = 0;
@@ -1275,7 +1275,7 @@ nvsqfintr(intf *vkey, intf *interlace)
  **  related: VSQueryfields--vsqfflds
  */
 
-FRETVAL(intf)
+intf
 nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen)
 {
     char *fld;
@@ -1296,7 +1296,7 @@ nvsqfldsc(intf *vkey, _fcd fields, intf *fieldslen)
  **  related: VSQueryvsize--vsqfvsiz
  */
 
-FRETVAL(intf)
+intf
 nvsqfvsiz(intf *vkey, intf *size)
 {
     int32 ret_size = 0;
@@ -1314,7 +1314,7 @@ nvsqfvsiz(intf *vkey, intf *size)
  **  related: VSQueryname--vsqfname
  */
 
-FRETVAL(intf)
+intf
 nvsqnamec(intf *vkey, _fcd name, intf *namelen)
 {
     char *nam;
@@ -1330,7 +1330,7 @@ nvsqnamec(intf *vkey, _fcd name, intf *namelen)
 }
 
 /* ------------------------------------------------------------------ */
-FRETVAL(intf)
+intf
 nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nrecs, _fcd pckfld, _fcd fldbuf,
          intf *buflds_len, intf *fld_len)
 {
@@ -1367,7 +1367,7 @@ nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
 }
 
 /* ------------------------------------------------------------------ */
-FRETVAL(intf)
+intf
 nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nrecs, _fcd pckfld,
          intf *fldbuf, intf *buflds_len, intf *fld_len)
 {
@@ -1409,7 +1409,7 @@ nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
  **
  */
 
-FRETVAL(intf)
+intf
 nvdtrc(intf *vkey, intf *tag, intf *ref)
 {
     return (intf)Vdeletetagref(*vkey, *tag, *ref);
@@ -1425,7 +1425,7 @@ nvdtrc(intf *vkey, intf *tag, intf *ref)
  *       Related functions: vffcls, VSfindclass
  *       Users:     HDF Fortran programmers
  ---------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nvscfcls(intf *id, _fcd name, intf *namelen)
 {
     intf  fi_id;
@@ -1449,7 +1449,7 @@ nvscfcls(intf *id, _fcd name, intf *namelen)
  *       Returns:   0 if succeeds, -1 if fails
  *       Users:     HDF Fortran programmers
  ---------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nvscsetblsz(intf *id, intf *block_size)
 {
     intf ret = -1;
@@ -1468,7 +1468,7 @@ nvscsetblsz(intf *id, intf *block_size)
  *       Returns:   0 if succeeds, -1 if fails
  *       Users:     HDF Fortran programmers
  ---------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nvscsetnmbl(intf *id, intf *num_blocks)
 {
     intf ret;
@@ -1488,7 +1488,7 @@ nvscsetnmbl(intf *id, intf *num_blocks)
  *       Returns:   0 if succeeds, -1 if fails
  *       Users:     HDF Fortran programmers
  ---------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nvscgblinfo(intf *id, intf *block_size, intf *num_blocks)
 {
     intf  ret = -1;
@@ -1515,7 +1515,7 @@ nvscgblinfo(intf *id, intf *block_size, intf *num_blocks)
  *       Returns:   0 if succeeds, -1 if fails
  *       Users:     HDF Fortran programmers
  ---------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nvcgvgrp(intf *id, intf *start_vg, intf *vg_count, intf *refarray)
 {
     intf    ret = -1;
@@ -1549,7 +1549,7 @@ nvcgvgrp(intf *id, intf *start_vg, intf *vg_count, intf *refarray)
  *       Returns:   0 if succeeds, -1 if fails
  *       Users:     HDF Fortran programmers
  ---------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nvscgvdatas(intf *id, intf *start_vd, intf *vd_count, intf *refarray)
 {
     intf    ret = -1;

--- a/hdf/test/forsupf.c
+++ b/hdf/test/forsupf.c
@@ -23,7 +23,7 @@
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 ngetverb(void)
 {
     char *verb_str;
@@ -45,7 +45,7 @@ ngetverb(void)
  * Invokes: system
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nhisystem(_fcd cmd, intf *cmdlen)
 {
     char *fn;
@@ -71,7 +71,7 @@ nhisystem(_fcd cmd, intf *cmdlen)
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
 
-FRETVAL(intf)
+intf
 nfixnamec(_fcd name, intf *name_len, _fcd name_out, intf *name_len_out)
 {
     char *c_name;

--- a/hdf/test/fortest.h
+++ b/hdf/test/fortest.h
@@ -26,8 +26,8 @@
 
 /* FORTRAN support C-stubs for FORTRAN interface tests */
 
-HDFFCLIBAPI FRETVAL(intf) ngetverb(void);
-HDFFCLIBAPI FRETVAL(intf) nhisystem(_fcd cmd, intf *cmdlen);
-HDFFCLIBAPI FRETVAL(intf) nfixnamec(_fcd name, intf *name_len, _fcd name_out, intf *name_len_out);
+HDFFCLIBAPI intf ngetverb(void);
+HDFFCLIBAPI intf nhisystem(_fcd cmd, intf *cmdlen);
+HDFFCLIBAPI intf nfixnamec(_fcd name, intf *name_len, _fcd name_out, intf *name_len_out);
 
 #endif /* H4_FORTEST_H */

--- a/mfhdf/fortran/mfsdf.c
+++ b/mfhdf/fortran/mfsdf.c
@@ -20,12 +20,12 @@
 */
 #include "mfsdf.h"
 
-FRETVAL(intf) nsfscfill(intf *id, _fcd val);
-FRETVAL(intf) nsfsfill(intf *id, void *val);
-FRETVAL(intf) nsfgfill(intf *id, void *val);
-FRETVAL(intf) nsfrnatt(intf *id, intf *index, void *buf);
-FRETVAL(intf) nscsnatt(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len);
-FRETVAL(intf) nsfsflmd(intf *id, intf *fillmode);
+intf nsfscfill(intf *id, _fcd val);
+intf nsfsfill(intf *id, void *val);
+intf nsfgfill(intf *id, void *val);
+intf nsfrnatt(intf *id, intf *index, void *buf);
+intf nscsnatt(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len);
+intf nsfsflmd(intf *id, intf *fillmode);
 
 #if defined H4_HAVE_WIN32_API && !defined CMAKE_INTDIR
 
@@ -36,7 +36,7 @@ FRETVAL(intf) nsfsflmd(intf *id, intf *fillmode);
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscend(intf *file_id)
 {
     return (SDend(*file_id));
@@ -49,7 +49,7 @@ nscend(intf *file_id)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscendacc(intf *id)
 {
     return (SDendaccess(*id));
@@ -62,7 +62,7 @@ nscendacc(intf *id)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscfinfo(intf *file_id, intf *datasets, intf *gattr)
 {
     int32 dset, nattr, status;
@@ -83,7 +83,7 @@ nscfinfo(intf *file_id, intf *datasets, intf *gattr)
  * Returns: sdsid on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscselct(intf *file_id, intf *index)
 {
     return (SDselect(*file_id, *index));
@@ -97,7 +97,7 @@ nscselct(intf *file_id, intf *index)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscdimid(intf *id, intf *index)
 {
     int32 rank, nt, dims[100], status, cdim, nattrs;
@@ -119,7 +119,7 @@ nscdimid(intf *id, intf *index)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgcal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt)
 {
     int32 nt32, status;
@@ -140,7 +140,7 @@ nscgcal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, in
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscscal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt)
 {
     return (SDsetcal(*id, *cal, *cale, *ioff, *ioffe, *nt));
@@ -156,7 +156,7 @@ nscscal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, in
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsdscale(intf *id, intf *count, intf *nt, void *values)
 {
     return (SDsetdimscale(*id, *count, *nt, values));
@@ -170,7 +170,7 @@ nscsdscale(intf *id, intf *count, intf *nt, void *values)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgdscale(intf *id, void *values)
 {
     return (SDgetdimscale(*id, values));
@@ -184,7 +184,7 @@ nscgdscale(intf *id, void *values)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *----------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscscfill(intf *id, _fcd val)
 {
     return (nscsfill(id, (void *)_fcdtocp(val)));
@@ -198,7 +198,7 @@ nscscfill(intf *id, _fcd val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *-----------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgcfill(intf *id, _fcd val)
 {
     return (nscgfill(id, (void *)_fcdtocp(val)));
@@ -212,7 +212,7 @@ nscgcfill(intf *id, _fcd val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsfill(intf *id, void *val)
 {
     return (SDsetfillvalue(*id, val));
@@ -226,7 +226,7 @@ nscsfill(intf *id, void *val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgfill(intf *id, void *val)
 {
     return (SDgetfillvalue(*id, val));
@@ -241,7 +241,7 @@ nscgfill(intf *id, void *val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgrange(intf *id, void *max, void *min)
 {
     return (SDgetrange(*id, max, min));
@@ -256,7 +256,7 @@ nscgrange(intf *id, void *max, void *min)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsrange(intf *id, void *max, void *min)
 {
     return (SDsetrange(*id, max, min));
@@ -271,7 +271,7 @@ nscsrange(intf *id, void *max, void *min)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrcatt(intf *id, intf *index, _fcd buf)
 {
     return (nscrnatt(id, index, (void *)_fcdtocp(buf)));
@@ -286,7 +286,7 @@ nscrcatt(intf *id, intf *index, _fcd buf)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrnatt(intf *id, intf *index, void *buf)
 {
     return (SDreadattr(*id, *index, buf));
@@ -301,7 +301,7 @@ nscrnatt(intf *id, intf *index, void *buf)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrattr(intf *id, intf *index, void *buf)
 {
     return (nscrnatt(id, index, buf));
@@ -319,7 +319,7 @@ nscrattr(intf *id, intf *index, void *buf)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *----------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrdata(intf *id, intf *start, intf *stride, intf *end, void *values)
 {
     intf  ret;
@@ -356,7 +356,7 @@ nscrdata(intf *id, intf *start, intf *stride, intf *end, void *values)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscwdata(intf *id, intf *start, intf *stride, intf *end, void *values)
 {
     intf  ret;
@@ -393,7 +393,7 @@ nscwdata(intf *id, intf *start, intf *stride, intf *end, void *values)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
 {
     return (nscrdata(id, start, stride, end, (void *)_fcdtocp(values)));
@@ -411,7 +411,7 @@ nscrcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscwcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
 {
     return (nscwdata(id, start, stride, end, (void *)_fcdtocp(values)));
@@ -423,7 +423,7 @@ nscwcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
  * Inputs:  id: variable id
  * Returns: reference number of a NDG representing this dataset
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscid2ref(intf *id)
 {
     return ((intf)SDidtoref(*id));
@@ -437,7 +437,7 @@ nscid2ref(intf *id)
  *          ref: reference number to look up
  * Returns: index of a NDG representing this dataset
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscr2idx(intf *id, intf *ref)
 {
     return ((intf)SDreftoindex(*id, (int32)*ref));
@@ -450,7 +450,7 @@ nscr2idx(intf *id, intf *ref)
  * Inputs:  id: sds id
  * Returns: TRUE/FALSE
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsciscvar(intf *id)
 {
     return ((intf)SDiscoordvar(*id));
@@ -466,7 +466,7 @@ nsciscvar(intf *id)
  *          fill_one: whether to fill the "background bits" with ones
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsnbit(intf *id, intf *start_bit, intf *bit_len, intf *sign_ext, intf *fill_one)
 {
     return ((intf)SDsetnbitdataset((int32)*id, (intn)*start_bit, (intn)*bit_len, (intn)*sign_ext,
@@ -481,7 +481,7 @@ nscsnbit(intf *id, intf *start_bit, intf *bit_len, intf *sign_ext, intf *fill_on
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsacct(intf *id, intf *type)
 {
     return ((intf)SDsetaccesstype(*id, *type));
@@ -498,7 +498,7 @@ nscsacct(intf *id, intf *type)
  * Returns: SUCCESS on success, FAIL on failure
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsdmvc(intf *id, intf *compmode)
 {
     return ((intf)SDsetdimval_comp(*id, *compmode));
@@ -515,7 +515,7 @@ nscsdmvc(intf *id, intf *compmode)
             FAIL (-1) for error.
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscisdmvc(intf *id)
 {
     return ((intf)SDisdimval_bwcomp(*id));
@@ -534,7 +534,7 @@ nscisdmvc(intf *id)
  *          FAIL (-1) for error.
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsflmd(intf *id, intf *fillmode)
 {
     return ((intf)SDsetfillmode(*id, *fillmode));
@@ -545,7 +545,7 @@ nscsflmd(intf *id, intf *fillmode)
  * Inputs:  id: sds id
  * Returns: TRUE/FALSE (1/0))
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfisrcrd(intf *id)
 {
     return ((intf)SDisrecord(*id));
@@ -557,7 +557,7 @@ nsfisrcrd(intf *id)
             block_size:  block size  in bytes
  * Returns: SUCCEED/FAIL (0/-1)
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsblsz(intf *id, intf *block_size)
 {
     return ((intf)SDsetblocksize(*id, *block_size));
@@ -572,7 +572,7 @@ nscsblsz(intf *id, intf *block_size)
  *          namelen: length of name
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscstart(_fcd name, intf *access, intf *namelen)
 {
     char *fn;
@@ -593,7 +593,7 @@ nscstart(_fcd name, intf *access, intf *namelen)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfend(intf *file_id)
 {
     return (SDend(*file_id));
@@ -606,7 +606,7 @@ nsfend(intf *file_id)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfendacc(intf *id)
 {
     return (SDendaccess(*id));
@@ -618,7 +618,7 @@ nsfendacc(intf *id)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsffinfo(intf *file_id, intf *datasets, intf *gattr)
 {
     int32 dset, nattr, status;
@@ -639,7 +639,7 @@ nsffinfo(intf *file_id, intf *datasets, intf *gattr)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfselect(intf *file_id, intf *index)
 {
     return (SDselect(*file_id, *index));
@@ -653,7 +653,7 @@ nsfselect(intf *file_id, intf *index)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfdimid(intf *id, intf *index)
 {
     int32 rank, nt, dims[100], status, cdim, nattrs;
@@ -678,7 +678,7 @@ nsfdimid(intf *id, intf *index)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscginfo(intf *id, _fcd name, intf *rank, intf *dimsizes, intf *nt, intf *nattr, intf *len)
 {
     char *iname;
@@ -715,7 +715,7 @@ nscginfo(intf *id, _fcd name, intf *rank, intf *dimsizes, intf *nt, intf *nattr,
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfgcal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt)
 {
     int32 nt32, status;
@@ -736,7 +736,7 @@ nsfgcal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, in
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfscal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt)
 {
     return (SDsetcal(*id, *cal, *cale, *ioff, *ioffe, *nt));
@@ -752,7 +752,7 @@ nsfscal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, in
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsdscale(intf *id, intf *count, intf *nt, void *values)
 {
     return (SDsetdimscale(*id, *count, *nt, values));
@@ -766,7 +766,7 @@ nsfsdscale(intf *id, intf *count, intf *nt, void *values)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfgdscale(intf *id, void *values)
 {
     return (SDgetdimscale(*id, values));
@@ -780,7 +780,7 @@ nsfgdscale(intf *id, void *values)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *----------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfscfill(intf *id, _fcd val)
 {
     return (nsfsfill(id, (void *)_fcdtocp(val)));
@@ -794,7 +794,7 @@ nsfscfill(intf *id, _fcd val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *-----------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfgcfill(intf *id, _fcd val)
 {
     return (nsfgfill(id, (void *)_fcdtocp(val)));
@@ -808,7 +808,7 @@ nsfgcfill(intf *id, _fcd val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsfill(intf *id, void *val)
 {
     return (SDsetfillvalue(*id, val));
@@ -822,7 +822,7 @@ nsfsfill(intf *id, void *val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfgfill(intf *id, void *val)
 {
     return (SDgetfillvalue(*id, val));
@@ -837,7 +837,7 @@ nsfgfill(intf *id, void *val)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfgrange(intf *id, void *max, void *min)
 {
     return (SDgetrange(*id, max, min));
@@ -852,7 +852,7 @@ nsfgrange(intf *id, void *max, void *min)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsrange(intf *id, void *max, void *min)
 {
     return (SDsetrange(*id, max, min));
@@ -866,7 +866,7 @@ nsfsrange(intf *id, void *max, void *min)
  *          namelen: length of name
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscn2index(intf *id, _fcd name, intf *namelen)
 {
     char *fn;
@@ -891,7 +891,7 @@ nscn2index(intf *id, _fcd name, intf *namelen)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsccreate(intf *id, _fcd name, intf *nt, intf *rank, intf *dims, intf *namelen)
 {
     char  *fn;
@@ -920,7 +920,7 @@ nsccreate(intf *id, _fcd name, intf *nt, intf *rank, intf *dims, intf *namelen)
  *          label, unit and format strings and their lengths
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsdimstr(intf *id, _fcd l, _fcd u, _fcd f, intf *ll, intf *ul, intf *fl)
 {
     char *lstr;
@@ -960,7 +960,7 @@ nscsdimstr(intf *id, _fcd l, _fcd u, _fcd f, intf *ll, intf *ul, intf *fl)
  *          name and its length
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsdimname(intf *id, _fcd name, intf *len)
 {
     char *nstr;
@@ -984,7 +984,7 @@ nscsdimname(intf *id, _fcd name, intf *len)
  *          label, unit and format strings and their lengths
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsdatstr(intf *id, _fcd l, _fcd u, _fcd f, _fcd c, intf *ll, intf *ul, intf *fl, intf *cl)
 {
     char *lstr;
@@ -1034,7 +1034,7 @@ nscsdatstr(intf *id, _fcd l, _fcd u, _fcd f, _fcd c, intf *ll, intf *ul, intf *f
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfrcatt(intf *id, intf *index, _fcd buf)
 {
     return (nsfrnatt(id, index, (void *)_fcdtocp(buf)));
@@ -1049,7 +1049,7 @@ nsfrcatt(intf *id, intf *index, _fcd buf)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfrnatt(intf *id, intf *index, void *buf)
 {
     return (SDreadattr(*id, *index, buf));
@@ -1064,7 +1064,7 @@ nsfrnatt(intf *id, intf *index, void *buf)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfrattr(intf *id, intf *index, void *buf)
 {
     return (nsfrnatt(id, index, buf));
@@ -1082,7 +1082,7 @@ nsfrattr(intf *id, intf *index, void *buf)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *----------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfrdata(intf *id, intf *start, intf *stride, intf *end, void *values)
 {
     intf  ret;
@@ -1119,7 +1119,7 @@ nsfrdata(intf *id, intf *start, intf *stride, intf *end, void *values)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfwdata(intf *id, intf *start, intf *stride, intf *end, void *values)
 {
     intf  ret;
@@ -1151,7 +1151,7 @@ nsfwdata(intf *id, intf *start, intf *stride, intf *end, void *values)
  * Returns: 0 on success, -1 on failure with DFerror set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *lunit, intf *lformat,
             intf *mlen)
 {
@@ -1191,7 +1191,7 @@ nscgdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *l
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfrcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
 {
     return (nsfrdata(id, start, stride, end, (void *)_fcdtocp(values)));
@@ -1209,7 +1209,7 @@ nsfrcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
  *          differences
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfwcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
 {
     return (nsfwdata(id, start, stride, end, (void *)_fcdtocp(values)));
@@ -1222,7 +1222,7 @@ nsfwcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values)
  * Returns: 0 on success, -1 on failure with DFerror set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgdatstrs(intf *id, _fcd label, _fcd unit, _fcd format, _fcd coord, intf *llabel, intf *lunit,
             intf *lformat, intf *lcoord, intf *len)
 {
@@ -1265,7 +1265,7 @@ nscgdatstrs(intf *id, _fcd label, _fcd unit, _fcd format, _fcd coord, intf *llab
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgainfo(intf *id, intf *number, _fcd name, intf *nt, intf *count, intf *len)
 {
     char *iname;
@@ -1299,7 +1299,7 @@ nscgainfo(intf *id, intf *number, _fcd name, intf *nt, intf *count, intf *len)
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgdinfo(intf *id, _fcd name, intf *sz, intf *nt, intf *nattr, intf *len)
 {
     char *iname;
@@ -1335,7 +1335,7 @@ nscgdinfo(intf *id, _fcd name, intf *sz, intf *nt, intf *nattr, intf *len)
  * Remarks:
  * Returns: 0 on success, -1 on failure with error set
  *--------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscscatt(intf *id, _fcd name, intf *nt, intf *count, _fcd data, intf *len)
 {
     return (nscsnatt(id, name, nt, count, (void *)_fcdtocp(data), len));
@@ -1353,7 +1353,7 @@ nscscatt(intf *id, _fcd name, intf *nt, intf *count, _fcd data, intf *len)
  * Remarks: This routine and scscattr are used to replace scsattr
  * Returns: 0 on success, -1 on failure with error set
  *--------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsnatt(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len)
 {
     char *an;
@@ -1382,7 +1382,7 @@ nscsnatt(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len)
  *          sfsattr declairs data as char *, scscatt assumes
  *          data as void *.
  *--------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsattr(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len)
 {
     char *an;
@@ -1401,7 +1401,7 @@ nscsattr(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len)
  *          name: name of attribute to find
  * Returns: attribute id on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscfattr(intf *id, _fcd name, intf *namelen)
 {
     char *fn;
@@ -1421,7 +1421,7 @@ nscfattr(intf *id, _fcd name, intf *namelen)
  * Inputs:  id: variable id
  * Returns: reference number of a NDG representing this dataset
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfid2ref(intf *id)
 {
     return ((intf)SDidtoref(*id));
@@ -1435,7 +1435,7 @@ nsfid2ref(intf *id)
  *          ref: reference number to look up
  * Returns: reference number of a NDG representing this dataset
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfref2index(intf *id, intf *ref)
 {
     return ((intf)SDreftoindex(*id, (int32)*ref));
@@ -1448,7 +1448,7 @@ nsfref2index(intf *id, intf *ref)
  * Inputs:  id: sds id
  * Returns: TRUE/FALSE
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfiscvar(intf *id)
 {
     return ((intf)SDiscoordvar(*id));
@@ -1464,7 +1464,7 @@ nsfiscvar(intf *id)
  *          namelen: length of name
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscsextf(intf *id, _fcd name, intf *offset, intf *namelen)
 {
     char *fn;
@@ -1488,7 +1488,7 @@ nscsextf(intf *id, _fcd name, intf *offset, intf *namelen)
  *          fill_one: whether to fill the "background bits" with ones
  * Returns: 0 on success, -1 on failure with error set
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsnbit(intf *id, intf *start_bit, intf *bit_len, intf *sign_ext, intf *fill_one)
 {
     return ((intf)SDsetnbitdataset((int32)*id, (intn)*start_bit, (intn)*bit_len, (intn)*sign_ext,
@@ -1503,7 +1503,7 @@ nsfsnbit(intf *id, intf *start_bit, intf *bit_len, intf *sign_ext, intf *fill_on
  * Returns: 0 on success, FAIL on failure with error set
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsacct(intf *id, intf *type)
 {
     return ((intf)SDsetaccesstype(*id, *type));
@@ -1521,7 +1521,7 @@ nsfsacct(intf *id, intf *type)
  * Returns: SUCCESS on success, FAIL on failure
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsdmvc(intf *id, intf *compmode)
 {
     return ((intf)SDsetdimval_comp(*id, *compmode));
@@ -1538,7 +1538,7 @@ nsfsdmvc(intf *id, intf *compmode)
             FAIL (-1) for error.
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfisdmvc(intf *id)
 {
     return ((intf)SDisdimval_bwcomp(*id));
@@ -1557,7 +1557,7 @@ nsfisdmvc(intf *id)
  *          FAIL (-1) for error.
  * Users:   HDF Fortran programmers
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsflmd(intf *id, intf *fillmode)
 {
     return ((intf)SDsetfillmode(*id, *fillmode));
@@ -1585,7 +1585,7 @@ nsfsflmd(intf *id, intf *fillmode)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgichnk(intf *id, intf *dim_length, intf *flags)
 {
 
@@ -1662,7 +1662,7 @@ nscgichnk(intf *id, intf *dim_length, intf *flags)
  *           If performance becomes an issue, use static cstart
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrchnk(intf *id, intf *start, void *num_data)
 {
     intf   ret;
@@ -1708,7 +1708,7 @@ nscrchnk(intf *id, intf *start, void *num_data)
  * Reamrks:  dimensions will be flipped in scrchnk function
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrcchnk(intf *id, intf *start, _fcd char_data)
 {
     intf ret;
@@ -1728,7 +1728,7 @@ nscrcchnk(intf *id, intf *start, _fcd char_data)
  * Calls:    SDsetchunkcache
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscscchnk(intf *id, intf *maxcache, intf *flags)
 {
     intf ret;
@@ -1763,7 +1763,7 @@ nscscchnk(intf *id, intf *maxcache, intf *flags)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm)
 {
 
@@ -1866,7 +1866,7 @@ nscschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm)
  *           If performance becomes an issue, use static cstart
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscwchnk(intf *id, intf *start, void *num_data)
 {
     intf   ret;
@@ -1913,7 +1913,7 @@ nscwchnk(intf *id, intf *start, void *num_data)
  * Reamrks:  dimensions will be flipped in scrchnk function
  * Returns:  0 on success, -1 on failure with error set
  *----------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscwcchnk(intf *id, intf *start, _fcd char_data)
 {
     intf ret;
@@ -1942,7 +1942,7 @@ nscwcchnk(intf *id, intf *start, _fcd char_data)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscscompress(intf *id, intf *comp_type, intf *comp_prm)
 {
 
@@ -2019,7 +2019,7 @@ nscscompress(intf *id, intf *comp_type, intf *comp_prm)
  * Returns: 0 on success, -1 on failure with error set
  * Users:   HDF Fortran programmers
  *-------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgcompress(intf *id, intf *comp_type, intf *comp_prm)
 {
 
@@ -2091,7 +2091,7 @@ nscgcompress(intf *id, intf *comp_type, intf *comp_prm)
  * Inputs:  id: sds id
  * Returns: TRUE/FALSE (1/0))
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfisrcrd(intf *id)
 {
     return ((intf)SDisrecord(*id));
@@ -2104,7 +2104,7 @@ nsfisrcrd(intf *id)
             block_size:  block size  in bytes
  * Returns: SUCCEED/FAIL (0/-1)
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nsfsblsz(intf *id, intf *block_size)
 {
     return ((intf)SDsetblocksize(*id, *block_size));
@@ -2117,7 +2117,7 @@ nsfsblsz(intf *id, intf *block_size)
             flag:        TRUE/FALSE flag
  * Returns: SUCCEED/FAIL (0/-1)
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscchempty(intf *id, intf *flag)
 {
     intn flag_c;
@@ -2135,7 +2135,7 @@ nscchempty(intf *id, intf *flag)
  *          namelen: length of file name
  * Returns: real length on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgetfname(intf *file_id, _fcd name, intf *namelen)
 {
     char *fn;
@@ -2159,7 +2159,7 @@ nscgetfname(intf *file_id, _fcd name, intf *namelen)
  * Outputs: namelen: name length
  * Returns: 0 on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgetnamelen(intf *obj_id, intf *namelen)
 {
     intn   ret;
@@ -2181,7 +2181,7 @@ nscgetnamelen(intf *obj_id, intf *namelen)
  *                                  2 for dimension scale
  * Returns: 0 on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscidtype(intf *obj_id, intf *obj_type)
 {
     intn         ret = -1;
@@ -2202,7 +2202,7 @@ nscidtype(intf *obj_id, intf *obj_type)
  * Inputs:  req_max: requested max number of files
  * Returns: current max number of opened files on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscrmaxopenf(intf *req_max)
 {
     intf cur_max;
@@ -2218,7 +2218,7 @@ nscrmaxopenf(intf *req_max)
  *          sys_limit: system limit on open files
  * Returns: 0 on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgmaxopenf(intf *cur_max, intf *sys_limit)
 {
     intf ret = 0;
@@ -2238,7 +2238,7 @@ nscgmaxopenf(intf *cur_max, intf *sys_limit)
  * Outputs: cur_num: number of files currently being opened
  * Returns: 0 on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgnumopenf(intf *cur_num)
 {
     intf ret = 0;
@@ -2263,7 +2263,7 @@ nscgnumopenf(intf *cur_num)
  *          type_list: list of types
  * Returns: 0 on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscn2indices(intf *sd_id, _fcd name, intf *namelen, intf *var_list, intf *type_list, intf *n_vars)
 {
     char          *fn;
@@ -2300,7 +2300,7 @@ nscn2indices(intf *sd_id, _fcd name, intf *namelen, intf *var_list, intf *type_l
  * Outputs: n_vars: number of data sets
  * Returns: 0 on success, -1 on failure
  *---------------------------------------------------------------------------*/
-FRETVAL(intf)
+intf
 nscgnvars_byname(intf *sd_id, _fcd name, intf *namelen, intf *n_vars)
 {
     char *fn;

--- a/mfhdf/fortran/mfsdf.h
+++ b/mfhdf/fortran/mfsdf.h
@@ -91,81 +91,77 @@ extern "C" {
 #define nscgnumopenf     H4_F77_FUNC(scgnumopenf, SCGNUMOPENF)
 #define nscrmaxopenf     H4_F77_FUNC(scrmaxopenf, SCRMAXOPENF)
 
-HDFFCLIBAPI FRETVAL(intf) nscstart(_fcd name, intf *access, intf *namelen);
-HDFFCLIBAPI FRETVAL(intf)
-    nscginfo(intf *id, _fcd name, intf *rank, intf *dimsizes, intf *nt, intf *nattr, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscn2index(intf *id, _fcd name, intf *namelen);
-HDFFCLIBAPI FRETVAL(intf) nsccreate(intf *id, _fcd name, intf *nt, intf *rank, intf *dims, intf *namelen);
-HDFFCLIBAPI FRETVAL(intf) nscsdimstr(intf *id, _fcd l, _fcd u, _fcd f, intf *ll, intf *ul, intf *fl);
-HDFFCLIBAPI FRETVAL(intf) nscsdimname(intf *id, _fcd name, intf *len);
-HDFFCLIBAPI FRETVAL(intf)
-    nscsdatstr(intf *id, _fcd l, _fcd u, _fcd f, _fcd c, intf *ll, intf *ul, intf *fl, intf *cl);
-HDFFCLIBAPI FRETVAL(intf) nscgdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel,
-                                      intf *lunit, intf *lformat, intf *mlen);
-HDFFCLIBAPI FRETVAL(intf) nscgdatstrs(intf *id, _fcd label, _fcd unit, _fcd format, _fcd coord, intf *llabel,
-                                      intf *lunit, intf *lformat, intf *lcoord, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscgainfo(intf *id, intf *number, _fcd name, intf *nt, intf *count, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscgdinfo(intf *id, _fcd name, intf *sz, intf *nt, intf *nattr, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscscatt(intf *id, _fcd name, intf *nt, intf *count, _fcd data, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscsnatt(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscsattr(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len);
-HDFFCLIBAPI FRETVAL(intf) nscsextf(intf *id, _fcd name, intf *offset, intf *namelen);
-HDFFCLIBAPI FRETVAL(intf) nscgichnk(intf *id, intf *dim_length, intf *flags);
-HDFFCLIBAPI FRETVAL(intf) nscrcchnk(intf *id, intf *start, _fcd char_data);
-HDFFCLIBAPI FRETVAL(intf) nscrchnk(intf *id, intf *start, void *num_data);
-HDFFCLIBAPI FRETVAL(intf) nscscchnk(intf *id, intf *maxcache, intf *flags);
-HDFFCLIBAPI FRETVAL(intf) nscschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm);
-HDFFCLIBAPI FRETVAL(intf) nscwcchnk(intf *id, intf *start, _fcd char_data);
-HDFFCLIBAPI FRETVAL(intf) nscwchnk(intf *id, intf *start, void *num_data);
-HDFFCLIBAPI FRETVAL(intf) nscscompress(intf *id, intf *comp_type, intf *comp_prm);
-HDFFCLIBAPI FRETVAL(intf) nscgcompress(intf *id, intf *comp_type, intf *comp_prm);
-HDFFCLIBAPI FRETVAL(intf) nscfattr(intf *id, _fcd name, intf *namelen);
-HDFFCLIBAPI FRETVAL(intf) nscchempty(intf *id, intf *flag);
+HDFFCLIBAPI intf nscstart(_fcd name, intf *access, intf *namelen);
+HDFFCLIBAPI intf nscginfo(intf *id, _fcd name, intf *rank, intf *dimsizes, intf *nt, intf *nattr, intf *len);
+HDFFCLIBAPI intf nscn2index(intf *id, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nsccreate(intf *id, _fcd name, intf *nt, intf *rank, intf *dims, intf *namelen);
+HDFFCLIBAPI intf nscsdimstr(intf *id, _fcd l, _fcd u, _fcd f, intf *ll, intf *ul, intf *fl);
+HDFFCLIBAPI intf nscsdimname(intf *id, _fcd name, intf *len);
+HDFFCLIBAPI intf nscsdatstr(intf *id, _fcd l, _fcd u, _fcd f, _fcd c, intf *ll, intf *ul, intf *fl, intf *cl);
+HDFFCLIBAPI intf nscgdimstrs(intf *dim, _fcd label, _fcd unit, _fcd format, intf *llabel, intf *lunit,
+                             intf *lformat, intf *mlen);
+HDFFCLIBAPI intf nscgdatstrs(intf *id, _fcd label, _fcd unit, _fcd format, _fcd coord, intf *llabel,
+                             intf *lunit, intf *lformat, intf *lcoord, intf *len);
+HDFFCLIBAPI intf nscgainfo(intf *id, intf *number, _fcd name, intf *nt, intf *count, intf *len);
+HDFFCLIBAPI intf nscgdinfo(intf *id, _fcd name, intf *sz, intf *nt, intf *nattr, intf *len);
+HDFFCLIBAPI intf nscscatt(intf *id, _fcd name, intf *nt, intf *count, _fcd data, intf *len);
+HDFFCLIBAPI intf nscsnatt(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len);
+HDFFCLIBAPI intf nscsattr(intf *id, _fcd name, intf *nt, intf *count, void *data, intf *len);
+HDFFCLIBAPI intf nscsextf(intf *id, _fcd name, intf *offset, intf *namelen);
+HDFFCLIBAPI intf nscgichnk(intf *id, intf *dim_length, intf *flags);
+HDFFCLIBAPI intf nscrcchnk(intf *id, intf *start, _fcd char_data);
+HDFFCLIBAPI intf nscrchnk(intf *id, intf *start, void *num_data);
+HDFFCLIBAPI intf nscscchnk(intf *id, intf *maxcache, intf *flags);
+HDFFCLIBAPI intf nscschnk(intf *id, intf *dim_length, intf *comp_type, intf *comp_prm);
+HDFFCLIBAPI intf nscwcchnk(intf *id, intf *start, _fcd char_data);
+HDFFCLIBAPI intf nscwchnk(intf *id, intf *start, void *num_data);
+HDFFCLIBAPI intf nscscompress(intf *id, intf *comp_type, intf *comp_prm);
+HDFFCLIBAPI intf nscgcompress(intf *id, intf *comp_type, intf *comp_prm);
+HDFFCLIBAPI intf nscfattr(intf *id, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nscchempty(intf *id, intf *flag);
 
-HDFFCLIBAPI FRETVAL(intf) nscgnvars_byname(intf *sd_id, _fcd name, intf *namelen, intf *n_vars);
-HDFFCLIBAPI FRETVAL(intf)
-    nscn2indices(intf *sd_id, _fcd name, intf *namelen, intf *var_list, intf *type_list, intf *n_vars);
-HDFFCLIBAPI FRETVAL(intf) nscgnumopenf(intf *cur_num);
-HDFFCLIBAPI FRETVAL(intf) nscgmaxopenf(intf *cur_max, intf *sys_limit);
-HDFFCLIBAPI FRETVAL(intf) nscrmaxopenf(intf *req_max);
-HDFFCLIBAPI FRETVAL(intf) nscidtype(intf *obj_id, intf *obj_type);
-HDFFCLIBAPI FRETVAL(intf) nscgetnamelen(intf *obj_id, intf *namelen);
-HDFFCLIBAPI FRETVAL(intf) nscgetfname(intf *file_id, _fcd name, intf *namelen);
+HDFFCLIBAPI intf nscgnvars_byname(intf *sd_id, _fcd name, intf *namelen, intf *n_vars);
+HDFFCLIBAPI intf nscn2indices(intf *sd_id, _fcd name, intf *namelen, intf *var_list, intf *type_list,
+                              intf *n_vars);
+HDFFCLIBAPI intf nscgnumopenf(intf *cur_num);
+HDFFCLIBAPI intf nscgmaxopenf(intf *cur_max, intf *sys_limit);
+HDFFCLIBAPI intf nscrmaxopenf(intf *req_max);
+HDFFCLIBAPI intf nscidtype(intf *obj_id, intf *obj_type);
+HDFFCLIBAPI intf nscgetnamelen(intf *obj_id, intf *namelen);
+HDFFCLIBAPI intf nscgetfname(intf *file_id, _fcd name, intf *namelen);
 
-HDFFCLIBAPI FRETVAL(intf) nsfend(intf *file_id);
-HDFFCLIBAPI FRETVAL(intf) nsfendacc(intf *id);
-HDFFCLIBAPI FRETVAL(intf) nsffinfo(intf *file_id, intf *datasets, intf *gattr);
-HDFFCLIBAPI FRETVAL(intf) nsfselect(intf *file_id, intf *index);
-HDFFCLIBAPI FRETVAL(intf) nsfdimid(intf *id, intf *index);
-HDFFCLIBAPI FRETVAL(intf)
-    nsfgcal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt);
-HDFFCLIBAPI FRETVAL(intf)
-    nsfscal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt);
-HDFFCLIBAPI FRETVAL(intf) nsfsdscale(intf *id, intf *count, intf *nt, void *values);
-HDFFCLIBAPI FRETVAL(intf) nsfgdscale(intf *id, void *values);
-HDFFCLIBAPI FRETVAL(intf) nsfscfill(intf *id, _fcd val);
-HDFFCLIBAPI FRETVAL(intf) nsfgcfill(intf *id, _fcd val);
-HDFFCLIBAPI FRETVAL(intf) nsfsfill(intf *id, void *val);
-HDFFCLIBAPI FRETVAL(intf) nsfgfill(intf *id, void *val);
-HDFFCLIBAPI FRETVAL(intf) nsfgrange(intf *id, void *max, void *min);
-HDFFCLIBAPI FRETVAL(intf) nsfsrange(intf *id, void *max, void *min);
-HDFFCLIBAPI FRETVAL(intf) nsfrcatt(intf *id, intf *index, _fcd buf);
-HDFFCLIBAPI FRETVAL(intf) nsfrnatt(intf *id, intf *index, void *buf);
-HDFFCLIBAPI FRETVAL(intf) nsfrattr(intf *id, intf *index, void *buf);
-HDFFCLIBAPI FRETVAL(intf) nsfrdata(intf *id, intf *start, intf *stride, intf *end, void *values);
-HDFFCLIBAPI FRETVAL(intf) nsfwdata(intf *id, intf *start, intf *stride, intf *end, void *values);
-HDFFCLIBAPI FRETVAL(intf) nsfrcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values);
-HDFFCLIBAPI FRETVAL(intf) nsfwcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values);
-HDFFCLIBAPI FRETVAL(intf) nsfid2ref(intf *id);
-HDFFCLIBAPI FRETVAL(intf) nsfref2index(intf *id, intf *ref);
-HDFFCLIBAPI FRETVAL(intf) nsfiscvar(intf *id);
-HDFFCLIBAPI FRETVAL(intf) nsfsnbit(intf *id, intf *start_bit, intf *bit_len, intf *sign_ext, intf *fill_one);
-HDFFCLIBAPI FRETVAL(intf) nsfsacct(intf *id, intf *type);
-HDFFCLIBAPI FRETVAL(intf) nsfsdmvc(intf *id, intf *compmode);
-HDFFCLIBAPI FRETVAL(intf) nsfisdmvc(intf *id);
-HDFFCLIBAPI FRETVAL(intf) nsfsflmd(intf *id, intf *fillmode);
-HDFFCLIBAPI FRETVAL(intf) nsfisrcrd(intf *id);
-HDFFCLIBAPI FRETVAL(intf) nsfsblsz(intf *id, intf *block_size);
+HDFFCLIBAPI intf nsfend(intf *file_id);
+HDFFCLIBAPI intf nsfendacc(intf *id);
+HDFFCLIBAPI intf nsffinfo(intf *file_id, intf *datasets, intf *gattr);
+HDFFCLIBAPI intf nsfselect(intf *file_id, intf *index);
+HDFFCLIBAPI intf nsfdimid(intf *id, intf *index);
+HDFFCLIBAPI intf nsfgcal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt);
+HDFFCLIBAPI intf nsfscal(intf *id, float64 *cal, float64 *cale, float64 *ioff, float64 *ioffe, intf *nt);
+HDFFCLIBAPI intf nsfsdscale(intf *id, intf *count, intf *nt, void *values);
+HDFFCLIBAPI intf nsfgdscale(intf *id, void *values);
+HDFFCLIBAPI intf nsfscfill(intf *id, _fcd val);
+HDFFCLIBAPI intf nsfgcfill(intf *id, _fcd val);
+HDFFCLIBAPI intf nsfsfill(intf *id, void *val);
+HDFFCLIBAPI intf nsfgfill(intf *id, void *val);
+HDFFCLIBAPI intf nsfgrange(intf *id, void *max, void *min);
+HDFFCLIBAPI intf nsfsrange(intf *id, void *max, void *min);
+HDFFCLIBAPI intf nsfrcatt(intf *id, intf *index, _fcd buf);
+HDFFCLIBAPI intf nsfrnatt(intf *id, intf *index, void *buf);
+HDFFCLIBAPI intf nsfrattr(intf *id, intf *index, void *buf);
+HDFFCLIBAPI intf nsfrdata(intf *id, intf *start, intf *stride, intf *end, void *values);
+HDFFCLIBAPI intf nsfwdata(intf *id, intf *start, intf *stride, intf *end, void *values);
+HDFFCLIBAPI intf nsfrcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values);
+HDFFCLIBAPI intf nsfwcdata(intf *id, intf *start, intf *stride, intf *end, _fcd values);
+HDFFCLIBAPI intf nsfid2ref(intf *id);
+HDFFCLIBAPI intf nsfref2index(intf *id, intf *ref);
+HDFFCLIBAPI intf nsfiscvar(intf *id);
+HDFFCLIBAPI intf nsfsnbit(intf *id, intf *start_bit, intf *bit_len, intf *sign_ext, intf *fill_one);
+HDFFCLIBAPI intf nsfsacct(intf *id, intf *type);
+HDFFCLIBAPI intf nsfsdmvc(intf *id, intf *compmode);
+HDFFCLIBAPI intf nsfisdmvc(intf *id);
+HDFFCLIBAPI intf nsfsflmd(intf *id, intf *fillmode);
+HDFFCLIBAPI intf nsfisrcrd(intf *id);
+HDFFCLIBAPI intf nsfsblsz(intf *id, intf *block_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These are no longer necessary. The FCALLKEYW macro they enable is not used, the logic makes no sense, and many functions already omit FRETVAL().