### PR TITLE
Fix encoder detection w/ --with-szlib & no paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -756,12 +756,14 @@ case "X-$withval" in
   X-yes)
     HAVE_SZIP="yes"
     AC_CHECK_HEADERS([szlib.h], [HAVE_SZLIB_H="yes"], [unset HAVE_SZIP])
-    if test "x$HAVE_SZLIB" = "xyes" -a "x$HAVE_SZLIB_H" = "xyes"; then
+    if test "x$HAVE_SZIP" = "xyes" -a "x$HAVE_SZLIB_H" = "xyes"; then
       AC_CHECK_LIB([sz], [SZ_BufftoBuffCompress],, [unset HAVE_SZIP])
     fi
 
     if test -z "$HAVE_SZIP"; then
       AC_MSG_ERROR([couldn't find szlib library])
+    else
+      USE_COMP_SZIP="yes"
     fi
     ;;
   X-|X-no|X-none)

--- a/mfhdf/test/tszip.c
+++ b/mfhdf/test/tszip.c
@@ -834,8 +834,8 @@ test_szip_chunk()
     for (j = 0; j < CLENGTH; j++) {
         for (i = 0; i < CWIDTH; i++) {
             if (chunk_out[j][i] != chunk4[j][i]) {
-                fprintf(stderr, "Bogus val in loc [%d][%d] in chunk #4, want %ld got %ld\n", j, i,
-                        chunk4[j][i], chunk_out[j][i]);
+                fprintf(stderr, "Bogus val in loc [%d][%d] in chunk #4, want %d got %d\n", j, i, chunk4[j][i],
+                        chunk_out[j][i]);
                 num_errs++;
             }
         }
@@ -852,8 +852,8 @@ test_szip_chunk()
     for (j = 0; j < CLENGTH; j++) {
         for (i = 0; i < CWIDTH; i++)
             if (chunk_out[j][i] != chunk5[j][i]) {
-                fprintf(stderr, "Bogus val in loc [%d][%d] in chunk #5, want %ld got %ld\n", j, i,
-                        chunk5[j][i], chunk_out[j][i]);
+                fprintf(stderr, "Bogus val in loc [%d][%d] in chunk #5, want %d got %d\n", j, i, chunk5[j][i],
+                        chunk_out[j][i]);
                 num_errs++;
             }
     }
@@ -885,9 +885,6 @@ test_szip_chunk()
 #define CHK_DIM1      2  /* second dimension of the chunk */
 #define CHK_DIM2      2  /* third dimension of the chunk */
 
-int16 all_data[SDS_DIM0][SDS_DIM1][SDS_DIM2];
-int16 out_data[SDS_DIM0][SDS_DIM1][SDS_DIM2];
-
 static intn
 test_szip_chunk_3d()
 {
@@ -903,8 +900,11 @@ test_szip_chunk_3d()
     int16         fill_value = 0; /* Fill value */
     comp_coder_t  comp_type;      /* to retrieve compression type into */
     comp_info     cinfo;          /* compression information structure */
-    int           num_errs = 0;   /* number of errors so far */
-    int           i, j, k;
+    int16         all_data[SDS_DIM0][SDS_DIM1][SDS_DIM2];
+    int16         out_data[SDS_DIM0][SDS_DIM1][SDS_DIM2];
+
+    int num_errs = 0; /* number of errors so far */
+    int i, j, k;
 
     for (i = 0; i < SDS_DIM0; i++) {
         for (j = 0; j < SDS_DIM1; j++) {
@@ -1024,7 +1024,7 @@ test_szip_chunk_3d()
         for (j = 0; j < SDS_DIM1; j++) {
             for (k = 0; k < SDS_DIM2; k++) {
                 if (out_data[i][j][k] != all_data[i][j][k]) {
-                    fprintf(stderr, "Bogus val in loc [%d][%d][%d] want %ld got %ld\n", i, j, k,
+                    fprintf(stderr, "Bogus val in loc [%d][%d][%d] want %d got %d\n", i, j, k,
                             out_data[i][j][k], all_data[i][j][k]);
                     num_errs++;
                 }

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -156,6 +156,16 @@ Support for new platforms and compilers
 Bugs fixed since HDF 4.2.16
 ===========================
 
+    - Fix --with-szlib with no paths not detecting the encoder
+
+      The --with-szlib option in the Autotools has been broken when used
+      without include/library paths for the past decade (git blame says 11
+      years ago). A misnamed variable and a missing setting would skip
+      the encoder check, so the library could only be added in decode-only
+      mode.
+
+      This has been fixed and szip encoding will now be detected normally.
+
     - Fixed an external file bug introduced in 4.2.16
 
       Fixing HDFFR-1607 introduced a bug where the flag that indicates whether


### PR DESCRIPTION
The Autotools --with-szlib option did not correctly detect the presence of the encoder due to a mis-named variable. When enabled, a missing variable would cause the dumper tests to fail due to picking the non-szip file for output diffs.

This is fixed now, and --with-szlib works as expected.

Also cleans up some szip-related warnings.