### PR TITLE
Fix most float-equal warnings

### DIFF
--- a/hdf/test/chunks.c
+++ b/hdf/test/chunks.c
@@ -142,12 +142,9 @@ static uint8 chunk6[4] = {120, 121, 122, 123};
 
 /* datay layout of arrays in memory */
 /* for comparison in Test 8 */
-static float32 f32_data[2][3][4] = {{{(float32)0.0, (float32)1.0, (float32)2.0, (float32)3.0},
-                                     {(float32)10.0, (float32)11.0, (float32)12.0, (float32)13.0},
-                                     {(float32)20.0, (float32)21.0, (float32)22.0, (float32)23.0}},
-                                    {{(float32)100.0, (float32)101.0, (float32)102.0, (float32)103.0},
-                                     {(float32)110.0, (float32)111.0, (float32)112.0, (float32)113.0},
-                                     {(float32)120.0, (float32)121.0, (float32)122.0, (float32)123.0}}};
+static float32 f32_data[2][3][4] = {
+    {{0.0F, 1.0F, 2.0F, 3.0F}, {10.0F, 11.0F, 12.0F, 13.0F}, {20.0F, 21.0F, 22.0F, 23.0F}},
+    {{100.0F, 101.0F, 102.0F, 103.0F}, {110.0F, 111.0F, 112.0F, 113.0F}, {120.0F, 121.0F, 122.0F, 123.0F}}};
 
 /* for comparison in Test 7 */
 static uint16 u16_data[2][3][4] = {{{0, 1, 2, 3}, {10, 11, 12, 13}, {20, 21, 22, 23}},
@@ -177,9 +174,9 @@ test_chunks(void)
     HCHUNK_DEF      chunk[1]; /* Chunk definition, see 'hchunks_priv.h' */
     int32           dims[5];
     int32           fill_val_len = 1;
-    uint8           fill_val_u8  = 0;            /* test 6 */
-    uint16          fill_val_u16 = 0;            /* test 7 */
-    float32         fill_val_f32 = (float32)0.0; /* test 8 */
+    uint8           fill_val_u8  = 0;    /* test 6 */
+    uint16          fill_val_u16 = 0;    /* test 7 */
+    float32         fill_val_f32 = 0.0F; /* test 8 */
     uint8           inbuf_u8[2][3][4];
     uint16          inbuf_u16[2][3][4]; /* input data buffer */
     float32         inbuf_f32[2][3][4]; /* input data buffer */
@@ -1356,7 +1353,7 @@ test_chunks(void)
     chunk[0].pdims[2].distrib_type = 0; /* NONE */
 
     fill_val_len = 4;
-    fill_val_f32 = (float32)0.0;
+    fill_val_f32 = 0.0F;
 
     /* Open file for writing last odd size chunks now */
     fid = Hopen(TESTFILE_NAME, DFACC_RDWR, 0);
@@ -1422,7 +1419,7 @@ test_chunks(void)
     for (i = 0; i < 2; i++) {
         for (j = 0; j < 3; j++) {
             for (k = 0; k < 4; k++) {
-                if (inbuf_f32[i][j][k] != f32_data[i][j][k]) {
+                if (!H4_FLT_ABS_EQUAL(inbuf_f32[i][j][k], f32_data[i][j][k])) {
                     printf("Wrong data at inbuf_f32[%d][%d][%d], out %f in %f\n", i, j, k,
                            (double)f32_data[i][j][k], (double)inbuf_f32[i][j][k]);
                     errors++;

--- a/hdf/test/mgr.c
+++ b/hdf/test/mgr.c
@@ -2398,12 +2398,12 @@ test_mgr_image_b2a2bb(int flag)
                 3,
                 printf("Error reading data for new image with user-defined fill-value, sub-setted image\n"););
 
-            MESSAGE(8,
-                    for (i = 0; i < TEST_YDIM; i++) for (j = 0; j < TEST_XDIM;
-                                                         j++) for (k = 0; k < TEST_NCOMP;
-                                                                   k++) if (image[i][j][k] != image0[i][j][k])
-                        printf("Location: [%d][%d][%d] image=%f, image0=%f \n", i, j, k,
-                               (double)image[i][j][k], (double)image0[i][j][k]););
+            MESSAGE(8, for (i = 0; i < TEST_YDIM;
+                            i++) for (j = 0; j < TEST_XDIM;
+                                      j++) for (k = 0; k < TEST_NCOMP;
+                                                k++) if (!H4_FLT_ABS_EQUAL(image[i][j][k], image0[i][j][k]))
+                           printf("Location: [%d][%d][%d] image=%f, image0=%f \n", i, j, k,
+                                  (double)image[i][j][k], (double)image0[i][j][k]););
             num_errs++;
         } /* end if */
 

--- a/hdf/test/sdmms.c
+++ b/hdf/test/sdmms.c
@@ -15,7 +15,7 @@
 
 static float32 f32[10][10], tf32[10][10];
 static float32 f32scale[10], tf32scale[10];
-static float32 f32max = (float32)40.0, f32min = (float32)0.0;
+static float32 f32max = 40.0F, f32min = 0.0F;
 static float32 tf32max, tf32min;
 
 static int8 i8[10][10], ti8[10][10];
@@ -234,12 +234,12 @@ test_sdmms(void)
     err2 = 0;
     for (i = 0; i < 10; i++) {
         for (j = 0; j < 10; j++)
-            if (f32[i][j] != tf32[i][j])
+            if (!H4_FLT_ABS_EQUAL(f32[i][j], tf32[i][j]))
                 err = 1;
-        if (f32scale[i] != tf32scale[i])
+        if (!H4_FLT_ABS_EQUAL(f32scale[i], tf32scale[i]))
             err2 = 1;
     }
-    if ((f32max != tf32max) || (f32min != tf32min))
+    if (!H4_FLT_ABS_EQUAL(f32max, tf32max) || !H4_FLT_ABS_EQUAL(f32min, tf32min))
         err1 = 1;
 
     num_errs += err + err1 + err2;
@@ -254,7 +254,8 @@ test_sdmms(void)
     MESSAGE(5, if (err1 == 1) printf(">>> Test failed for float32 max/min.\n");
             else printf("Test passed for float32 max/min.\n"););
 
-    if ((cal1 != ical1) || (cal2 != ical2) || (cal3 != ical3) || (cal4 != ical4) || (cal5 != ical5)) {
+    if (!H4_DBL_ABS_EQUAL(cal1, ical1) || !H4_DBL_ABS_EQUAL(cal2, ical2) || !H4_DBL_ABS_EQUAL(cal3, ical3) ||
+        !H4_DBL_ABS_EQUAL(cal4, ical4) || cal5 != ical5) {
         MESSAGE(5, printf(">>> Test failed for float32 calibration.\n"););
         MESSAGE(5, printf(" Is %f %f %f %f %d\n", ical1, ical2, ical3, ical4, (int)ical5););
         MESSAGE(5, printf(" sld be %f %f %f %f %d\n", cal1, cal2, cal3, cal4, (int)cal5););

--- a/hdf/test/sdnmms.c
+++ b/hdf/test/sdnmms.c
@@ -15,12 +15,12 @@
 
 static float64 f64[10][10], tf64[10][10];
 static float64 f64scale[10], tf64scale[10];
-static float64 f64max = (float64)40.0, f64min = (float64)0.0;
+static float64 f64max = 40.0, f64min = 0.0;
 static float64 tf64max, tf64min;
 
 static float32 f32[10][10], tf32[10][10];
 static float32 f32scale[10], tf32scale[10];
-static float32 f32max = (float32)40.0, f32min = (float32)0.0;
+static float32 f32max = 40.0F, f32min = 0.0F;
 static float32 tf32max, tf32min;
 
 static int8 i8[10][10], ti8[10][10];
@@ -239,12 +239,12 @@ test_sdnmms(void)
     err2 = 0;
     for (i = 0; i < 10; i++) {
         for (j = 0; j < 10; j++)
-            if (f64[i][j] != tf64[i][j])
+            if (!H4_DBL_ABS_EQUAL(f64[i][j], tf64[i][j]))
                 err = 1;
-        if (f64scale[i] != tf64scale[i])
+        if (!H4_DBL_ABS_EQUAL(f64scale[i], tf64scale[i]))
             err2 = 1;
     }
-    if ((f64max != tf64max) || (f64min != tf64min))
+    if (!H4_DBL_ABS_EQUAL(f64max, tf64max) || !H4_DBL_ABS_EQUAL(f64min, tf64min))
         err1 = 1;
 
     num_errs += err + err1 + err2;
@@ -260,12 +260,12 @@ test_sdnmms(void)
     err2 = 0;
     for (i = 0; i < 10; i++) {
         for (j = 0; j < 10; j++)
-            if (f32[i][j] != tf32[i][j])
+            if (!H4_FLT_ABS_EQUAL(f32[i][j], tf32[i][j]))
                 err = 1;
-        if (f32scale[i] != tf32scale[i])
+        if (!H4_FLT_ABS_EQUAL(f32scale[i], tf32scale[i]))
             err2 = 1;
     }
-    if ((f32max != tf32max) || (f32min != tf32min))
+    if (!H4_FLT_ABS_EQUAL(f32max, tf32max) || !H4_FLT_ABS_EQUAL(f32min, tf32min))
         err1 = 1;
 
     num_errs += err + err1 + err2;

--- a/hdf/test/slab.c
+++ b/hdf/test/slab.c
@@ -28,9 +28,9 @@ static float64 maxf64  = 123.0;
 static float64 minf64  = -1.0;
 static float64 fillf64 = 1.0;
 
-static float32 maxf32  = (float32)123.0;
-static float32 minf32  = (float32)-1.0;
-static float32 fillf32 = (float32)1.0;
+static float32 maxf32  = 123.0F;
+static float32 minf32  = -1.0F;
+static float32 fillf32 = 1.0F;
 
 static int32 maxin  = 123;
 static int32 minin  = -1;
@@ -86,9 +86,9 @@ static float64 scplnf64[2] = {0.0, 100.0};
 static float64 scrowf64[3] = {0.0, 10.0, 20.0};
 static float64 sccolf64[4] = {0.0, 1.0, 2.0, 3.0};
 
-static float32 scplnf32[2] = {(float32)0.0, (float32)100.0};
-static float32 scrowf32[3] = {(float32)0.0, (float32)10.0, (float32)20.0};
-static float32 sccolf32[4] = {(float32)0.0, (float32)1.0, (float32)2.0, (float32)3.0};
+static float32 scplnf32[2] = {0.0F, 100.0F};
+static float32 scrowf32[3] = {0.0F, 10.0F, 20.0F};
+static float32 sccolf32[4] = {0.0F, 1.0F, 2.0F, 3.0F};
 
 static int32 scplnin[2] = {0, 100};
 static int32 scrowin[3] = {0, 10, 20};
@@ -123,14 +123,11 @@ static uint8 scrowui8[3] = {0, 10, 20};
 static uint8 sccolui8[4] = {0, 1, 2, 3};
 
 /* Slabs for slabw(), slab1w(), slab2w() */
-static float32 slabw1[1][1][3] = {{{(float32)110.0, (float32)111.0, (float32)112.0}}};
-static float32 slabw2[2][1][3] = {{{(float32)20.0, (float32)21.0, (float32)22.0}},
-                                  {{(float32)120.0, (float32)121.0, (float32)122.0}}};
-static float32 slabw3[1][2][3] = {
-    {{(float32)0.0, (float32)1.0, (float32)2.0}, {(float32)10.0, (float32)11.0, (float32)12.0}}};
-static float32 slabw4[1][1][3] = {{{(float32)100.0, (float32)101.0, (float32)102.0}}};
-static float32 slabw5[2][3][1] = {{{(float32)3.0}, {(float32)13.0}, {(float32)23.0}},
-                                  {{(float32)103.0}, {(float32)113.0}, {(float32)123.0}}};
+static float32 slabw1[1][1][3] = {{{110.0F, 111.0F, 112.0F}}};
+static float32 slabw2[2][1][3] = {{{20.0F, 21.0F, 22.0F}}, {{120.0F, 121.0F, 122.0F}}};
+static float32 slabw3[1][2][3] = {{{0.0F, 1.0F, 2.0F}, {10.0F, 11.0F, 12.0F}}};
+static float32 slabw4[1][1][3] = {{{100.0F, 101.0F, 102.0F}}};
+static float32 slabw5[2][3][1] = {{{3.0F}, {13.0F}, {23.0F}}, {{103.0F}, {113.0F}, {123.0F}}};
 
 static float64 slabw1f64[1][1][3] = {{{110.0, 111.0, 112.0}}};
 static float64 slabw2f64[2][1][3] = {{{20.0, 21.0, 22.0}}, {{120.0, 121.0, 122.0}}};
@@ -186,38 +183,35 @@ static uint8 slabw3ui8[1][2][3] = {{{0, 1, 2}, {10, 11, 12}}};
 static uint8 slabw4ui8[1][1][3] = {{{100, 101, 102}}};
 static uint8 slabw5ui8[2][3][1] = {{{3}, {13}, {23}}, {{103}, {113}, {123}}};
 /* Slabs for slab3w() */
-static float32 slab1[1][1][1]  = {{{(float32)0.0}}};
-static float32 slab2[1][1][1]  = {{{(float32)1.0}}};
-static float32 slab3[1][1][1]  = {{{(float32)2.0}}};
-static float32 slab4[1][1][1]  = {{{(float32)3.0}}};
-static float32 slab5[1][1][1]  = {{{(float32)10.0}}};
-static float32 slab6[1][1][1]  = {{{(float32)11.0}}};
-static float32 slab7[1][1][1]  = {{{(float32)12.0}}};
-static float32 slab8[1][1][1]  = {{{(float32)13.0}}};
-static float32 slab9[1][1][1]  = {{{(float32)20.0}}};
-static float32 slab10[1][1][1] = {{{(float32)21.0}}};
-static float32 slab11[1][1][1] = {{{(float32)22.0}}};
-static float32 slab12[1][1][1] = {{{(float32)23.0}}};
-static float32 slab13[1][1][1] = {{{(float32)100.0}}};
-static float32 slab14[1][1][1] = {{{(float32)101.0}}};
-static float32 slab15[1][1][1] = {{{(float32)102.0}}};
-static float32 slab16[1][1][1] = {{{(float32)103.0}}};
-static float32 slab17[1][1][1] = {{{(float32)110.0}}};
-static float32 slab18[1][1][1] = {{{(float32)111.0}}};
-static float32 slab19[1][1][1] = {{{(float32)112.0}}};
-static float32 slab20[1][1][1] = {{{(float32)113.0}}};
-static float32 slab21[1][1][1] = {{{(float32)120.0}}};
-static float32 slab22[1][1][1] = {{{(float32)121.0}}};
-static float32 slab23[1][1][1] = {{{(float32)122.0}}};
-static float32 slab24[1][1][1] = {{{(float32)123.0}}};
+static float32 slab1[1][1][1]  = {{{0.0F}}};
+static float32 slab2[1][1][1]  = {{{1.0F}}};
+static float32 slab3[1][1][1]  = {{{2.0F}}};
+static float32 slab4[1][1][1]  = {{{3.0F}}};
+static float32 slab5[1][1][1]  = {{{10.0F}}};
+static float32 slab6[1][1][1]  = {{{11.0F}}};
+static float32 slab7[1][1][1]  = {{{12.0F}}};
+static float32 slab8[1][1][1]  = {{{13.0F}}};
+static float32 slab9[1][1][1]  = {{{20.0F}}};
+static float32 slab10[1][1][1] = {{{21.0F}}};
+static float32 slab11[1][1][1] = {{{22.0F}}};
+static float32 slab12[1][1][1] = {{{23.0F}}};
+static float32 slab13[1][1][1] = {{{100.0F}}};
+static float32 slab14[1][1][1] = {{{101.0F}}};
+static float32 slab15[1][1][1] = {{{102.0F}}};
+static float32 slab16[1][1][1] = {{{103.0F}}};
+static float32 slab17[1][1][1] = {{{110.0F}}};
+static float32 slab18[1][1][1] = {{{111.0F}}};
+static float32 slab19[1][1][1] = {{{112.0F}}};
+static float32 slab20[1][1][1] = {{{113.0F}}};
+static float32 slab21[1][1][1] = {{{120.0F}}};
+static float32 slab22[1][1][1] = {{{121.0F}}};
+static float32 slab23[1][1][1] = {{{122.0F}}};
+static float32 slab24[1][1][1] = {{{123.0F}}};
 
 /* data array in memory  */
-static float32 fdata[2][3][4]   = {{{(float32)0.0, (float32)1.0, (float32)2.0, (float32)3.0},
-                                  {(float32)10.0, (float32)11.0, (float32)12.0, (float32)13.0},
-                                  {(float32)20.0, (float32)21.0, (float32)22.0, (float32)23.0}},
-                                 {{(float32)100.0, (float32)101.0, (float32)102.0, (float32)103.0},
-                                  {(float32)110.0, (float32)111.0, (float32)112.0, (float32)113.0},
-                                  {(float32)120.0, (float32)121.0, (float32)122.0, (float32)123.0}}};
+static float32 fdata[2][3][4] = {
+    {{0.0F, 1.0F, 2.0F, 3.0F}, {10.0F, 11.0F, 12.0F, 13.0F}, {20.0F, 21.0F, 22.0F, 23.0F}},
+    {{100.0F, 101.0F, 102.0F, 103.0F}, {110.0F, 111.0F, 112.0F, 113.0F}, {120.0F, 121.0F, 122.0F, 123.0F}}};
 static float64 f64data[2][3][4] = {
     {{0.0, 1.0, 2.0, 3.0}, {10.0, 11.0, 12.0, 13.0}, {20.0, 21.0, 22.0, 23.0}},
     {{100.0, 101.0, 102.0, 103.0}, {110.0, 111.0, 112.0, 113.0}, {120.0, 121.0, 122.0, 123.0}}};
@@ -388,7 +382,7 @@ slabwf32(void)
     /* Get fill value */
     ret = DFSDgetfillvalue((void *)&lfill);
     CHECK(ret, FAIL, "DFSDgetfillvalue");
-    if (lfill != fillf32)
+    if (!H4_FLT_ABS_EQUAL(lfill, fillf32))
         num_err++;
     MESSAGE(10, printf("\n       fill value =: %f \n", (double)lfill););
 
@@ -400,7 +394,7 @@ slabwf32(void)
     for (i = 0; i < d_dims[0]; i++)
         for (j = 0; j < d_dims[1]; j++)
             for (k = 0; k < d_dims[2]; k++) {
-                if (sdata[i][j][k] != fdata[i][j][k])
+                if (!H4_FLT_ABS_EQUAL(sdata[i][j][k], fdata[i][j][k]))
                     num_err++;
                 MESSAGE(10, printf("%f, ", (double)sdata[i][j][k]););
             }
@@ -536,7 +530,7 @@ slabwf64(void)
     /* Get fill value */
     ret = DFSDgetfillvalue((void *)&lfill);
     CHECK(ret, FAIL, "DFSDgetfillvalue");
-    if (lfill != fillf64)
+    if (!H4_DBL_ABS_EQUAL(lfill, fillf64))
         num_err += 1;
     MESSAGE(10, printf("\n       fill value =: %f \n", (double)lfill););
 
@@ -548,7 +542,7 @@ slabwf64(void)
     for (i = 0; i < d_dims[0]; i++)
         for (j = 0; j < d_dims[1]; j++)
             for (k = 0; k < d_dims[2]; k++) {
-                if (sdata[i][j][k] != f64data[i][j][k])
+                if (!H4_DBL_ABS_EQUAL(sdata[i][j][k], f64data[i][j][k]))
                     num_err++;
                 MESSAGE(10, printf("%f, ", (double)sdata[i][j][k]););
             }
@@ -1841,7 +1835,7 @@ slab2w(void)
     int32   ret     = 0;
     int32   num_err = 0;
     float32 sdata[2][3][4]; /* Data array read from from file */
-    float32 lfill = (float32)0.0;
+    float32 lfill = 0.0F;
     intn    trank;
 
     MESSAGE(10, printf("\n slab2w:  Writing the last 2 of 5 slabs to slab1w.hdf \n"););
@@ -1910,7 +1904,7 @@ slab2w(void)
     for (i = 0; i < d_dims[0]; i++)
         for (j = 0; j < d_dims[1]; j++)
             for (k = 0; k < d_dims[2]; k++) {
-                if (sdata[i][j][k] != fdata[i][j][k])
+                if (!H4_FLT_ABS_EQUAL(sdata[i][j][k], fdata[i][j][k]))
                     num_err++;
             }
 
@@ -2210,7 +2204,7 @@ slab3w(void)
     for (i = 0; i < d_dims[0]; i++)
         for (j = 0; j < d_dims[1]; j++)
             for (k = 0; k < d_dims[2]; k++) {
-                if (adata[i][j][k] != fdata[i][j][k])
+                if (!H4_FLT_ABS_EQUAL(adata[i][j][k], fdata[i][j][k]))
                     num_err++;
                 MESSAGE(10, printf("%f, ", (double)adata[i][j][k]););
             }
@@ -2301,7 +2295,7 @@ slab4w(void)
     for (i = 0; i < d_dims[0]; i++)
         for (j = 0; j < d_dims[1]; j++)
             for (k = 0; k < d_dims[2]; k++) {
-                if (bdata[i][j][k] != fdata[i][j][k])
+                if (!H4_FLT_ABS_EQUAL(bdata[i][j][k], fdata[i][j][k]))
                     num_err++;
             }
     if (num_err == 0)

--- a/hdf/test/tutils.h
+++ b/hdf/test/tutils.h
@@ -14,6 +14,9 @@
 #ifndef H4_TUTILS_H
 #define H4_TUTILS_H
 
+#include <float.h>
+#include <math.h>
+
 #include "hdf_priv.h"
 
 /* Define these for use in all the tests */
@@ -206,6 +209,20 @@ extern
         puts(" -SKIP-");                                                                                     \
         fflush(stdout);                                                                                      \
     }
+
+/*
+ * Methods to compare the equality of floating-point values:
+ *
+ *    1. H4_XXX_ABS_EQUAL - check if the difference is smaller than the
+ *       Epsilon value.  The Epsilon values, FLT_EPSILON, DBL_EPSILON,
+ *       and LDBL_EPSILON, are defined by compiler in float.h.
+ *
+ *  HDF5 (from whence these macros came) also includes macros that
+ *  use relative error. Those will be brought over only if needed.
+ */
+#define H4_FLT_ABS_EQUAL(X, Y)  (fabsf((X) - (Y)) < FLT_EPSILON)
+#define H4_DBL_ABS_EQUAL(X, Y)  (fabs((X) - (Y)) < DBL_EPSILON)
+#define H4_LDBL_ABS_EQUAL(X, Y) (fabsl((X) - (Y)) < LDBL_EPSILON)
 
 /* Definition for JPEG tests */
 #define JPEG_FUZZ 1

--- a/hdf/test/tvset.c
+++ b/hdf/test/tvset.c
@@ -736,14 +736,14 @@ read_vset_stuff(void)
     CHECK(status, FAIL, "VSsetfields:vs1");
 
     for (i = 0; i < count; i++)
-        fbuf[i] = (float32)0.0;
+        fbuf[i] = 0.0F;
 
     status = VSread(vs1, (unsigned char *)fbuf, count, FULL_INTERLACE);
     CHECK(status, FAIL, "VSread:vs1");
 
     /* verify */
     for (i = 0; i < count; i++) {
-        if (fbuf[i] != (float32)i) {
+        if (!H4_FLT_ABS_EQUAL(fbuf[i], (float32)i)) {
             num_errs++;
             printf(">>> Float value %d was expecting %d got %f\n", (int)i, (int)i, (double)fbuf[i]);
         }
@@ -930,8 +930,8 @@ read_vset_stuff(void)
     /* verify */
     p = gbuf;
     for (i = 0; i < count; i++) {
-        float32 fl = (float32)0.0;
-        int32   in = (int32)0;
+        float32 fl = 0.0F;
+        int32   in = 0;
 
         memcpy(&fl, p, sizeof(float32));
         p += sizeof(float32);
@@ -943,7 +943,7 @@ read_vset_stuff(void)
             printf(">>> Mixed int value %d was expecting %d got %d\n", (int)i, (int)i, (int)in);
         }
 
-        if (fl != (float32)(i * 2)) {
+        if (!H4_FLT_ABS_EQUAL(fl, (float32)(i * 2))) {
             num_errs++;
             printf(">>> Mixed float value %d was expecting %d got %f\n", (int)i, (int)i, (double)fl);
         }
@@ -1015,9 +1015,9 @@ read_vset_stuff(void)
     c_expected  = 'a';
 
     for (i = 0; i < count; i++) {
-        float32 fl = (float32)0.0;
-        int32   in = (int32)0;
-        char8   c  = (char8)0;
+        float32 fl = 0.0F;
+        int32   in = 0;
+        char8   c  = 0;
 
         /* read and verify characters */
         memcpy(&c, p, sizeof(char8));
@@ -1071,12 +1071,12 @@ read_vset_stuff(void)
         memcpy(&fl, p, sizeof(float32));
         p += sizeof(float32);
 
-        if (fl != fl_expected) {
+        if (!H4_FLT_ABS_EQUAL(fl, fl_expected)) {
             num_errs++;
             printf(">>> Multi-order float value %d was expecting %f got %f\n", (int)i, (double)fl_expected,
                    (double)fl);
         }
-        fl_expected += (float32)0.5;
+        fl_expected += 0.5F;
     }
 
     /*
@@ -1203,7 +1203,6 @@ test_vsdelete(void)
     int32 num_of_elements;
     int16 vdata_buf[NUMBER_OF_ROWS * ORDER];
     int32 v_ref;
-    intn  i;
 
     /* Open the HDF file. */
     fid = Hopen(FNAME0, DFACC_RDWR, 0);
@@ -1226,7 +1225,7 @@ test_vsdelete(void)
     CHECK_VOID(status, FAIL, "VSsetfields:vdata_id");
 
     /* Generate the Vset data. */
-    for (i = 0; i < NUMBER_OF_ROWS * ORDER; i += ORDER) {
+    for (int16 i = 0; i < NUMBER_OF_ROWS * ORDER; i += ORDER) {
         vdata_buf[i]     = i;
         vdata_buf[i + 1] = i + 1;
         vdata_buf[i + 2] = i + 2;
@@ -2213,9 +2212,10 @@ test_getvgroups(void)
 } /* test_getvgroups() */
 
 intn
-check_vgs(int32 id, uintn start_vg, uintn n_vgs, char *ident_text, /* just for debugging, remove when done */
-          uintn   resultcount,                                     /* expected number of vgroups */
-          uint16 *resultarray)                                     /* array containing expected values */
+check_vgs(int32 id, uintn start_vg, uintn n_vgs,
+          const char *ident_text,  /* just for debugging, remove when done */
+          uintn       resultcount, /* expected number of vgroups */
+          uint16     *resultarray)     /* array containing expected values */
 {
     uint16 *refarray = NULL;
     uintn   count    = 0, ii;
@@ -2252,10 +2252,11 @@ check_vgs(int32 id, uintn start_vg, uintn n_vgs, char *ident_text, /* just for d
     return ret_value;
 }
 
-intn
-check_vds(int32 id, uintn start_vd, uintn n_vds, char *ident_text, /* just for debugging, remove when done */
-          uintn   resultcount,                                     /* expected number of vdatas */
-          uint16 *resultarray)                                     /* array containing expected values */
+static int
+check_vds(int32 id, uintn start_vd, uintn n_vds,
+          const char *ident_text,  /* just for debugging, remove when done */
+          uintn       resultcount, /* expected number of vdatas */
+          uint16     *resultarray)     /* array containing expected values */
 {
     uint16 *refarray = NULL;
     uintn   count    = 0, ii;
@@ -2636,21 +2637,21 @@ Tables_External_File.
 static void
 test_extfile(void)
 {
-    int32   fid, vdata1_id, vdata_ref = -1; /* ref number of a vdata, set to -1 to create  */
-    int32   vdata1_ref;
-    int32   offset = -1, length = -1;
-    char    hibuf[2]  = "hi";
-    char    byebuf[3] = "bye";
-    char   *extfile_name;
-    void   *columnPtrs[3];
-    int     bufsize;
-    void   *databuf;
-    intn    name_len = 0;
-    intn    status_n; /* returned status for functions returning an intn  */
-    int32   status;   /* returned status for functions returning an int32 */
-    char8   col1buf[NROWS][2] = {{'A', 'B'}, {'B', 'C'}, {'C', 'D'}, {'D', 'E'}, {'E', 'F'}};
-    uint16  col2buf[NROWS]    = {1, 2, 3, 4, 5};
-    float32 col3buf[NROWS][2] = {{.01, .1}, {.02, .2}, {.03, .3}, {.04, .4}, {.05, .5}};
+    int32      fid, vdata1_id, vdata_ref = -1; /* ref number of a vdata, set to -1 to create  */
+    int32      vdata1_ref;
+    int32      offset = -1, length = -1;
+    const char hibuf[2]  = "hi";
+    const char byebuf[3] = "bye";
+    char      *extfile_name;
+    void      *columnPtrs[3];
+    int        bufsize;
+    void      *databuf;
+    intn       name_len = 0;
+    intn       status_n; /* returned status for functions returning an intn  */
+    int32      status;   /* returned status for functions returning an int32 */
+    char8      col1buf[NROWS][2] = {{'A', 'B'}, {'B', 'C'}, {'C', 'D'}, {'D', 'E'}, {'E', 'F'}};
+    uint16     col2buf[NROWS]    = {1, 2, 3, 4, 5};
+    float32    col3buf[NROWS][2] = {{.01F, .1F}, {.02F, .2F}, {.03F, .3F}, {.04F, .4F}, {.05F, .5F}};
 
     /* Create the HDF file for data used in this test routine */
     fid = Hopen(EXTFILE, DFACC_CREATE, 0);

--- a/mfhdf/nctest/slabs.c
+++ b/mfhdf/nctest/slabs.c
@@ -44,320 +44,316 @@ static void
 val_stuff(nc_type type, void *v, int ii, long val) /* v[ii] = val */
 {
     static char pname[] = "val_stuff";
-#ifdef WRONG_for_PGCC /* This way caused a lot of problems for PGI CC compiler                               \
-                         EIP 2004/12/15 */
-    union gp {
-        char   cp[1];
-        short  sp[1];
-        nclong lp[1];
-        float  fp[1];
-        double dp[1];
-    } * gp;
-
-    gp = (union gp *)v;
     switch (type) {
         case NC_BYTE:
         case NC_CHAR:
-            gp->cp[ii] = (char)val;
+            ((char *)v)[ii] = (char)val;
             break;
         case NC_SHORT:
-            gp->sp[ii] = (short)val;
+            ((short *)v)[ii] = (short)val;
             break;
         case NC_LONG:
-            gp->lp[ii] = (nclong)val;
+            ((nclong *)v)[ii] = (nclong)val;
             break;
         case NC_FLOAT:
-            gp->fp[ii] = (float)val;
+            ((float *)v)[ii] = (float)val;
             break;
         case NC_DOUBLE:
-            gp->dp[ii] = val;
+            ((double *)v)[ii] = (double)val;
             break;
         default:
             error("%s: bad type, test program error", pname);
-#endif /*WRONG_for_PGCC*/
-            switch (type) {
-                case NC_BYTE:
-                case NC_CHAR:
-                    ((char *)v)[ii] = (char)val;
-                    break;
-                case NC_SHORT:
-                    ((short *)v)[ii] = (short)val;
-                    break;
-                case NC_LONG:
-                    ((nclong *)v)[ii] = (nclong)val;
-                    break;
-                case NC_FLOAT:
-                    ((float *)v)[ii] = (float)val;
-                    break;
-                case NC_DOUBLE:
-                    ((double *)v)[ii] = (double)val;
-                    break;
-                default:
-                    error("%s: bad type, test program error", pname);
-            }
+    }
+}
+
+/*
+ * Compare typed array element with specified value, that is return
+ *
+ * 	(v[ii] != val)
+ *
+ * returns 0 if equal, 1 if not equal
+ */
+
+/* type - netcdf type of v, NC_BYTE, ..., NC_DOUBLE */
+/* v    - array of specified type */
+/* ii   - it's v[ii] we want to compare */
+/* val  - value to compare with */
+static int
+val_diff(nc_type type, void *v, int ii, long val) /* v[ii] != val */
+{
+    static char pname[] = "val_diff";
+    switch (type) {
+        case NC_BYTE:
+        case NC_CHAR:
+            return ((char *)v)[ii] != (char)val;
+        case NC_SHORT:
+            return ((short *)v)[ii] != (short)val;
+        case NC_LONG:
+            return ((nclong *)v)[ii] != (nclong)val;
+        case NC_FLOAT:
+            return H4_FLT_ABS_EQUAL(((float *)v)[ii], (float)val);
+        case NC_DOUBLE:
+            return H4_DBL_ABS_EQUAL(((double *)v)[ii], (double)val);
+        default:
+            error("%s: bad type, test program error", pname);
+            return (-1);
+    }
+}
+
+/*
+ * For each type of variable, put a four-dimensional hypercube of values
+ * with a single call to ncvarput.  Then use ncvarget to retrieve a single
+ * interior value, an interior vector of values along each of the four
+ * dimensions, an interior plane of values along each of the six pairs of
+ * dimensions, and an interior cube of values along each of the four
+ * triples of dimensions.  In each case, compare the retrieved values with
+ * the written values.
+ */
+/* cdfid - handle of netcdf open and in data mode */
+int
+test_slabs(int cdfid)
+{
+    int                  nerrs       = 0;
+    static char          pname[]     = "test_slabs";
+    static struct cdfdim dims[NDIMS] = {{"w", WSIZE}, {"x", XSIZE}, {"y", YSIZE}, {"z", ZSIZE}};
+    int                  dimids[NDIMS]; /* dimension ids */
+    long                 corner[NDIMS], edge[NDIMS], point[NDIMS];
+
+    static struct cdfvar va[NVARS] = {
+        /* variables of all types */
+        {"bytevar", NC_BYTE, NDIMS, ___, 0},   {"charvar", NC_CHAR, NDIMS, ___, 0},
+        {"shortvar", NC_SHORT, NDIMS, ___, 0}, {"longvar", NC_LONG, NDIMS, ___, 0},
+        {"floatvar", NC_FLOAT, NDIMS, ___, 0}, {"doublevar", NC_DOUBLE, NDIMS, ___, 0},
+    };
+    void *v;
+
+    int varid[NVARS], iv; /* variable id */
+    int idim, jdim, kdim, ldim;
+    int iw, ix, iy, iz, ii, jj, kk;
+
+    if (ncredef(cdfid) == -1) {
+        error("%s: cdredef failed", pname);
+        ncclose(cdfid);
+        return 1;
     }
 
-    /*
-     * Compare typed array element with specified value, that is return
-     *
-     * 	(v[ii] != val)
-     *
-     * returns 0 if equal, 1 if not equal
-     */
+    /* back in define mode OK, now add dimensions */
 
-    /* type - netcdf type of v, NC_BYTE, ..., NC_DOUBLE */
-    /* v    - array of specified type */
-    /* ii   - it's v[ii] we want to compare */
-    /* val  - value to compare with */
-    static int val_diff(nc_type type, void *v, int ii, long val) /* v[ii] != val */
-    {
-        static char pname[] = "val_diff";
-#ifdef WRONG_for_PGCC /* This way caused a lot of problems for PGI CC compiler                               \
-                         EIP 2004/12/15 */
-        union gp {
-            char   cp[1];
-            short  sp[1];
-            nclong lp[1];
-            float  fp[1];
-            double dp[1];
-        } * gp;
-
-        gp = (union gp *)v;
-        switch (type) {
-            case NC_BYTE:
-            case NC_CHAR:
-                return (gp->cp[ii] != (char)val);
-            case NC_SHORT:
-                return (gp->sp[ii] != (short)val);
-            case NC_LONG:
-                return (gp->lp[ii] != (nclong)val);
-            case NC_FLOAT:
-                return (gp->fp[ii] != (float)val);
-            case NC_DOUBLE:
-                return (gp->dp[ii] != (double)val);
-            default:
-                error("%s: bad type, test program error", pname);
-                return (-1);
-#endif /*WRONG_for_PGCC*/
-                switch (type) {
-                    case NC_BYTE:
-                    case NC_CHAR:
-                        return (((char *)v)[ii] != (char)val);
-                    case NC_SHORT:
-                        return (((short *)v)[ii] != (short)val);
-                    case NC_LONG:
-                        return (((nclong *)v)[ii] != (nclong)val);
-                    case NC_FLOAT:
-                        return (((float *)v)[ii] != (float)val);
-                    case NC_DOUBLE:
-                        return (((double *)v)[ii] != (double)val);
-                    default:
-                        error("%s: bad type, test program error", pname);
-                        return (-1);
-                }
+    for (idim = 0; idim < NDIMS; idim++) {
+        dimids[idim] = ncdimdef(cdfid, dims[idim].name, dims[idim].size);
+        if (dimids[idim] == -1) {
+            error("%s: ncdimdef failed", pname);
+            ncclose(cdfid);
+            return 1;
         }
+        add_dim(test_g, &dims[idim]);
+    }
 
-        /*
-         * For each type of variable, put a four-dimensional hypercube of values
-         * with a single call to ncvarput.  Then use ncvarget to retrieve a single
-         * interior value, an interior vector of values along each of the four
-         * dimensions, an interior plane of values along each of the six pairs of
-         * dimensions, and an interior cube of values along each of the four
-         * triples of dimensions.  In each case, compare the retrieved values with
-         * the written values.
-         */
-        /* cdfid - handle of netcdf open and in data mode */
-        int test_slabs(int cdfid)
-        {
-            int                  nerrs       = 0;
-            static char          pname[]     = "test_slabs";
-            static struct cdfdim dims[NDIMS] = {{"w", WSIZE}, {"x", XSIZE}, {"y", YSIZE}, {"z", ZSIZE}};
-            int                  dimids[NDIMS]; /* dimension ids */
-            long                 corner[NDIMS], edge[NDIMS], point[NDIMS];
+    /* define a multi-dimensional variable of each type */
 
-            static struct cdfvar va[NVARS] = {
-                /* variables of all types */
-                {"bytevar", NC_BYTE, NDIMS, ___, 0},   {"charvar", NC_CHAR, NDIMS, ___, 0},
-                {"shortvar", NC_SHORT, NDIMS, ___, 0}, {"longvar", NC_LONG, NDIMS, ___, 0},
-                {"floatvar", NC_FLOAT, NDIMS, ___, 0}, {"doublevar", NC_DOUBLE, NDIMS, ___, 0},
-            };
-            void *v;
+    for (iv = 0; iv < NVARS; iv++) {
+        va[iv].dims = (int *)emalloc(sizeof(int) * va[iv].ndims);
+        for (idim = 0; idim < va[iv].ndims; idim++)
+            va[iv].dims[idim] = dimids[idim];
+        varid[iv] = ncvardef(cdfid, va[iv].name, va[iv].type, va[iv].ndims, va[iv].dims);
+        if (varid[iv] == -1) {
+            error("%s: ncvardef failed", pname);
+            ncclose(cdfid);
+            return 1;
+        }
+        add_var(test_g, &va[iv]); /* keep in-memory netcdf in sync */
+    }
 
-            int varid[NVARS], iv; /* variable id */
-            int idim, jdim, kdim, ldim;
-            int iw, ix, iy, iz, ii, jj, kk;
+    if (ncendef(cdfid) == -1) {
+        error("%s: ncendef failed", pname);
+        ncclose(cdfid);
+        return 1;
+    }
 
-            if (ncredef(cdfid) == -1) {
-                error("%s: cdredef failed", pname);
-                ncclose(cdfid);
-                return 1;
-            }
+    for (iv = 0; iv < NVARS; iv++) { /* test each type of variable */
 
-            /* back in define mode OK, now add dimensions */
-
-            for (idim = 0; idim < NDIMS; idim++) {
-                dimids[idim] = ncdimdef(cdfid, dims[idim].name, dims[idim].size);
-                if (dimids[idim] == -1) {
-                    error("%s: ncdimdef failed", pname);
-                    ncclose(cdfid);
-                    return 1;
-                }
-                add_dim(test_g, &dims[idim]);
-            }
-
-            /* define a multi-dimensional variable of each type */
-
-            for (iv = 0; iv < NVARS; iv++) {
-                va[iv].dims = (int *)emalloc(sizeof(int) * va[iv].ndims);
-                for (idim = 0; idim < va[iv].ndims; idim++)
-                    va[iv].dims[idim] = dimids[idim];
-                varid[iv] = ncvardef(cdfid, va[iv].name, va[iv].type, va[iv].ndims, va[iv].dims);
-                if (varid[iv] == -1) {
-                    error("%s: ncvardef failed", pname);
-                    ncclose(cdfid);
-                    return 1;
-                }
-                add_var(test_g, &va[iv]); /* keep in-memory netcdf in sync */
-            }
-
-            if (ncendef(cdfid) == -1) {
-                error("%s: ncendef failed", pname);
-                ncclose(cdfid);
-                return 1;
-            }
-
-            for (iv = 0; iv < NVARS; iv++) { /* test each type of variable */
-
-                v = emalloc(WSIZE * XSIZE * YSIZE * ZSIZE * nctypelen(va[iv].type));
-                /* fill it with values using a function of dimension indices */
-                ii = 0;
-                for (iw = 0; iw < WSIZE; iw++) {
-                    corner[0] = iw;
-                    for (ix = 0; ix < XSIZE; ix++) {
-                        corner[1] = ix;
-                        for (iy = 0; iy < YSIZE; iy++) {
-                            corner[2] = iy;
-                            for (iz = 0; iz < ZSIZE; iz++) {
-                                corner[3] = iz;
-                                /* v[ii++] = VF(corner); */
-                                if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR)
-                                    val_stuff(va[iv].type, v, ii, VFC(corner));
-                                else
-                                    val_stuff(va[iv].type, v, ii, VF(corner));
-                                ii++;
-                            }
-                        }
+        v = emalloc(WSIZE * XSIZE * YSIZE * ZSIZE * nctypelen(va[iv].type));
+        /* fill it with values using a function of dimension indices */
+        ii = 0;
+        for (iw = 0; iw < WSIZE; iw++) {
+            corner[0] = iw;
+            for (ix = 0; ix < XSIZE; ix++) {
+                corner[1] = ix;
+                for (iy = 0; iy < YSIZE; iy++) {
+                    corner[2] = iy;
+                    for (iz = 0; iz < ZSIZE; iz++) {
+                        corner[3] = iz;
+                        /* v[ii++] = VF(corner); */
+                        if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR)
+                            val_stuff(va[iv].type, v, ii, VFC(corner));
+                        else
+                            val_stuff(va[iv].type, v, ii, VF(corner));
+                        ii++;
                     }
                 }
+            }
+        }
 
-                for (idim = 0; idim < NDIMS; idim++) {
-                    corner[idim] = 0;
-                    edge[idim]   = dims[idim].size;
-                }
+        for (idim = 0; idim < NDIMS; idim++) {
+            corner[idim] = 0;
+            edge[idim]   = dims[idim].size;
+        }
 
-                /* ncvarput the whole variable */
-                if (ncvarput(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
-                    error("%s: ncvarput failed", pname);
-                    nerrs++;
-                }
+        /* ncvarput the whole variable */
+        if (ncvarput(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
+            error("%s: ncvarput failed", pname);
+            nerrs++;
+        }
 
-                add_data(test_g, varid[iv], corner, edge); /* keep test in sync */
-                /*
-                 * For several combinations of fixed dimensions, get a slab and compare
-                 * values to function values.
-                 */
+        add_data(test_g, varid[iv], corner, edge); /* keep test in sync */
+        /*
+         * For several combinations of fixed dimensions, get a slab and compare
+         * values to function values.
+         */
 
-                /* get an interior point */
-                for (idim = 0; idim < NDIMS; idim++) {
-                    corner[idim] = dims[idim].size / 2;
-                    edge[idim]   = 1;
-                    point[idim]  = corner[idim];
-                }
-                if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
-                    error("%s: ncvarget of one point failed", pname);
-                    nerrs++;
-                }
-                /* if (v[0] != VF(point)) */
+        /* get an interior point */
+        for (idim = 0; idim < NDIMS; idim++) {
+            corner[idim] = dims[idim].size / 2;
+            edge[idim]   = 1;
+            point[idim]  = corner[idim];
+        }
+        if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
+            error("%s: ncvarget of one point failed", pname);
+            nerrs++;
+        }
+        /* if (v[0] != VF(point)) */
+        if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR) {
+
+            if (val_diff(va[iv].type, v, 0, VFC(point))) {
+                error("%s: ncvarget got wrong value for point", pname);
+                nerrs++;
+            }
+        }
+        else {
+            if (val_diff(va[iv].type, v, 0, VF(point))) {
+                error("%s: ncvarget got wrong value for point", pname);
+                nerrs++;
+            }
+        }
+        /*endif NC_BYTE || NC_CHAR */
+
+        /* get an interior vector in each direction */
+        for (idim = 0; idim < NDIMS; idim++) {
+            for (jdim = 0; jdim < NDIMS; jdim++) {
+                corner[jdim] = dims[jdim].size / 2;
+                edge[jdim]   = 1;
+                point[jdim]  = corner[jdim];
+            }
+            corner[idim] = 1; /* get vector along dimension idim */
+            edge[idim]   = dims[idim].size - 2;
+            if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
+                error("%s: ncvarget of vector failed", pname);
+                nerrs++;
+            }
+            for (ii = corner[idim]; ii <= edge[idim]; ii++) {
+                point[idim] = ii;
+                /* if (v[ii-1] != VF(point)) */
                 if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR) {
-
-                    if (val_diff(va[iv].type, v, 0, VFC(point))) {
-                        error("%s: ncvarget got wrong value for point", pname);
+                    if (val_diff(va[iv].type, v, ii - 1, VFC(point))) {
+                        error("%s: ncvarget got wrong value for vector", pname);
                         nerrs++;
                     }
                 }
                 else {
-                    if (val_diff(va[iv].type, v, 0, VF(point))) {
-                        error("%s: ncvarget got wrong value for point", pname);
+                    if (val_diff(va[iv].type, v, ii - 1, VF(point))) {
+                        error("%s: ncvarget got wrong value for vector", pname);
                         nerrs++;
                     }
                 }
-                /*endif NC_BYTE || NC_CHAR */
+            }
+        }
 
-                /* get an interior vector in each direction */
-                for (idim = 0; idim < NDIMS; idim++) {
-                    for (jdim = 0; jdim < NDIMS; jdim++) {
-                        corner[jdim] = dims[jdim].size / 2;
-                        edge[jdim]   = 1;
-                        point[jdim]  = corner[jdim];
-                    }
-                    corner[idim] = 1; /* get vector along dimension idim */
-                    edge[idim]   = dims[idim].size - 2;
-                    if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
-                        error("%s: ncvarget of vector failed", pname);
-                        nerrs++;
-                    }
-                    for (ii = corner[idim]; ii <= edge[idim]; ii++) {
+        /* get an interior plane in each direction */
+        for (idim = 0; idim < NDIMS; idim++) {
+            for (jdim = idim + 1; jdim < NDIMS; jdim++) {
+                for (kdim = 0; kdim < NDIMS; kdim++) { /* reset corners and edges */
+                    corner[kdim] = dims[kdim].size / 2;
+                    edge[kdim]   = 1;
+                    point[kdim]  = corner[kdim];
+                }
+                corner[idim] = 1; /* interior plane along dimensions idim jdim */
+                corner[jdim] = 1;
+                edge[idim]   = dims[idim].size - 2;
+                edge[jdim]   = dims[jdim].size - 2;
+                if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
+                    error("%s: ncvarget of plane failed", pname);
+                    nerrs++;
+                }
+                for (ii = corner[idim]; ii <= edge[idim]; ii++) {
+                    for (jj = corner[jdim]; jj <= edge[jdim]; jj++) {
                         point[idim] = ii;
-                        /* if (v[ii-1] != VF(point)) */
+                        point[jdim] = jj;
+                        /* if (v[(ii-1)*edge[jdim]+jj-1] != VF(point)) { */
                         if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR) {
-                            if (val_diff(va[iv].type, v, ii - 1, VFC(point))) {
-                                error("%s: ncvarget got wrong value for vector", pname);
+                            if (val_diff(va[iv].type, v, (ii - 1) * (int)edge[jdim] + jj - 1, VFC(point))) {
+                                error("%s: ncvarget got wrong value in plane", pname);
+                                error("idim=%d,jdim=%d,ii=%d,jj=%d", idim, jdim, ii, jj);
                                 nerrs++;
                             }
                         }
                         else {
-                            if (val_diff(va[iv].type, v, ii - 1, VF(point))) {
-                                error("%s: ncvarget got wrong value for vector", pname);
+                            if (val_diff(va[iv].type, v, (ii - 1) * (int)edge[jdim] + jj - 1, VF(point))) {
+                                error("%s: ncvarget got wrong value in plane", pname);
+                                error("idim=%d,jdim=%d,ii=%d,jj=%d", idim, jdim, ii, jj);
                                 nerrs++;
                             }
                         }
                     }
                 }
+            }
+        }
 
-                /* get an interior plane in each direction */
-                for (idim = 0; idim < NDIMS; idim++) {
-                    for (jdim = idim + 1; jdim < NDIMS; jdim++) {
-                        for (kdim = 0; kdim < NDIMS; kdim++) { /* reset corners and edges */
-                            corner[kdim] = dims[kdim].size / 2;
-                            edge[kdim]   = 1;
-                            point[kdim]  = corner[kdim];
-                        }
-                        corner[idim] = 1; /* interior plane along dimensions idim jdim */
-                        corner[jdim] = 1;
-                        edge[idim]   = dims[idim].size - 2;
-                        edge[jdim]   = dims[jdim].size - 2;
-                        if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
-                            error("%s: ncvarget of plane failed", pname);
-                            nerrs++;
-                        }
-                        for (ii = corner[idim]; ii <= edge[idim]; ii++) {
-                            for (jj = corner[jdim]; jj <= edge[jdim]; jj++) {
+        /* get an interior cube in each direction */
+        for (idim = 0; idim < NDIMS; idim++) {
+            for (jdim = idim + 1; jdim < NDIMS; jdim++) {
+                for (kdim = jdim + 1; kdim < NDIMS; kdim++) {
+                    for (ldim = 0; ldim < NDIMS; ldim++) { /* reset corners, edges */
+                        corner[ldim] = dims[ldim].size / 2;
+                        edge[ldim]   = 1;
+                        point[ldim]  = corner[ldim];
+                    }
+                    corner[idim] = 1; /* intr. cube along idim jdim kdim */
+                    corner[jdim] = 1;
+                    corner[kdim] = 1;
+                    edge[idim]   = dims[idim].size - 2;
+                    edge[jdim]   = dims[jdim].size - 2;
+                    edge[kdim]   = dims[kdim].size - 2;
+                    if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
+                        error("%s: ncvarget of cube failed", pname);
+                        nerrs++;
+                    }
+                    for (ii = corner[idim]; ii <= edge[idim]; ii++) {
+                        for (jj = corner[jdim]; jj <= edge[jdim]; jj++) {
+                            for (kk = corner[kdim]; kk <= edge[kdim]; kk++) {
                                 point[idim] = ii;
                                 point[jdim] = jj;
-                                /* if (v[(ii-1)*edge[jdim]+jj-1] != VF(point)) { */
+                                point[kdim] = kk;
+                                /* if (v[((ii-1)*edge[jdim]+jj-1)*
+                                   edge[kdim]+kk-1] != VF(point)) { */
                                 if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR) {
-                                    if (val_diff(va[iv].type, v, (ii - 1) * (int)edge[jdim] + jj - 1,
+                                    if (val_diff(va[iv].type, v,
+                                                 ((ii - 1) * (int)edge[jdim] + jj - 1) * (int)edge[kdim] +
+                                                     kk - 1,
                                                  VFC(point))) {
-                                        error("%s: ncvarget got wrong value in plane", pname);
-                                        error("idim=%d,jdim=%d,ii=%d,jj=%d", idim, jdim, ii, jj);
+                                        error("%s: ncvarget got wrong value in cube", pname);
+                                        error("idim=%d,jdim=%d,kdim=%d,ii=%d,jj=%d,kk=%d", idim, jdim, kdim,
+                                              ii, jj, kk);
                                         nerrs++;
                                     }
                                 }
                                 else {
-                                    if (val_diff(va[iv].type, v, (ii - 1) * (int)edge[jdim] + jj - 1,
+                                    if (val_diff(va[iv].type, v,
+                                                 ((ii - 1) * (int)edge[jdim] + jj - 1) * (int)edge[kdim] +
+                                                     kk - 1,
                                                  VF(point))) {
-                                        error("%s: ncvarget got wrong value in plane", pname);
-                                        error("idim=%d,jdim=%d,ii=%d,jj=%d", idim, jdim, ii, jj);
+                                        error("%s: ncvarget got wrong value in cube", pname);
+                                        error("idim=%d,jdim=%d,kdim=%d,ii=%d,jj=%d,kk=%d", idim, jdim, kdim,
+                                              ii, jj, kk);
                                         nerrs++;
                                     }
                                 }
@@ -365,65 +361,9 @@ val_stuff(nc_type type, void *v, int ii, long val) /* v[ii] = val */
                         }
                     }
                 }
-
-                /* get an interior cube in each direction */
-                for (idim = 0; idim < NDIMS; idim++) {
-                    for (jdim = idim + 1; jdim < NDIMS; jdim++) {
-                        for (kdim = jdim + 1; kdim < NDIMS; kdim++) {
-                            for (ldim = 0; ldim < NDIMS; ldim++) { /* reset corners, edges */
-                                corner[ldim] = dims[ldim].size / 2;
-                                edge[ldim]   = 1;
-                                point[ldim]  = corner[ldim];
-                            }
-                            corner[idim] = 1; /* intr. cube along idim jdim kdim */
-                            corner[jdim] = 1;
-                            corner[kdim] = 1;
-                            edge[idim]   = dims[idim].size - 2;
-                            edge[jdim]   = dims[jdim].size - 2;
-                            edge[kdim]   = dims[kdim].size - 2;
-                            if (ncvarget(cdfid, varid[iv], corner, edge, (void *)v) == -1) {
-                                error("%s: ncvarget of cube failed", pname);
-                                nerrs++;
-                            }
-                            for (ii = corner[idim]; ii <= edge[idim]; ii++) {
-                                for (jj = corner[jdim]; jj <= edge[jdim]; jj++) {
-                                    for (kk = corner[kdim]; kk <= edge[kdim]; kk++) {
-                                        point[idim] = ii;
-                                        point[jdim] = jj;
-                                        point[kdim] = kk;
-                                        /* if (v[((ii-1)*edge[jdim]+jj-1)*
-                                           edge[kdim]+kk-1] != VF(point)) { */
-                                        if (va[iv].type == NC_BYTE || va[iv].type == NC_CHAR) {
-                                            if (val_diff(va[iv].type, v,
-                                                         ((ii - 1) * (int)edge[jdim] + jj - 1) *
-                                                                 (int)edge[kdim] +
-                                                             kk - 1,
-                                                         VFC(point))) {
-                                                error("%s: ncvarget got wrong value in cube", pname);
-                                                error("idim=%d,jdim=%d,kdim=%d,ii=%d,jj=%d,kk=%d", idim, jdim,
-                                                      kdim, ii, jj, kk);
-                                                nerrs++;
-                                            }
-                                        }
-                                        else {
-                                            if (val_diff(va[iv].type, v,
-                                                         ((ii - 1) * (int)edge[jdim] + jj - 1) *
-                                                                 (int)edge[kdim] +
-                                                             kk - 1,
-                                                         VF(point))) {
-                                                error("%s: ncvarget got wrong value in cube", pname);
-                                                error("idim=%d,jdim=%d,kdim=%d,ii=%d,jj=%d,kk=%d", idim, jdim,
-                                                      kdim, ii, jj, kk);
-                                                nerrs++;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                free(v);
             }
-            return nerrs;
         }
+        free(v);
+    }
+    return nerrs;
+}

--- a/mfhdf/nctest/testcdf.h
+++ b/mfhdf/nctest/testcdf.h
@@ -13,8 +13,12 @@
  * them in sync.
  */
 
+#include <float.h>
+#include <math.h>
 #include <stdlib.h>
+
 #include "mfhdf.h"
+
 #define ___      0              /* marker for structure place-holder */
 #define BAD_TYPE NC_UNSPECIFIED /* must be distinct from valid types */
 
@@ -56,5 +60,19 @@ struct netcdf {
 
 /* In-memory netcdf structure, kept in sync with disk netcdf */
 extern struct netcdf *test_g;
+
+/*
+ * Methods to compare the equality of floating-point values:
+ *
+ *    1. H4_XXX_ABS_EQUAL - check if the difference is smaller than the
+ *       Epsilon value.  The Epsilon values, FLT_EPSILON, DBL_EPSILON,
+ *       and LDBL_EPSILON, are defined by compiler in float.h.
+ *
+ *  HDF5 (from whence these macros came) also includes macros that
+ *  use relative error. Those will be brought over only if needed.
+ */
+#define H4_FLT_ABS_EQUAL(X, Y)  (fabsf((X) - (Y)) < FLT_EPSILON)
+#define H4_DBL_ABS_EQUAL(X, Y)  (fabs((X) - (Y)) < DBL_EPSILON)
+#define H4_LDBL_ABS_EQUAL(X, Y) (fabsl((X) - (Y)) < LDBL_EPSILON)
 
 #endif /* NCTEST_TESTCDF_H */

--- a/mfhdf/nctest/val.c
+++ b/mfhdf/nctest/val.c
@@ -172,7 +172,7 @@ val_cmp(nc_type type, long len, void *v1, void *v2)
             gp.fp = (float *)v1;
             hp.fp = (float *)v2;
             for (iel = 0; iel < len; iel++) {
-                if (*gp.fp != *hp.fp)
+                if (!H4_FLT_ABS_EQUAL(*gp.fp, *hp.fp))
                     return (iel + 1);
                 gp.fp++;
                 hp.fp++;
@@ -182,7 +182,7 @@ val_cmp(nc_type type, long len, void *v1, void *v2)
             gp.dp = (double *)v1;
             hp.dp = (double *)v2;
             for (iel = 0; iel < len; iel++) {
-                if (*gp.dp != *hp.dp)
+                if (!H4_DBL_ABS_EQUAL(*gp.dp, *hp.dp))
                     return (iel + 1);
                 gp.dp++;
                 hp.dp++;

--- a/mfhdf/nctest/varget_unlim.c
+++ b/mfhdf/nctest/varget_unlim.c
@@ -108,7 +108,7 @@ test_ncvarget_unlim(char *basefile)
 
     for (i = 0; i < 2; i++) {
         for (j = 0; j < 3; j++) {
-            if (a[i][j] != a_val[i][j]) {
+            if (!H4_FLT_ABS_EQUAL(a[i][j], a_val[i][j])) {
                 nerrs++;
                 printf(" Wrong value of variable a at index %d,%d\n", i, j);
             }

--- a/mfhdf/nctest/vartests.c
+++ b/mfhdf/nctest/vartests.c
@@ -342,14 +342,14 @@ test_varputget1(int cdfid)
                     }
                     break;
                 case NC_FLOAT:
-                    if (elm[ie].val.fl != flval) {
+                    if (!H4_FLT_ABS_EQUAL(elm[ie].val.fl, flval)) {
                         error("%s: ncvarget1 returned float %g, expected %g", pname, (double)flval,
                               (double)elm[ie].val.fl);
                         nerrs++;
                     }
                     break;
                 case NC_DOUBLE:
-                    if (elm[ie].val.db != dbval) {
+                    if (!H4_DBL_ABS_EQUAL(elm[ie].val.db, dbval)) {
                         error("%s: ncvarget1 returned double %g, expected %g", pname, dbval, elm[ie].val.db);
                         nerrs++;
                     }

--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -466,7 +466,7 @@ main(void)
         num_errs++;
     }
 
-    for (int i = 0; i < 50; i++)
+    for (int16 i = 0; i < 50; i++)
         sdata[i] = i;
 
     /* Write data to dataset 'DataSetBeta' in file 'test2.hdf' */
@@ -484,23 +484,23 @@ main(void)
     CHECK(status, FAIL, "SDreaddata");
 
     /* verify the data values retrieved from 'DataSetAlpha' */
-    if (data[0] != -17.5F) {
+    if (!H4_FLT_ABS_EQUAL(data[0], -17.5F)) {
         fprintf(stderr, "Wrong value returned loc 0: %f\n", (double)data[0]);
         num_errs++;
     }
-    if (data[3] != -17.5F) {
+    if (!H4_FLT_ABS_EQUAL(data[3], -17.5F)) {
         fprintf(stderr, "Wrong value returned loc 3: %f\n", (double)data[3]);
         num_errs++;
     }
-    if (data[5] != 1.0F) {
+    if (!H4_FLT_ABS_EQUAL(data[5], 1.0F)) {
         fprintf(stderr, "Wrong value returned loc 5: %f\n", (double)data[5]);
         num_errs++;
     }
-    if (data[6] != -17.5F) {
+    if (!H4_FLT_ABS_EQUAL(data[6], -17.5F)) {
         fprintf(stderr, "Wrong value returned loc 6: %f\n", (double)data[6]);
         num_errs++;
     }
-    if (data[8] != 4.0F) {
+    if (!H4_FLT_ABS_EQUAL(data[8], 4.0F)) {
         fprintf(stderr, "Wrong value returned loc 8: %f\n", (double)data[8]);
         num_errs++;
     }
@@ -544,22 +544,22 @@ main(void)
     CHECK(status, FAIL, "SDgetcal");
 
     /* Verify calibration data for data set 'DataSetGamma' */
-    if (cal != 1.0) {
+    if (!H4_DBL_ABS_EQUAL(cal, 1.0)) {
         fprintf(stderr, "Wrong calibration info\n");
         num_errs++;
     }
 
-    if (cale != 5.0) {
+    if (!H4_DBL_ABS_EQUAL(cale, 5.0)) {
         fprintf(stderr, "Wrong calibration info\n");
         num_errs++;
     }
 
-    if (ioff != 3.0) {
+    if (!H4_DBL_ABS_EQUAL(ioff, 3.0)) {
         fprintf(stderr, "Wrong calibration info\n");
         num_errs++;
     }
 
-    if (ioffe != 2.5) {
+    if (!H4_DBL_ABS_EQUAL(ioffe, 2.5)) {
         fprintf(stderr, "Wrong calibration info\n");
         num_errs++;
     }

--- a/mfhdf/test/hdftest.h
+++ b/mfhdf/test/hdftest.h
@@ -14,10 +14,11 @@
 #ifndef HDFTEST_H
 #define HDFTEST_H
 
+#include <float.h>
+#include <math.h>
 #include <stdio.h>
 
-/*
- * The name of the test is printed by saying TESTING("something") which will
+/* The name of the test is printed by saying TESTING("something") which will
  * result in the string `Testing something' being flushed to standard output.
  * If a test passes, fails, or is skipped then the PASSED(), H4_FAILED(), or
  * SKIPPED() macro should be called.  After H4_FAILED(), the caller
@@ -98,6 +99,20 @@
             exit(1);                                                                                         \
         }                                                                                                    \
     }
+
+/*
+ * Methods to compare the equality of floating-point values:
+ *
+ *    1. H4_XXX_ABS_EQUAL - check if the difference is smaller than the
+ *       Epsilon value.  The Epsilon values, FLT_EPSILON, DBL_EPSILON,
+ *       and LDBL_EPSILON, are defined by compiler in float.h.
+ *
+ *  HDF5 (from whence these macros came) also includes macros that
+ *  use relative error. Those will be brought over only if needed.
+ */
+#define H4_FLT_ABS_EQUAL(X, Y)  (fabsf((X) - (Y)) < FLT_EPSILON)
+#define H4_DBL_ABS_EQUAL(X, Y)  (fabs((X) - (Y)) < DBL_EPSILON)
+#define H4_LDBL_ABS_EQUAL(X, Y) (fabsl((X) - (Y)) < LDBL_EPSILON)
 
 /*************************** Utility Functions ***************************/
 

--- a/mfhdf/test/tchunk.c
+++ b/mfhdf/test/tchunk.c
@@ -431,7 +431,7 @@ test3:
     for (i = 0; i < d_dims[0]; i++) {
         for (j = 0; j < d_dims[1]; j++) {
             for (k = 0; k < d_dims[2]; k++) {
-                if (inbuf_f32[i][j][k] != f32_data[i][j][k]) {
+                if (!H4_FLT_ABS_EQUAL(inbuf_f32[i][j][k], f32_data[i][j][k])) {
                     fprintf(stderr, "Chunk Test 3. inbuf_f32[%d][%d][%d]=%f,", i, j, k,
                             (double)inbuf_f32[i][j][k]);
                     fprintf(stderr, "f32_data[%d][%d][%d]=%f,", i, j, k, (double)f32_data[i][j][k]);

--- a/mfhdf/test/tcoordvar.c
+++ b/mfhdf/test/tcoordvar.c
@@ -86,7 +86,7 @@
 static intn
 test_dim1_SDS1(void)
 {
-    float32        sds1_data[] = {0.1, 2.3, 4.5, 6.7, 8.9};
+    float32        sds1_data[] = {0.1F, 2.3F, 4.5F, 6.7F, 8.9F};
     float32        out_data[5];
     int32          dimsize[1];
     int32          sds_id, file_id, dim_id;
@@ -229,7 +229,7 @@ test_dim1_SDS1(void)
     CHECK(status, FAIL, "SDreaddata");
 
     for (idx1 = 0; idx1 < dimsize[0]; idx1++)
-        if (out_data[idx1] != sds1_data[idx1]) {
+        if (!H4_FLT_ABS_EQUAL(out_data[idx1], sds1_data[idx1])) {
             fprintf(stderr, "Read value (%f) differs from written (%f) at [%d]\n", (double)out_data[idx1],
                     (double)sds1_data[idx1], idx1);
             num_errs++;
@@ -283,7 +283,7 @@ static intn
 test_dim1_SDS2(void)
 {
     char    sds_name[20];
-    float32 sds2_data[2][3] = {{0.1, 2.3, 4.5}, {4.5, 6.7, 8.9}};
+    float32 sds2_data[2][3] = {{0.1F, 2.3F, 4.5F}, {4.5F, 6.7F, 8.9F}};
     int32   dimsize[1], dimsize2[2];
     int32   sds1_id, sds2_id, file_id, dim_id, index;
     int32   start2[2] = {0, 0}, stride2[2] = {1, 1};
@@ -398,7 +398,7 @@ test_dim1_SDS2(void)
 
     for (idx1 = 0; idx1 < dimsize2[0]; idx1++)
         for (idx2 = 0; idx2 < dimsize2[1]; idx2++) {
-            if (out_data2[idx1][idx2] != sds2_data[idx1][idx2]) {
+            if (!H4_FLT_ABS_EQUAL(out_data2[idx1][idx2], sds2_data[idx1][idx2])) {
                 fprintf(stderr, "Read value (%f) differs from written (%f) at [%d][%d]\n",
                         (double)out_data2[idx1][idx2], (double)sds2_data[idx1][idx2], idx1, idx2);
                 num_errs++;

--- a/mfhdf/test/temptySDSs.c
+++ b/mfhdf/test/temptySDSs.c
@@ -40,10 +40,10 @@
 /* Utility routine that selects that named SDS, then calls SDcheckempty
  * and verifies the returned values. */
 static void
-check_empty_SDS(int32 fid,          /* file id */
-                char *sds_name,     /* name of the inquired SDS */
-                int32 verify_value, /* expected value of 'emptySDS' from SDcheckempty */
-                int  *ret_num_errs /* current number of errors */)
+check_empty_SDS(int32       fid,          /* file id */
+                const char *sds_name,     /* name of the inquired SDS */
+                int32       verify_value, /* expected value of 'emptySDS' from SDcheckempty */
+                int        *ret_num_errs /* current number of errors */)
 {
     int32 sds_id, sds_index, status_32;
     intn  status, emptySDS;
@@ -76,10 +76,10 @@ check_empty_SDS(int32 fid,          /* file id */
  * verify the returned values.  The routine also verifies that SDgetchunkinfo
  * did not fail when the file is opened as read-only (bug HDFFR-171) */
 static void
-check_getchunkinfo(int32 fid,          /* file id */
-                   char *sds_name,     /* name of the inquired SDS */
-                   int32 verify_value, /* expected value of 'flags' from SDgetchunkinfo */
-                   int  *ret_num_errs /* current number of errors */)
+check_getchunkinfo(int32       fid,          /* file id */
+                   const char *sds_name,     /* name of the inquired SDS */
+                   int32       verify_value, /* expected value of 'flags' from SDgetchunkinfo */
+                   int        *ret_num_errs /* current number of errors */)
 {
     int32         sds_id, sds_index;
     HDF_CHUNK_DEF c_def_out; /* Chunking definitions */

--- a/mfhdf/test/tszip.c
+++ b/mfhdf/test/tszip.c
@@ -402,16 +402,16 @@ test_szip_SDSfl32bit()
     char      name[H4_MAX_NC_NAME];
     comp_info c_info;
     int32     start[2], edges[2];
-    float32   fill_value = 0; /* Fill value */
+    float32   fill_value = 0.0F; /* Fill value */
     int       i, j;
     int       num_errs = 0; /* number of errors so far */
     float32   out_data[LENGTH][WIDTH];
     float32   in_data[LENGTH][WIDTH] = {
-        {100.0, 100.0, 200.0, 200.0, 300.0, 400.0}, {100.0, 100.0, 200.0, 200.0, 300.0, 400.0},
-        {100.0, 100.0, 200.0, 200.0, 300.0, 400.0}, {300.0, 300.0, 0.0, 400.0, 300.0, 400.0},
-        {300.0, 300.0, 0.0, 400.0, 300.0, 400.0},   {300.0, 300.0, 0.0, 400.0, 300.0, 400.0},
-        {0.0, 0.0, 600.0, 600.0, 300.0, 400.0},     {500.0, 500.0, 600.0, 600.0, 300.0, 400.0},
-        {0.0, 0.0, 600.0, 600.0, 300.0, 400.0}};
+        {100.0F, 100.0F, 200.0F, 200.0F, 300.0F, 400.0F}, {100.0F, 100.0F, 200.0F, 200.0F, 300.0F, 400.0F},
+        {100.0F, 100.0F, 200.0F, 200.0F, 300.0F, 400.0F}, {300.0F, 300.0F, 0.0F, 400.0F, 300.0F, 400.0F},
+        {300.0F, 300.0F, 0.0F, 400.0F, 300.0F, 400.0F},   {300.0F, 300.0F, 0.0F, 400.0F, 300.0F, 400.0F},
+        {0.0F, 0.0F, 600.0F, 600.0F, 300.0F, 400.0F},     {500.0F, 500.0F, 600.0F, 600.0F, 300.0F, 400.0F},
+        {0.0F, 0.0F, 600.0F, 600.0F, 300.0F, 400.0F}};
 
     /********************* End of variable declaration ***********************/
 
@@ -490,7 +490,7 @@ test_szip_SDSfl32bit()
     /* Compare read data against input data */
     for (j = 0; j < LENGTH; j++) {
         for (i = 0; i < WIDTH; i++)
-            if (out_data[j][i] != in_data[j][i]) {
+            if (!H4_FLT_ABS_EQUAL(out_data[j][i], in_data[j][i])) {
                 fprintf(stderr, "Bogus val in loc [%d][%d] in compressed dset, want %ld got %ld\n", j, i,
                         (long)in_data[j][i], (long)out_data[j][i]);
                 num_errs++;
@@ -608,7 +608,7 @@ test_szip_SDSfl64bit()
     /* Compare read data against input data */
     for (j = 0; j < LENGTH; j++) {
         for (i = 0; i < WIDTH; i++)
-            if (out_data[j][i] != in_data[j][i]) {
+            if (!H4_DBL_ABS_EQUAL(out_data[j][i], in_data[j][i])) {
                 fprintf(stderr, "Bogus val in loc [%d][%d] in compressed dset, want %ld got %ld\n", j, i,
                         (long)in_data[j][i], (long)out_data[j][i]);
                 num_errs++;


### PR DESCRIPTION
Brought over the floating point compare macros from the HDF5 test library and applied them to HDF4's tests, fixing most warnings about comparing floating-point numbers.