### PR TITLE
Make some hbitio.h things private

### DIFF
--- a/hdf/src/CMakeLists.txt
+++ b/hdf/src/CMakeLists.txt
@@ -100,6 +100,7 @@ set (HDF4_PRIVATE_HDF_SRC_CHDRS
     ${HDF4_HDF_SRC_SOURCE_DIR}/dfufp2i_priv.h
     ${HDF4_HDF_SRC_SOURCE_DIR}/dynarray_priv.h
     ${HDF4_HDF_SRC_SOURCE_DIR}/glist_priv.h
+    ${HDF4_HDF_SRC_SOURCE_DIR}/hbitio_priv.h
     ${HDF4_HDF_SRC_SOURCE_DIR}/hchunks_priv.h
     ${HDF4_HDF_SRC_SOURCE_DIR}/hcomp_priv.h
     ${HDF4_HDF_SRC_SOURCE_DIR}/hconv_priv.h

--- a/hdf/src/hbitio.c
+++ b/hdf/src/hbitio.c
@@ -37,7 +37,13 @@ LOCAL ROUTINES
 */
 
 #include "hdf_priv.h"
+#include "hbitio_priv.h"
 #include "hfile_priv.h"
+
+/* Define the number of elements in the buffered array */
+#define BITBUF_SIZE 4096
+/* Macro to define the number of bits able to be read/written at a time */
+#define DATANUM (sizeof(uint32) * 8)
 
 /* Local Variables */
 

--- a/hdf/src/hbitio.h
+++ b/hdf/src/hbitio.h
@@ -23,45 +23,10 @@
 
 #include "hdf.h"
 
-/* Define the number of elements in the buffered array */
-#define BITBUF_SIZE 4096
 /* Macro to define the number of bits cached in the 'bits' variable */
 #define BITNUM (sizeof(uint8) * 8)
-/* Macro to define the number of bits able to be read/written at a time */
-#define DATANUM (sizeof(uint32) * 8)
-
-typedef struct bitrec_t {
-    int32 acc_id;       /* Access ID for H layer I/O routines */
-    int32 bit_id;       /* Bitfile ID for internal use */
-                        /* Note that since HDF has signed 32bit offset limit we need to change this to signed
-                           since the get passed to Hxxx calls which take signed 32bit arguments */
-    int32 block_offset; /* offset of the current buffered block in the dataset */
-    int32 max_offset;   /* offset of the last byte written to the dataset */
-    int32 byte_offset;  /* offset of the current byte in the dataset */
-
-    intn   count;    /* bit count to next boundary */
-    intn   buf_read; /* number of bytes read into buffer (necessary for random I/O) */
-    uint8  access;   /* What the access on this file is ('r', 'w', etc..) */
-    uint8  mode;     /* how are we interacting with the data now ('r', 'w', etc) */
-    uint8  bits;     /* extra bit buffer, 0..BITNUM-1 bits */
-    uint8 *bytep;    /* current position in buffer */
-    uint8 *bytez;    /* end of buffer to compare */
-    uint8 *bytea;    /* byte buffer */
-} bitrec_t;
 
 /* Function-like Macros */
 #define Hputbit(bitid, bit) ((Hbitwrite(bitid, 1, (uint32)bit) == FAIL) ? FAIL : SUCCEED)
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-HDFLIBAPI const uint8 maskc[9];
-
-HDFLIBAPI const uint32 maskl[33];
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* H4_HBITIO_H */

--- a/hdf/src/hbitio_priv.h
+++ b/hdf/src/hbitio_priv.h
@@ -1,0 +1,57 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Board of Trustees of the University of Illinois.         *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF.  The full HDF copyright notice, including       *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://support.hdfgroup.org/ftp/HDF/releases/.  *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ **  hbitio_priv.h
+ **
+ **  Data structures and macros for bitfile access to HDF data objects.
+ **  These are mainly used for compression I/O and N-bit data objects.
+ */
+
+#ifndef H4_HBITIO_PRIV_H
+#define H4_HBITIO_PRIV_H
+
+#include "hdf.h"
+
+typedef struct bitrec_t {
+    int32 acc_id;       /* Access ID for H layer I/O routines */
+    int32 bit_id;       /* Bitfile ID for internal use */
+                        /* Note that since HDF has signed 32bit offset limit we need to change this to signed
+                           since the get passed to Hxxx calls which take signed 32bit arguments */
+    int32 block_offset; /* offset of the current buffered block in the dataset */
+    int32 max_offset;   /* offset of the last byte written to the dataset */
+    int32 byte_offset;  /* offset of the current byte in the dataset */
+
+    intn   count;    /* bit count to next boundary */
+    intn   buf_read; /* number of bytes read into buffer (necessary for random I/O) */
+    uint8  access;   /* What the access on this file is ('r', 'w', etc..) */
+    uint8  mode;     /* how are we interacting with the data now ('r', 'w', etc) */
+    uint8  bits;     /* extra bit buffer, 0..BITNUM-1 bits */
+    uint8 *bytep;    /* current position in buffer */
+    uint8 *bytez;    /* end of buffer to compare */
+    uint8 *bytea;    /* byte buffer */
+} bitrec_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+HDFLIBAPI const uint8 maskc[9];
+
+HDFLIBAPI const uint32 maskl[33];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H4_HBITIO_PRIV_H */

--- a/hdf/src/hdf.h
+++ b/hdf/src/hdf.h
@@ -184,9 +184,8 @@ typedef intn (*hdf_termfunc_t)(void); /* termination function typedef */
 #include "hcomp.h"
 #include "herr.h"
 #include "hproto.h"
-#include "hdatainfo.h" /* data info header */
-#include "vg.h"        /* Vgroup/Vdata header */
-#include "mfgr.h"      /* GR header */
+#include "vg.h"   /* Vgroup/Vdata header */
+#include "mfgr.h" /* GR header */
 
 /* these may eventually evolve into real-life functions but not yet */
 #define HDFopen(f, a, d) Hopen((f), (a), (d))

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -164,6 +164,22 @@ New features and changes
         mstdio.h
         tbbt.h
 
+    - Most of hbitio.h moved to hbitio_priv.h
+
+      Still in hbitio.h:
+
+      * BITNUM #define
+      * Hputbit() function-like macro
+
+      These are referenced in older versions of the reference manual, e.g., in
+      the Hendbitaccess() entry.
+
+      Moved to hbitio_priv.h:
+
+      * BITBUF_SIZE, DATANUM #defines
+      * bitrec_t struct
+      * maskc and maskl variable declarations
+
     - hdfi.h is no longer included by hdf.h
 
       In the past, hdfi.h (an internal header file) was included in the


### PR DESCRIPTION
Most of hbitio.h moved to hbitio_priv.h

Still in hbitio.h:

* BITNUM #define
* Hputbit() function-like macro

These are referenced in older versions of the reference manual, e.g., in the Hendbitaccess() entry.

Moved to hbitio_priv.h:

* BITBUF_SIZE, DATANUM #defines
* bitrec_t struct
* maskc and maskl variable declarations