### PR TITLE
Fix clang warnings

### DIFF
--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -2824,7 +2824,7 @@ DFSDIputndg(int32 file_id, uint16 ref, DFSsdg *sdg)
             /* if dataluf non-NULL, set up to write */
             if (sdg->dataluf[luf] && sdg->dataluf[luf][0]) {
                 strcpy((char *)bufp, sdg->dataluf[luf]);
-                bufp += strlen(bufp) + 1;
+                bufp += strlen((char *)bufp) + 1;
             }
             else { /* dataluf NULL */
                 *bufp++ = '\0';
@@ -2834,7 +2834,7 @@ DFSDIputndg(int32 file_id, uint16 ref, DFSsdg *sdg)
             for (i = 0; i < sdg->rank; i++) {
                 if (sdg->dimluf[luf] && sdg->dimluf[luf][i] && sdg->dimluf[luf][i][0]) { /* dimluf not NULL */
                     strcpy((char *)bufp, sdg->dimluf[luf][i]);
-                    bufp += strlen(bufp) + 1;
+                    bufp += strlen((char *)bufp) + 1;
                 }
                 else { /* dimluf NULL */
                     *bufp++ = '\0';
@@ -4660,7 +4660,6 @@ DFSDwriteslab(int32 start[], int32 stride[], int32 count[], void *data)
     int32 fileNTsize;  /* size of this NT in the file  */
     int32 localNTsize; /* size of this NT as it occurs in this machine */
     int32 numelements; /* number of floats to read at once */
-    int32 sdgsize;     /* number of bytes to be written in the SDG */
     int32 rowsize;     /* number of bytes to be written at once */
                        /*   in the hyperslab */
     int32  fileoffset; /* offset into the current dataset in the file */
@@ -4716,11 +4715,6 @@ DFSDwriteslab(int32 start[], int32 stride[], int32 count[], void *data)
     localNTsize     = DFKNTsize((numtype | DFNT_NATIVE) & (~DFNT_LITEND));
     fileNTsize      = DFKNTsize(numtype);
     fileNT          = Writesdg.filenumsubclass;
-
-    /* Calculate total bytes in SDS that can be written */
-    sdgsize = fileNTsize;
-    for (i = 0; i < Writesdg.rank; i++)
-        sdgsize *= Writesdg.dimsizes[i];
 
     /* Set Access Id */
     aid = Writesdg.aid;

--- a/hdf/src/dfunjpeg.c
+++ b/hdf/src/dfunjpeg.c
@@ -338,7 +338,7 @@ DFCIunjpeg(int32 file_id, uint16 tag, uint16 ref, void *image, int32 xdim, int32
     while (cinfo_ptr->output_scanline < cinfo_ptr->output_height) {
         buffer     = (JSAMPARRAY)&image;
         lines_read = jpeg_read_scanlines(cinfo_ptr, buffer, 1);
-        image = (char *)image +
+        image      = (char *)image +
                 ((size_t)cinfo_ptr->output_width * (size_t)cinfo_ptr->output_components * lines_read);
     }
 

--- a/hdf/src/dfunjpeg.c
+++ b/hdf/src/dfunjpeg.c
@@ -310,7 +310,7 @@ DFCIunjpeg(int32 file_id, uint16 tag, uint16 ref, void *image, int32 xdim, int32
      */
     struct jpeg_decompress_struct *cinfo_ptr;
     struct jpeg_error_mgr         *jerr_ptr;
-    JDIMENSION                     lines_read, lines_left;
+    JDIMENSION                     lines_read;
     JSAMPARRAY                     buffer;
 
     if ((cinfo_ptr = calloc(1, sizeof(struct jpeg_decompress_struct))) == NULL)
@@ -335,14 +335,12 @@ DFCIunjpeg(int32 file_id, uint16 tag, uint16 ref, void *image, int32 xdim, int32
     jpeg_start_decompress(cinfo_ptr);
 
     /* read the whole image in */
-    lines_left = (JDIMENSION)ydim;
     while (cinfo_ptr->output_scanline < cinfo_ptr->output_height) {
         buffer     = (JSAMPARRAY)&image;
         lines_read = jpeg_read_scanlines(cinfo_ptr, buffer, 1);
-        lines_left -= lines_read;
         image = (char *)image +
                 ((size_t)cinfo_ptr->output_width * (size_t)cinfo_ptr->output_components * lines_read);
-    } /* end while */
+    }
 
     /* Finish reading stuff in */
     jpeg_finish_decompress(cinfo_ptr);

--- a/hdf/test/mgr.c
+++ b/hdf/test/mgr.c
@@ -4513,6 +4513,9 @@ test_mgr_chunkwr_pixel(int flag)
     /********************** End of variable declaration **********************/
 
     i = flag;
+
+    memset(&chunk_def, 0, sizeof(HDF_CHUNK_DEF));
+
     /*
      * Create and open the file.
      */
@@ -4576,6 +4579,7 @@ test_mgr_chunkwr_pixel(int flag)
             break;
         }
         default: {
+            comp_flag = HDF_NONE;
             printf("Error\n");
             break;
         }

--- a/hdf/util/gif2hdf.c
+++ b/hdf/util/gif2hdf.c
@@ -21,7 +21,7 @@ int
 main(int argv, char *argc[])
 {
 
-    GIFTOMEM     GifMemoryStruct;
+    GIFTOMEM GifMemoryStruct;
 
     FILE *fpGif;
     int32 i;

--- a/hdf/util/gif2hdf.c
+++ b/hdf/util/gif2hdf.c
@@ -22,7 +22,6 @@ main(int argv, char *argc[])
 {
 
     GIFTOMEM     GifMemoryStruct;
-    GIFIMAGEDESC gifImageDesc;
 
     FILE *fpGif;
     int32 i;

--- a/mfhdf/hdfimport/hdfimport.c
+++ b/mfhdf/hdfimport/hdfimport.c
@@ -1731,13 +1731,15 @@ gtype(char *infile, struct Input *in, FILE **strm)
         else {
             if (!memcmp("FP64", buf, 4) || !memcmp("fp64", buf, 4)) {
                 in->is_fp64 = TRUE;
-                if (in->outtype != FP_64)
+                if (in->outtype != FP_64) {
                     if (in->outtype != NO_NE) {
                         fprintf(stderr, err4, infile);
                         goto err;
                     }
-                    else
+                    else {
                         in->outtype = FP_32;
+                    }
+                }
             }
             else {
                 if (in->outtype != NO_NE) {

--- a/mfhdf/libsrc/putget.c
+++ b/mfhdf/libsrc/putget.c
@@ -1806,31 +1806,32 @@ ncvarput(int cdfid, int varid, const long *start, const long *edges, ncvoid *val
 int
 NC_fill_buffer(NC *handle, int varid, const long *edges, void *values)
 {
-    NC_var       *vp;
-    NC_attr     **attr;
+    NC_var       *vp   = NULL;
+    NC_attr     **attr = NULL;
     unsigned long buf_size;
-    int           ii;
 
     /* Find the variable structure */
     if (handle->vars == NULL)
-        return (-1);
+        return -1;
     vp = NC_hlookupvar(handle, varid);
     if (vp == NULL)
-        return (-1);
+        return -1;
 
     /* Compute the size of the buffer using the edges */
     buf_size = 1;
-    for (ii = 0; ii < vp->assoc->count; ii++)
+    for (int ii = 0; ii < vp->assoc->count; ii++)
         buf_size = buf_size * edges[ii];
 
     /* Find user-defined fill-value and fill the buffer with it */
     attr = NC_findattr(&vp->attrs, _FillValue);
     if (attr != NULL)
-        if (HDmemfill(values, (*attr)->data->values, vp->szof, buf_size) == NULL)
-            return (-1);
+        if (HDmemfill(values, (*attr)->data->values, vp->szof, buf_size) == NULL) {
+            return -1;
+        }
         /* If no user-defined fill-value, fill the buffer with default fill-value */
-        else
+        else {
             NC_arrayfill(values, buf_size * vp->szof, vp->type);
+        }
     return 0;
 }
 

--- a/mfhdf/test/tncvargetfill.c
+++ b/mfhdf/test/tncvargetfill.c
@@ -166,8 +166,6 @@ test_1dim_multivars()
     /* result data to compare against read data */
     int16 sdresult1[] = {300, 301, 302, 303, -1, -1, 306, 307};
     int16 sdresult2[] = {102, 104};
-    int16 ncresult1[] = {300, 301, 302, 303, -1, -1, 306, 307}; /* same as sd result */
-    int16 ncresult2[] = {102, 104, -2, -2, -2, -2, -2, -2};
 
     /* Create a new file */
     fid = SDstart(FILENAME1, DFACC_CREATE);
@@ -677,9 +675,6 @@ test_readings(long max_numrecs)
 
     /* data resulted from reading at start=[4,0,0] for edges=[6,1,1] */
     int16 result3D_start400_edge611[6] = {-3, -3, -3, 800, -3, -3};
-
-    /* data resulted from reading at start=[4] for edges=[6] */
-    int16 result1D_start4_edge6[] = {302, 303, -1, -1, -1, -1};
 
     /* Open the file for reading and writing with nc API */
     ncid = ncopen(FILENAME2, NC_RDWR);


### PR DESCRIPTION
* String casts in hdf/src/dfsd.c
* Unused variables
* Possible unset variables in hdf/test/mgr.c
* Ambiguous braces