### PR TITLE
Support OpenBSD for Autotools.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -994,6 +994,7 @@ AC_CHECK_FUNCS([fork getrusage system wait])
 ## of being copied depending upon the host.
 case "$host" in
   *-linux*|*-k*bsd*-gnu|*-gnu*)BAR="linux"       ;;
+  *-openbsd*)           BAR="fbsd"        ;;  
   *-freebsd*)           BAR="fbsd"        ;;
   *-ibm-aix*)           BAR="aix"         ;;
   sparc64-*-solaris2*)  BAR="solaris64"   ;;


### PR DESCRIPTION
As you can see from the following table, OpenBSD community actively supports the latest HDF (cf., FreeBSD).

![reology](https://repology.org/badge/vertical-allrepos/hdf5.svg?header=hdf5)

I hope they will add HDF4  in their package system, too.