### PR TITLE
Remove TBBT_INTERNALS scheme

### DIFF
--- a/hdf/src/hdatainfo.c
+++ b/hdf/src/hdatainfo.c
@@ -726,7 +726,7 @@ GRgetattdatainfo(int32 id, int32 attrindex, int32 *offset, int32 *length)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
     /* Search for an attribute with the same index */
-    aentry = (void **)tbbtfirst((TBBT_NODE *)*search_tree);
+    aentry = (void **)tbbtfirst(search_tree->root);
     found  = FALSE;
     while (!found && (aentry != NULL)) {
         at_ptr = (at_info_t *)*aentry;

--- a/hdf/src/mfan.c
+++ b/hdf/src/mfan.c
@@ -683,7 +683,7 @@ ANInumann(int32    an_id,  /* IN: annotation interface id */
     }
 
     /* Traverse the list looking for a match */
-    for (entry = tbbtfirst((TBBT_NODE *)*(file_rec->an_tree[type])); entry != NULL; entry = tbbtnext(entry)) {
+    for (entry = tbbtfirst(file_rec->an_tree[type]->root); entry != NULL; entry = tbbtnext(entry)) {
         ann_entry = (ANentry *)entry->data; /* get annotation entry from node */
         if ((ann_entry->elmref == elem_ref) && (ann_entry->elmtag == elem_tag)) {
             nanns++; /* increment ref counter if match */
@@ -744,7 +744,7 @@ ANIannlist(int32    an_id,  /* IN: annotation interface id */
     }
 
     /* Traverse the list looking for a match */
-    for (entry = tbbtfirst((TBBT_NODE *)*(file_rec->an_tree[type])); entry != NULL; entry = tbbtnext(entry)) {
+    for (entry = tbbtfirst(file_rec->an_tree[type]->root); entry != NULL; entry = tbbtnext(entry)) {
         ann_entry = (ANentry *)entry->data; /* get annotation entry from node */
         if ((ann_entry->elmref == elem_ref) &&
             (ann_entry->elmtag == elem_tag)) { /* save ref of ann match in list */
@@ -1329,7 +1329,7 @@ ANend(int32 an_id /* IN: Annotation ID of file to close */)
     /* free file label annotation rb tree */
     if (file_rec->an_tree[AN_FILE_LABEL] !=
         NULL) { /* Traverse tree puling ann_id's to delete from annotation atom group */
-        for (aentry = tbbtfirst((TBBT_NODE *)*(file_rec->an_tree[AN_FILE_LABEL])); aentry != NULL;
+        for (aentry = tbbtfirst(file_rec->an_tree[AN_FILE_LABEL]->root); aentry != NULL;
              aentry = tbbtnext(aentry)) { /* get annotation entry from node */
             ann_entry = (ANentry *)aentry->data;
 
@@ -1346,7 +1346,7 @@ ANend(int32 an_id /* IN: Annotation ID of file to close */)
     /* free file desc annotation rb tree */
     if (file_rec->an_tree[AN_FILE_DESC] !=
         NULL) { /* Traverse tree puling ann_id's to delete from annotation atom group */
-        for (aentry = tbbtfirst((TBBT_NODE *)*(file_rec->an_tree[AN_FILE_DESC])); aentry != NULL;
+        for (aentry = tbbtfirst(file_rec->an_tree[AN_FILE_DESC]->root); aentry != NULL;
              aentry = tbbtnext(aentry)) { /* get annotation entry from node */
             ann_entry = (ANentry *)aentry->data;
 
@@ -1364,7 +1364,7 @@ ANend(int32 an_id /* IN: Annotation ID of file to close */)
     /* free label annotation rb tree */
     if (file_rec->an_tree[AN_DATA_LABEL] !=
         NULL) { /* Traverse tree puling ann_id's to delete from annotation atom group */
-        for (aentry = tbbtfirst((TBBT_NODE *)*(file_rec->an_tree[AN_DATA_LABEL])); aentry != NULL;
+        for (aentry = tbbtfirst(file_rec->an_tree[AN_DATA_LABEL]->root); aentry != NULL;
              aentry = tbbtnext(aentry)) { /* get annotation entry from node */
             ann_entry = (ANentry *)aentry->data;
 
@@ -1381,7 +1381,7 @@ ANend(int32 an_id /* IN: Annotation ID of file to close */)
     /* free desc annotation rb tree */
     if (file_rec->an_tree[AN_DATA_DESC] !=
         NULL) { /* Traverse tree pulling ann_id's to delete from annotation atom group */
-        for (aentry = tbbtfirst((TBBT_NODE *)*(file_rec->an_tree[AN_DATA_DESC])); aentry != NULL;
+        for (aentry = tbbtfirst(file_rec->an_tree[AN_DATA_DESC]->root); aentry != NULL;
              aentry = tbbtnext(aentry)) { /* get annotation entry from node */
             ann_entry = (ANentry *)aentry->data;
 
@@ -1534,7 +1534,7 @@ ANselect(int32    an_id, /* IN: annotation interface ID */
         HE_REPORT_GOTO("bad index", FAIL);
 
     /* find 'index' entry */
-    if ((entry = tbbtindx((TBBT_NODE *)*(file_rec->an_tree[type]), index)) == NULL)
+    if ((entry = tbbtindx(file_rec->an_tree[type]->root, index)) == NULL)
         HE_REPORT_GOTO("failed to find 'index' entry", FAIL);
 
     ann_entry = (ANentry *)entry->data;
@@ -1774,7 +1774,7 @@ ANget_tagref(int32    an_id, /* IN: annotation interface ID */
         HE_REPORT_GOTO("bad index", FAIL);
 
     /* find 'index' entry */
-    if ((entry = tbbtindx((TBBT_NODE *)*(file_rec->an_tree[type]), index)) == NULL)
+    if ((entry = tbbtindx(file_rec->an_tree[type]->root, index)) == NULL)
         HE_REPORT_GOTO("failed to find 'index' entry", FAIL);
 
     ann_entry = (ANentry *)entry->data;

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -1995,7 +1995,7 @@ GRend(int32 grid)
             void     **t2;
             ri_info_t *img_ptr; /* ptr to the image */
 
-            if (NULL == (t2 = (void **)tbbtfirst((TBBT_NODE *)*(gr_ptr->grtree)))) {
+            if (NULL == (t2 = (void **)tbbtfirst(gr_ptr->grtree->root))) {
                 HGOTO_ERROR(DFE_NOTINTABLE, FAIL);
             } /* end if */
             else
@@ -2029,7 +2029,7 @@ GRend(int32 grid)
                     void     **t3;
                     at_info_t *attr_ptr; /* ptr to the attribute */
 
-                    if (NULL == (t3 = (void **)tbbtfirst((TBBT_NODE *)*(img_ptr->lattree)))) {
+                    if (NULL == (t3 = (void **)tbbtfirst(img_ptr->lattree->root))) {
                         HGOTO_ERROR(DFE_NOTINTABLE, FAIL);
                     } /* end if */
                     else
@@ -2082,7 +2082,7 @@ GRend(int32 grid)
             void     **t2;
             at_info_t *attr_ptr; /* ptr to the attribute */
 
-            if (NULL == (t2 = (void **)tbbtfirst((TBBT_NODE *)*(gr_ptr->gattree)))) {
+            if (NULL == (t2 = (void **)tbbtfirst(gr_ptr->gattree->root))) {
                 HGOTO_ERROR(DFE_NOTINTABLE, FAIL);
             } /* end if */
             else
@@ -2358,7 +2358,7 @@ GRnametoindex(int32 grid, const char *name)
     if (NULL == (gr_ptr = (gr_info_t *)HAatom_object(grid)))
         HGOTO_ERROR(DFE_GRNOTFOUND, FAIL);
 
-    if ((t = (void **)tbbtfirst((TBBT_NODE *)*(gr_ptr->grtree))) == NULL)
+    if ((t = (void **)tbbtfirst(gr_ptr->grtree->root)) == NULL)
         HGOTO_ERROR(DFE_RINOTFOUND, FAIL);
     do {
         ri_ptr = (ri_info_t *)*t;
@@ -3352,7 +3352,7 @@ GRreftoindex(int32 grid, uint16 ref)
     if (NULL == (gr_ptr = (gr_info_t *)HAatom_object(grid)))
         HGOTO_ERROR(DFE_GRNOTFOUND, FAIL);
 
-    if ((t = (void **)tbbtfirst((TBBT_NODE *)*(gr_ptr->grtree))) == NULL)
+    if ((t = (void **)tbbtfirst(gr_ptr->grtree->root)) == NULL)
         HGOTO_ERROR(DFE_RINOTFOUND, FAIL);
     do {
         ri_ptr = (ri_info_t *)*t;
@@ -4392,7 +4392,7 @@ GRsetattr(int32 id, const char *name, int32 attr_nt, int32 count, const void *da
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
     /* Search for an attribute with the same name */
-    if ((t = (void **)tbbtfirst((TBBT_NODE *)*search_tree)) != NULL) {
+    if ((t = (void **)tbbtfirst(search_tree->root)) != NULL) {
         do {
             at_ptr = (at_info_t *)*t;
             if (at_ptr != NULL && strcmp(at_ptr->name, name) == 0) /* ie. the name matches */
@@ -4755,7 +4755,7 @@ GRfindattr(int32 id, const char *name)
     else /* shouldn't get here, but what the heck... */
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    if ((t = (void **)tbbtfirst((TBBT_NODE *)*search_tree)) == NULL)
+    if ((t = (void **)tbbtfirst(search_tree->root)) == NULL)
         HGOTO_ERROR(DFE_RINOTFOUND, FAIL);
     do {
         at_ptr = (at_info_t *)*t;

--- a/hdf/src/tbbt.h
+++ b/hdf/src/tbbt.h
@@ -19,87 +19,45 @@
 
 #include "hdfi.h"
 
-typedef struct tbbt_node TBBT_NODE;
-
-/* Threaded node structure */
-struct tbbt_node {
-    void *data; /* Pointer to user data to be associated with node */
-    void *key;  /* Field to sort nodes on */
-
-#ifdef TBBT_INTERNALS
-#define PARENT 0
-#define LEFT   1
-#define RIGHT  2
-    TBBT_NODE *link[3]; /* Pointers to parent, left child, and right child */
-#define Parent    link[PARENT]
-#define Lchild    link[LEFT]
-#define Rchild    link[RIGHT]
-#define TBBT_FLAG unsigned long
-#define TBBT_LEAF unsigned long
-    TBBT_FLAG flags;    /* Combination of the following bit fields: */
-#define TBBT_HEAVY(s) s /* If the `s' sub-tree is deeper than the other */
-#define TBBT_DOUBLE   4 /* If "heavy" sub-tree is two levels deeper */
-#define TBBT_INTERN   8 /* If node is internal (has two children) */
-#define TBBT_UNBAL    (TBBT_HEAVY(LEFT) | TBBT_HEAVY(RIGHT))
-#define TBBT_FLAGS    (TBBT_UNBAL | TBBT_INTERN | TBBT_DOUBLE)
-#define TBBT_CHILD(s) (TBBT_INTERN | TBBT_HEAVY(s))
-    TBBT_LEAF lcnt;                   /* count of left children */
-    TBBT_LEAF rcnt;                   /* count of right children */
-#define LeftCnt(node)  ((node)->lcnt) /* Left descendants */
-#define RightCnt(node) ((node)->rcnt) /* Left descendants */
-#define Cnt(node, s)   (LEFT == (s) ? LeftCnt(node) : RightCnt(node))
-#define HasChild(n, s) (Cnt(n, s) > 0)
-#define Heavy(n, s)    ((s) & (LeftCnt(n) > RightCnt(n) ? LEFT : LeftCnt(n) == RightCnt(n) ? 0 : RIGHT))
-#define Intern(n)      (LeftCnt(n) && RightCnt(n))
-#define UnBal(n)       (LeftCnt(n) > RightCnt(n) ? LEFT : LeftCnt(n) == RightCnt(n) ? 0 : RIGHT)
-#define Double(n)      (TBBT_DOUBLE & (n)->flags)
-#define Other(side)    (LEFT + RIGHT - (side))
-#define Delta(n, s)    ((Heavy(n, s) ? 1 : -1) * (Double(n) ? 2 : UnBal(n) ? 1 : 0))
-#define SetFlags(n, s, b, i)                                                                                 \
-    ((-2 < (b) && (b) < 2 ? 0 : TBBT_DOUBLE) |                                                               \
-     (0 > (b)   ? TBBT_HEAVY(s)                                                                              \
-      : (b) > 0 ? TBBT_HEAVY(Other(s))                                                                       \
-                : 0) |                                                                                       \
-     ((i) ? TBBT_INTERN : 0))
-};
-
-/* Pointer to the tbbt node free list */
-static TBBT_NODE *tbbt_free_list = NULL;
-
-typedef struct tbbt_tree TBBT_TREE;
-/* Threaded tree structure */
-struct tbbt_tree {
-    TBBT_NODE    *root;
-    unsigned long count;        /* The number of nodes in the tree currently */
-    uintn         fast_compare; /* use a faster in-line compare (with casts) instead of function call */
-    intn (*compar)(void *k1, void *k2, intn cmparg);
-    intn cmparg;
-#endif /* TBBT_INTERNALS */
-};
-
 /* Define the "fast compare" values */
 #define TBBT_FAST_UINT16_COMPARE 1
 #define TBBT_FAST_INT32_COMPARE  2
 
-#ifndef TBBT_INTERNALS
-typedef TBBT_NODE **TBBT_TREE;
-#endif /* TBBT_INTERNALS */
+/* Private TBBT information (defined in tbbt.c) */
+struct tbbt_node_private;
 
-/* Return maximum of two scalar values (use arguments w/o side effects): */
-#define Max(a, b) ((a) > (b) ? (a) : (b))
+/* Private TBBT node information (defined in tbbt.c) */
+struct tbbt_tree_private;
+
+/* Threaded node structure */
+typedef struct tbbt_node {
+    void *data; /* Pointer to user data to be associated with node */
+    void *key;  /* Field to sort nodes on */
+
+    struct tbbt_node_private *priv; /* Private information about the TBBT node */
+} TBBT_NODE;
+
+/* Threaded tree structure */
+typedef struct tbbt_tree {
+    TBBT_NODE *root;
+
+    struct tbbt_tree_private *priv; /* Private information about the TBBT */
+} TBBT_TREE;
 
 /* These routines are designed to allow use of a general-purpose balanced tree
  * implementation.  These trees are appropriate for maintaining in memory one
  * or more lists of items, each list sorted according to key values (key values
  * must form a "completely ordered set") where no two items in a single list
  * can have the same key value.  The following operations are supported:
- *     Create an empty list
- *     Add an item to a list
- *     Look up an item in a list by key value
- *     Look up the Nth item in a list
- *     Delete an item from a list
- *     Find the first/last/next/previous item in a list
- *     Destroy a list
+ *
+ *  - Create an empty list
+ *  - Add an item to a list
+ *  - Look up an item in a list by key value
+ *  - Look up the Nth item in a list
+ *  - Delete an item from a list
+ *  - Find the first/last/next/previous item in a list
+ *  - Destroy a list
+ *
  * Each of the above operations requires Order(log(N)) time where N is the
  * number of items in the list (except for list creation which requires
  * constant time and list destruction which requires Order(N) time if the user-
@@ -139,7 +97,7 @@ typedef TBBT_NODE **TBBT_TREE;
 extern "C" {
 #endif
 
-HDFLIBAPI TBBT_TREE *tbbtdmake(intn (*compar)(void *, void *, intn), intn arg, uintn fast_compare);
+HDFLIBAPI TBBT_TREE *tbbtdmake(int (*compar)(void *, void *, int), int arg, unsigned fast_compare);
 /* Allocates and initializes an empty threaded, balanced, binary tree and
  * returns a pointer to the control structure for it.  You can also create
  * empty trees without this function as long as you never use tbbtd* routines
@@ -201,10 +159,10 @@ HDFLIBAPI TBBT_TREE *tbbtdmake(intn (*compar)(void *, void *, intn), intn arg, u
  */
 
 HDFLIBAPI TBBT_NODE *tbbtdfind(TBBT_TREE *tree, void *key, TBBT_NODE **pp);
-HDFLIBAPI TBBT_NODE *tbbtfind(TBBT_NODE *root, void *key, intn (*cmp)(void *, void *, intn), intn arg,
+HDFLIBAPI TBBT_NODE *tbbtfind(TBBT_NODE *root, void *key, int (*cmp)(void *, void *, int), int arg,
                               TBBT_NODE **pp);
 HDFLIBAPI TBBT_NODE *tbbtdless(TBBT_TREE *tree, void *key, TBBT_NODE **pp);
-HDFLIBAPI TBBT_NODE *tbbtless(TBBT_NODE *root, void *key, intn (*cmp)(void *, void *, intn), intn arg,
+HDFLIBAPI TBBT_NODE *tbbtless(TBBT_NODE *root, void *key, int (*cmp)(void *, void *, int), int arg,
                               TBBT_NODE **pp);
 /* Locate a node based on the key given.  A pointer to the node in the tree
  * with a key value matching `key' is returned.  If no such node exists, NULL
@@ -228,8 +186,8 @@ HDFLIBAPI TBBT_NODE *tbbtindx(TBBT_NODE *root, int32 indx);
  */
 
 HDFLIBAPI TBBT_NODE *tbbtdins(TBBT_TREE *tree, void *item, void *key);
-HDFLIBAPI TBBT_NODE *tbbtins(TBBT_NODE **root, void *item, void *key, intn (*cmp)(void *, void *, intn),
-                             intn arg);
+HDFLIBAPI TBBT_NODE *tbbtins(TBBT_NODE **root, void *item, void *key, int (*cmp)(void *, void *, int),
+                             int arg);
 /* Insert a new node to the tree having a key value of `key' and a data pointer
  * of `item'.  If a node already exists in the tree with key value `key' or if
  * malloc() fails, NULL is returned (no node is inserted), otherwise a pointer
@@ -280,7 +238,7 @@ HDFLIBAPI void       tbbtfree(TBBT_NODE **root, void (*fd)(void *), void (*fk)(v
 HDFLIBAPI void tbbtprint(TBBT_NODE *node);
 /* Prints out the data in a node */
 
-HDFLIBAPI void tbbtdump(TBBT_TREE *tree, intn method);
+HDFLIBAPI void tbbtdump(TBBT_TREE *tree, int method);
 /* Prints an entire tree.  The method variable determines which sort of
  * traversal is used:
  *      -1 : Pre-Order Traversal
@@ -291,7 +249,7 @@ HDFLIBAPI void tbbtdump(TBBT_TREE *tree, intn method);
 HDFLIBAPI long tbbtcount(TBBT_TREE *tree);
 
 /* Terminate the buffers used in the tbbt*() interface */
-HDFPUBLIC intn tbbt_shutdown(void);
+HDFPUBLIC int tbbt_shutdown(void);
 
 #ifdef __cplusplus
 }

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -2291,7 +2291,7 @@ Vgetid(HFILEID f, /* IN: file handle */
         if (vf->vgtree == NULL)
             HGOTO_DONE(FAIL); /* just return FAIL, no error */
 
-        if (NULL == (t = (void **)tbbtfirst((TBBT_NODE *)*(vf->vgtree))))
+        if (NULL == (t = (void **)tbbtfirst(vf->vgtree->root)))
             HGOTO_DONE(FAIL); /* just return FAIL, no error */
 
         /* t is assumed to valid at this point */
@@ -2305,8 +2305,8 @@ Vgetid(HFILEID f, /* IN: file handle */
         key = (int32)vgid;
         t   = (void **)tbbtdfind(vf->vgtree, (void *)&key, NULL);
 
-        if (t == NULL || t == (void **)tbbtlast((TBBT_NODE *)*(
-                                  vf->vgtree))) { /* couldn't find the old vgid or at the end */
+        if (t == NULL || t == (void **)tbbtlast(vf->vgtree->root)) {
+            /* couldn't find the old vgid or at the end */
             ret_value = (FAIL);
         }
         else if (NULL == (t = (void **)tbbtnext((TBBT_NODE *)t))) /* get the next node in the tree */

--- a/hdf/src/vio.c
+++ b/hdf/src/vio.c
@@ -1174,7 +1174,7 @@ VSgetid(HFILEID f, /* IN: file handle */
         if (vf->vstree == NULL)
             HGOTO_DONE(FAIL);
 
-        if ((t = (void **)tbbtfirst((TBBT_NODE *)*(vf->vstree))) == NULL)
+        if ((t = (void **)tbbtfirst(vf->vstree->root)) == NULL)
             HGOTO_DONE(FAIL);
 
         /* we assume 't' is valid at this point */


### PR DESCRIPTION
The TBBT code used a weird scheme where the main data structures were defined differently in the header and source files in an attempt to hide private details. This has been switched to use a PIMPL scheme with properly hidden data instead.