### PR TITLE
Enable szip + encoder by default

### DIFF
--- a/CMakeFilters.cmake
+++ b/CMakeFilters.cmake
@@ -184,10 +184,10 @@ endif ()
 #-----------------------------------------------------------------------------
 # Option for SzLib support
 #-----------------------------------------------------------------------------
-option (HDF4_ENABLE_SZIP_SUPPORT "Use SZip Filter" OFF)
+option (HDF4_ENABLE_SZIP_SUPPORT "Use SZip Filter" ON)
 set (SZIP_INFO "disabled")
 if (HDF4_ENABLE_SZIP_SUPPORT)
-  option (HDF4_ENABLE_SZIP_ENCODING "Use SZip Encoding" OFF)
+  option (HDF4_ENABLE_SZIP_ENCODING "Use SZip Encoding" ON)
   if (NOT SZIP_USE_EXTERNAL)
     set(SZIP_FOUND FALSE)
     set(libaec_USE_STATIC_LIBS ${USE_LIBAEC_STATIC})

--- a/configure.ac
+++ b/configure.ac
@@ -745,12 +745,15 @@ esac
 
 ## ----------------------------------------------------------------------
 ## Is the szip library present?
+##
+## Now that libaec is easily available, we attempt to detect it by
+## default
 AC_SUBST(USE_COMP_SZIP) USE_COMP_SZIP="no"
 AC_SUBST(SZIP_HAS_ENCODER) SZIP_HAS_ENCODER="no"
 AC_ARG_WITH([szlib],
             [AS_HELP_STRING([--with-szlib=DIR],
-                            [Use szlib library [default=no]])],,
-            [withval=no])
+                            [Use szlib library [default=yes]])],,
+            [withval=yes])
 
 case "X-$withval" in
   X-yes)

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -39,6 +39,11 @@ New features and changes
 ========================
     Configuration:
     -------------
+    - szip support enabled by default
+
+      Now that libaec is easily available, HDF4 will attempt to build w/
+      szip + encoder by default in both CMake and the Autotools.
+
     - XDR changes
 
       We now only support building HDF4 with the XDR implementation packaged


### PR DESCRIPTION
As in HDF5, now that libaec is easily available, we attempt to build HDF4 using szip with the encoder enabled by default in both the Autotools and CMake.