### PR TITLE
Address comments in HCget_config_info()

### DIFF
--- a/hdf/src/cnone.c
+++ b/hdf/src/cnone.c
@@ -14,9 +14,6 @@
 /*
    cnone.c - HDF none encoding I/O routines
 
-   These routines are only included for completeness and are not
-   actually expected to be used.
-
    None of these routines are designed to be called by other users except
    for the modeling layer of the compression routines.
  */
@@ -43,7 +40,7 @@ static int32 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode);
 
 /*--------------------------------------------------------------------------
  NAME
-    HCIcnone_staccess -- Start accessing a RLE compressed data element.
+    HCIcnone_staccess -- Start accessing an uncompressed data element.
 
  USAGE
     int32 HCIcnone_staccess(access_rec, access)
@@ -55,11 +52,6 @@ static int32 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode);
 
  DESCRIPTION
     Common code called by HCIcnone_stread and HCIcnone_stwrite
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 static int32
 HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode)
@@ -93,11 +85,6 @@ HCIcnone_staccess(accrec_t *access_rec, int16 acc_mode)
 
  DESCRIPTION
     Start read access on a compressed data element using no compression.
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 int32
 HCPcnone_stread(accrec_t *access_rec)
@@ -122,11 +109,6 @@ HCPcnone_stread(accrec_t *access_rec)
 
  DESCRIPTION
     Start write access on a compressed data element using no compression.
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 int32
 HCPcnone_stwrite(accrec_t *access_rec)
@@ -156,11 +138,6 @@ HCPcnone_stwrite(accrec_t *access_rec)
     calculations have been taken care of at a higher level, it is an
     un-used parameter.  The 'offset' is used as an absolute offset
     because of this.
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 int32
 HCPcnone_seek(accrec_t *access_rec, int32 offset, int origin)
@@ -189,12 +166,7 @@ HCPcnone_seek(accrec_t *access_rec, int32 offset, int origin)
     Returns the number of bytes read or FAIL
 
  DESCRIPTION
-    Read in a number of bytes from a RLE compressed data element.
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
+    Read in a number of bytes from an uncompressed data element.
 --------------------------------------------------------------------------*/
 int32
 HCPcnone_read(accrec_t *access_rec, int32 length, void *data)
@@ -224,11 +196,6 @@ HCPcnone_read(accrec_t *access_rec, int32 length, void *data)
 
  DESCRIPTION
     Write out a number of bytes to a data element (w/ no compression).
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 int32
 HCPcnone_write(accrec_t *access_rec, int32 length, const void *data)
@@ -266,11 +233,6 @@ HCPcnone_write(accrec_t *access_rec, int32 length, const void *data)
  DESCRIPTION
     Inquire information about the access record and data element.
     [Currently a NOP].
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 int32
 HCPcnone_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pref, int32 *plength,
@@ -302,11 +264,6 @@ HCPcnone_inquire(accrec_t *access_rec, int32 *pfile_id, uint16 *ptag, uint16 *pr
 
  DESCRIPTION
     Close the compressed data element and free modelling info.
-
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 intn
 HCPcnone_endaccess(accrec_t *access_rec)

--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -1387,27 +1387,17 @@ HCget_config_info(comp_coder_t coder_type, /* IN: compression type */
 {
 
     *compression_config_info = 0;
+
     switch (coder_type) {
         case COMP_CODE_IMCOMP: /* IMCOMP no longer supported */
             *compression_config_info = 0;
             break;
-        /* This block doesn't look intentional, for there is no "break;"
-           before case COMP_CODE_RLE:, which means *compression_config_info
-           was reassigned to something else even though it is "case
-           COMP_CODE_NONE:"  When I added "break;" for "case COMP_CODE_NONE:",             some tests failed.
-           It needs to be checked out.-BMR, Jul 16, 2012*/
-        case COMP_CODE_NONE: /* "none" (i.e. no) encoding */
-            *compression_config_info = 0;
+        case COMP_CODE_NONE:    /* "none" (i.e. no) encoding (still uses callbacks) */
         case COMP_CODE_RLE:     /* Run-length encoding */
         case COMP_CODE_NBIT:    /* N-bit encoding */
         case COMP_CODE_SKPHUFF: /* Skipping Huffman encoding */
-            *compression_config_info = COMP_DECODER_ENABLED | COMP_ENCODER_ENABLED;
-            break;
-
-        case COMP_CODE_JPEG: /* jpeg may be optional */
-            *compression_config_info = COMP_DECODER_ENABLED | COMP_ENCODER_ENABLED;
-            break;
-        case COMP_CODE_DEFLATE: /* gzip 'deflate' encoding, maybe optional */
+        case COMP_CODE_JPEG:    /* jpeg compression */
+        case COMP_CODE_DEFLATE: /* gzip 'deflate' encoding */
             *compression_config_info = COMP_DECODER_ENABLED | COMP_ENCODER_ENABLED;
             break;
 


### PR DESCRIPTION
There was some confusion about the proper behavior of COMP_CODE_NONE and the fallthrough behavior of a switch statement. The correct behavior is to set the encoder and decoder, even for 'no compression' since the 'none' callbacks will be used.