### PR TITLE
Remove the VSET_INTERFACE macro

### DIFF
--- a/hdf/src/vattr.c
+++ b/hdf/src/vattr.c
@@ -185,9 +185,6 @@
 * First draft on 7/31/96, modified on 8/6/96, 8/15/96
 *************************************************************/
 
-#define VSET_INTERFACE
-#include "hdf.h"
-
 /* -----------------  VSfindex ---------------------
 NAME
       VSfindex -- find index of a named field in a vdata

--- a/hdf/src/vattrf.c
+++ b/hdf/src/vattrf.c
@@ -20,8 +20,8 @@
  *
  ******************************************************/
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 #include "hproto_fortran.h"
 
 /* ----------------- vsfcfdx ----------------------

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -27,9 +27,9 @@
  * Part of the HDF Vset interface.
  */
 
-#define VSET_INTERFACE
 #include "hdfi.h"
 #include "hfile.h"
+#include "vgint.h"
 
 /*
  ** ==================================================================

--- a/hdf/src/vg.c
+++ b/hdf/src/vg.c
@@ -61,8 +61,8 @@ PRIVATE functions manipulate vsdir and are used only within this file.
 PRIVATE data structures in here pertain to vdata in vsdir only.
  */
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 
 /* These are used to determine whether a vdata had been created by the
    library internally, that is, not created by user's application */

--- a/hdf/src/vg.h
+++ b/hdf/src/vg.h
@@ -65,9 +65,4 @@
 #define VSET_OLD_VERSION 2                /* All version <= 2 use old type mappings */
 #define VSET_OLD_TYPES   VSET_OLD_VERSION /* For backward compatibility */
 
-/* Only include the library header if the VSET_INTERFACE macro is defined */
-#ifdef VSET_INTERFACE
-#include "vgint.h" /* Library VSet information header */
-#endif             /* VSET_INTERFACE */
-
 #endif /* H4_VG_H */

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -31,8 +31,8 @@
  *
  *********************************************************************** */
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 #include "hproto_fortran.h"
 
 /*

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -101,8 +101,8 @@ EXPORTED ROUTINES
 
 *************************************************************************/
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 
 /* These are used to determine whether a vgroup had been created by the
    library internally, that is, not created by user's application */

--- a/hdf/src/vhi.c
+++ b/hdf/src/vhi.c
@@ -22,8 +22,8 @@
  *       VHmakegroup  -- makes a vgroup from tag/ref pairs
  */
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 
 /* ------------------------ VHstoredata -------------------------------
    NAME

--- a/hdf/src/vio.c
+++ b/hdf/src/vio.c
@@ -58,8 +58,8 @@ EXPORTED ROUTINES
 
 *************************************************************************/
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 
 /* Private Function Prototypes */
 static intn vunpackvs(VDATA *vs, uint8 buf[], int32 len);

--- a/hdf/src/vparse.c
+++ b/hdf/src/vparse.c
@@ -22,8 +22,8 @@
 
 ************************************************************************/
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 
 #define ISCOMMA(c) ((c == ',') ? 1 : 0)
 

--- a/hdf/src/vrw.c
+++ b/hdf/src/vrw.c
@@ -34,8 +34,8 @@ EXPORTED ROUTINES
 
 ************************************************************************/
 
-#define VSET_INTERFACE
 #include "hdfi.h"
+#include "vgint.h"
 
 #ifndef MIN
 #define MIN(a, b) ((a) < (b) ? (a) : (b))

--- a/hdf/src/vsfld.c
+++ b/hdf/src/vsfld.c
@@ -36,9 +36,10 @@ EXPORTED ROUTINES
 
 ************************************************************************/
 
-#define VSET_INTERFACE
-#include "hdfi.h"
 #include <stdarg.h>
+
+#include "hdfi.h"
+#include "vgint.h"
 
 /*
  ** ==================================================================

--- a/hdf/util/vshow.c
+++ b/hdf/util/vshow.c
@@ -26,8 +26,9 @@
  *
  *
  ******************************************************************************/
-#define VSET_INTERFACE
+
 #include "hdf.h"
+#include "vgint.h"
 
 static int condensed;
 

--- a/mfhdf/dumper/hdp.c
+++ b/mfhdf/dumper/hdp.c
@@ -11,9 +11,9 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#define VSET_INTERFACE
 #include "hdp.h"
-#include "local_nc.h" /* to use some definitions */
+#include "local_nc.h"
+#include "vgint.h"
 
 /********************/
 /* Global Variables */

--- a/mfhdf/dumper/show.c
+++ b/mfhdf/dumper/show.c
@@ -13,8 +13,8 @@
 
 /* Modified from vshow.c by Eric Tsui, 12/25/1994. */
 
-#define VSET_INTERFACE
 #include "hdp.h"
+#include "vgint.h"
 
 #define BUFFER 1000000
 


### PR DESCRIPTION
This was an awkward way to protect an internal
header file.