### PR TITLE
Checked for invalid file ID

### DIFF
--- a/hdf/src/hfile.c
+++ b/hdf/src/hfile.c
@@ -205,7 +205,7 @@ static intn HIstart(void);
 
 /*--------------------------------------------------------------------------
 NAME
-   Hopen -- Opens a HDF file.
+   Hopen -- Opens or creates an HDF file.
 USAGE
    int32 Hopen(path, access, ndds)
    char *path;             IN: Name of file to be opened.

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -645,6 +645,10 @@ Vinitialize(HFILEID f /* IN: file handle */)
     /* clear error stack */
     HEclear();
 
+    /* Check file ID */
+    if (f < 0)
+        HGOTO_ERROR(DFE_ARGS, FAIL);
+
     /* Perform global, one-time initialization */
     if (library_terminate == FALSE) {
         if (VIstart() == FAIL)


### PR DESCRIPTION
Vinitialize did not fail when the passed-in file ID is -1.
Added a check for negative file ID.

Fixed GH-354 (HDFFR-125)