### PR TITLE
Corrected handling of SDgetcompress()

### DIFF
--- a/config/cmake/h4config.h.in
+++ b/config/cmake/h4config.h.in
@@ -141,6 +141,9 @@
    */
 #define H4_LT_OBJDIR "@HDF4_LT_OBJDIR@"
 
+/* Define if deprecated public API symbols are disabled */
+#cmakedefine H4_NO_DEPRECATED_SYMBOLS @H4_NO_DEPRECATED_SYMBOLS@
+
 /* Define to 1 if your C compiler doesn't accept -c and -o together. */
 #cmakedefine H4_NO_MINUS_C_MINUS_O @H4_NO_MINUS_C_MINUS_O@
 

--- a/config/cmake/libhdf4.settings.cmake.in
+++ b/config/cmake/libhdf4.settings.cmake.in
@@ -40,3 +40,4 @@ Features:
                SZIP compression: @SZIP_INFO@
  Export HDF4-built netCDF-2 API: @HDF4_ENABLE_NETCDF@ (ON: export undecorated netCDF names, OFF: prefix with 'sd_')
     HDF4-built ncdump and ncgen: @HDF4_BUILD_NETCDF_TOOLS@
+ With deprecated public symbols: @HDF4_ENABLE_DEPRECATED_SYMBOLS@

--- a/java/src/jni/hdfsdsImp.c
+++ b/java/src/jni/hdfsdsImp.c
@@ -1419,6 +1419,7 @@ done:
     return JNI_TRUE;
 }
 
+#ifndef H4_NO_DEPRECATED_SYMBOLS
 JNIEXPORT jboolean JNICALL
 Java_hdf_hdflib_HDFLibrary_SDgetcompress(JNIEnv *env, jclass clss, jlong sdsid, jobject cinfo)
 {
@@ -1441,6 +1442,7 @@ Java_hdf_hdflib_HDFLibrary_SDgetcompress(JNIEnv *env, jclass clss, jlong sdsid, 
 done:
     return JNI_TRUE;
 }
+#endif /* H4_NO_DEPRECATED_SYMBOLS */
 
 JNIEXPORT jboolean JNICALL
 Java_hdf_hdflib_HDFLibrary_SDsetaccesstype(JNIEnv *env, jclass clss, jlong sdsid, jint accesstype)

--- a/java/src/jni/hdfsdsImp.h
+++ b/java/src/jni/hdfsdsImp.h
@@ -187,8 +187,10 @@ JNIEXPORT jboolean JNICALL Java_hdf_hdflib_HDFLibrary_SDsetcompress(JNIEnv *env,
 JNIEXPORT jboolean JNICALL Java_hdf_hdflib_HDFLibrary_SDgetcompinfo(JNIEnv *env, jclass clss, jlong sdsid,
                                                                     jobject cinfo);
 
+#ifndef H4_NO_DEPRECATED_SYMBOLS
 JNIEXPORT jboolean JNICALL Java_hdf_hdflib_HDFLibrary_SDgetcompress(JNIEnv *env, jclass clss, jlong sdsid,
                                                                     jobject cinfo);
+#endif
 
 JNIEXPORT jboolean JNICALL Java_hdf_hdflib_HDFLibrary_SDsetaccesstype(JNIEnv *env, jclass clss, jlong sdsid,
                                                                       jint accesstype);

--- a/libhdf4.settings.in
+++ b/libhdf4.settings.in
@@ -39,3 +39,4 @@ Features:
                SZIP compression: @SZIP_INFO@
  Export HDF4-built netCDF-2 API: @BUILD_NETCDF@ (yes: export undecorated netCDF names, no: prefix with 'sd_')
     HDF4-built ncdump and ncgen: @BUILD_NETCDF_TOOLS@
+ With deprecated public symbols: @DEPRECATED_SYMBOLS@

--- a/mfhdf/libsrc/mfhdf.h
+++ b/mfhdf/libsrc/mfhdf.h
@@ -139,7 +139,9 @@ HDFLIBAPI intn SDsetnbitdataset(int32 id, intn start_bit, intn bit_len, intn sig
 
 HDFLIBAPI intn SDsetcompress(int32 id, comp_coder_t type, comp_info *c_info);
 
+#ifndef H4_NO_DEPRECATED_SYMBOLS
 HDFLIBAPI intn SDgetcompress(int32 id, comp_coder_t *type, comp_info *c_info);
+#endif
 
 HDFLIBAPI intn SDgetcompinfo(int32 id, comp_coder_t *type, comp_info *c_info);
 

--- a/mfhdf/test/tcomp.c
+++ b/mfhdf/test/tcomp.c
@@ -254,7 +254,7 @@ test_compressed_data()
     /*
      * Retrieve and verify the compression info - bug# 307
      */
-#ifndef H4_NO_DEPRECATED_SYMBOLS   /* Jan 9, 2013 */
+#ifndef H4_NO_DEPRECATED_SYMBOLS
     comp_type = COMP_CODE_INVALID; /* reset variables before retrieving info */
     memset(&cinfo, 0, sizeof(cinfo));
     status = SDgetcompress(newsds2, &comp_type, &cinfo);
@@ -610,7 +610,7 @@ test_compressed_data()
     /*
      * Retrieve and verify the compression info - bug# 307
      */
-#ifndef H4_NO_DEPRECATED_SYMBOLS   /* Jan 9, 2013 */
+#ifndef H4_NO_DEPRECATED_SYMBOLS
     comp_type = COMP_CODE_INVALID; /* reset variables before retrieving info */
     memset(&cinfo, 0, sizeof(cinfo));
     status = SDgetcompress(newsds2, &comp_type, &cinfo);
@@ -696,7 +696,7 @@ test_compressed_data()
     /*
      * Retrieve and verify the compression info - bug# 307
      */
-#ifndef H4_NO_DEPRECATED_SYMBOLS   /* Jan 9, 2013 */
+#ifndef H4_NO_DEPRECATED_SYMBOLS
     comp_type = COMP_CODE_INVALID; /* reset variables before retrieving info */
     memset(&cinfo, 0, sizeof(cinfo));
     status = SDgetcompress(newsds2, &comp_type, &cinfo);
@@ -783,7 +783,7 @@ test_compressed_data()
     /*
      * Retrieve and verify the compression info - bug# 307
      */
-#ifndef H4_NO_DEPRECATED_SYMBOLS   /* Jan 9, 2013 */
+#ifndef H4_NO_DEPRECATED_SYMBOLS
     comp_type = COMP_CODE_INVALID; /* reset variables before retrieving info */
     memset(&cinfo, 0, sizeof(cinfo));
     status = SDgetcompress(newsds2, &comp_type, &cinfo);

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -237,6 +237,8 @@ Bugs fixed since HDF 4.2.16
 
       In this release:
 
+      * CMake builds did not expose H4_NO_DEPRECATED_SYMBOLS via
+        h4config.h
       * The mfhdf.h header now hides the SDgetcompress() call behind an
         H4_NO_DEPRECATED_SYMBOLS ifdef (pulled in via h4config.h via hdf.h)
       * The Java wrappers now correctly exclude SDgetcompress() when

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -228,6 +228,22 @@ Support for new platforms and compilers
 Bugs fixed since HDF 4.2.16
 ===========================
 
+    - Corrected handling of SDgetcompress()
+
+      SDgetcompress() was deprecated in HDF 4.2.9 (2013) and hidden behind
+      ifdefs controlled by the --enable-deprecated-symbols (Autotools) and
+      HDF4_ENABLE_DEPRECATED_SYMBOLS (CMake) options. These ifdefs were
+      incompletely propagated throughout the library.
+
+      In this release:
+
+      * The mfhdf.h header now hides the SDgetcompress() call behind an
+        H4_NO_DEPRECATED_SYMBOLS ifdef (pulled in via h4config.h via hdf.h)
+      * The Java wrappers now correctly exclude SDgetcompress() when
+        deprecated symbols are disabled
+      * The libhdf4.settings file now indicates whether HDF4 was built
+        with or without deprecated symbols
+
     - Fix --with-szlib with no paths not detecting the encoder
 
       The --with-szlib option in the Autotools has been broken when used


### PR DESCRIPTION
SDgetcompress() was deprecated in HDF 4.2.9 (2013) and hidden behind ifdefs controlled by the --enable-deprecated-symbols (Autotools) and HDF4_ENABLE_DEPRECATED_SYMBOLS (CMake) options. These ifdefs were incompletely propagated throughout the library.

In this PR:

* The mfhdf.h header now hides the SDgetcompress() call behind an H4_NO_DEPRECATED_SYMBOLS ifdef (pulled in via h4config.h via hdf.h)
* The Java wrappers now correctly exclude SDgetcompress() when deprecated symbols are disabled
* The libhdf4.settings file now indicates whether HDF4 was built with or without deprecated symbols