### PR TITLE
Moved libver symbols to hdf.h

### DIFF
--- a/bin/h4vers
+++ b/bin/h4vers
@@ -27,7 +27,7 @@ use strict;
 
 ### Purpose
 # Increments the hdf4 version number by changing the value of
-# constants in the hdf/src/hfile_priv.h file.  The new version number is
+# constants in the hdf/src/hdf.h file.  The new version number is
 # printed on the standard output. An alternate source file name can be
 # specified as an argument.  In any case, the original file is saved
 # by appending a tilde `~' to the name.
@@ -61,11 +61,11 @@ use strict;
 # and the annotation string is cleared.
 #
 # If a file is specified then that file is used instead of
-# ./hfile_priv.h or ./hdf/src/hfile_priv.h.
+# ./hdf.h or ./hdf/src/hdf.h.
 #
 # If the version number is changed (either `-s' or `-i' was used on
 # the command line) then the first line of the README.md and
-# release_notes/RELEASE.txt two levels above the hfile_priv.h file are also
+# release_notes/RELEASE.txt two levels above the hdf.h file are also
 # modified so it looks something like: This is hdf4-1.2.3-pre1 currently
 # under development. The AC_INIT macro in configure.in will also change
 # in this case to be something like: AC_INIT([HDF4], [hdf4-1.2.3-pre1],
@@ -128,15 +128,15 @@ Usage: $prog [OPTS] [FILE]
         as \"version 1.1 release 0 (pre1)\" will be printed.
     FILE
         The name of the file that contains version information.  This is
-        seldom necessary since files hfile_priv.h, hdf/src/hfile_priv.h,
-        src/hfile_priv.h, and ../hdf/src/hfile_priv.h are automatically checked.
+        seldom necessary since files hdf.h, hdf/src/hdf.h,
+        src/hdf.h, and ../hdf/src/hdf.h are automatically checked.
 EOF
   exit 1;
 }
 
 # Parse arguments
 my ($verbose, $set, $inc, $file, $rc);
-my (@files) = ("hdf/src/hfile_priv.h", "../hdf/src/hfile_priv.h", "src/hfile_priv.h", "hfile_priv.h");
+my (@files) = ("hdf/src/hdf.h", "../hdf/src/hdf.h", "src/hdf.h", "hdf.h");
 while ($_ = shift) {
   $_ eq "-s" && do {
     die "-s switch needs a version number\n" unless @ARGV;
@@ -168,12 +168,12 @@ die "mutually exclusive options given\n" if $set && $inc;
 #print "file is $file.\n";
 #print "File array is ", @files;
 
-# Determine file to use as hfile_priv.h, README.md,
+# Determine file to use as hdf.h, README.md,
 # release_notes/RELEASE.txt, configure.in,
 # and config/cmake/scripts/HDF4config.cmake.
 # The paths to README.md, release_notes/RELEASE.txt, configure.ac,
 # and config/cmake/scripts/HDF4config.cmake
-# files are always from the directory two levels above hfile_priv.h.
+# files are always from the directory two levels above hdf.h.
 unless ($file) {
   for (@files) {
     ($file=$_,last) if -f $_;

--- a/hdf/src/hdf.h
+++ b/hdf/src/hdf.h
@@ -14,6 +14,17 @@
 #ifndef H4_HDF_H
 #define H4_HDF_H
 
+/* Library version numbers */
+
+#define LIBVER_MAJOR      4
+#define LIBVER_MINOR      3
+#define LIBVER_RELEASE    0
+#define LIBVER_SUBRELEASE "1" /* For pre-releases like snap0 */
+                              /* Empty string for real releases */
+#define LIBVER_STRING "HDF Version 4.3 Release 0-1, February 5, 2024"
+#define LIBVSTR_LEN   80 /* Length of version string */
+#define LIBVER_LEN    92 /* 4+4+4+80 = 92 */
+
 /* NOTE: This header is not protected by include guards, so don't include
  *       it outside of hdf.h
  */

--- a/hdf/src/hfile_priv.h
+++ b/hdf/src/hfile_priv.h
@@ -52,16 +52,9 @@
 #endif
 
 /* ----------------------------- Version Tags ----------------------------- */
-/* Library version numbers */
 
-#define LIBVER_MAJOR      4
-#define LIBVER_MINOR      3
-#define LIBVER_RELEASE    0
-#define LIBVER_SUBRELEASE "1" /* For pre-releases like snap0 */
-                              /* Empty string for real releases */
-#define LIBVER_STRING "HDF Version 4.3 Release 0-1, February 5, 2024"
-#define LIBVSTR_LEN   80 /* Length of version string */
-#define LIBVER_LEN    92 /* 4+4+4+80 = 92 */
+/* NOTE: Version info moved to hdf.h for public consumption */
+
 /* end of version tags */
 
 /* -------------------------- File I/O Functions -------------------------- */

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -131,6 +131,19 @@ New features and changes
 
     C Library:
     ----------
+    - Version symbols moved from hfile.h to hdf.h
+
+      Since hfile.h is now private, the following symbols have been moved
+      to hdf.h for public consumption:
+
+        LIBVER_MAJOR
+        LIBVER_MINOR
+        LIBVER_RELEASE
+        LIBVER_SUBRELEASE
+        LIBVER_STRING
+        LIBVSTR_LEN
+        LIBVER_LEN
+
     - Private headers are no longer deployed
 
       The following private headers are not a part of the public API and


### PR DESCRIPTION
The following symbols have been moved from hfile.h (now hfile_priv.h) to hdf.h:

        LIBVER_MAJOR
        LIBVER_MINOR
        LIBVER_RELEASE
        LIBVER_SUBRELEASE
        LIBVER_STRING
        LIBVSTR_LEN
        LIBVER_LEN