### PR TITLE
Fixed invalid URLs

### DIFF
--- a/HDF4Examples/JAVA/exAN/h4jex_AN_create_annotation.java
+++ b/HDF4Examples/JAVA/exAN/h4jex_AN_create_annotation.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exGR/h4jex_GR_create_and_write_image.java
+++ b/HDF4Examples/JAVA/exGR/h4jex_GR_create_and_write_image.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exJ/HDF4DatasetCreate.java
+++ b/HDF4Examples/JAVA/exJ/HDF4DatasetCreate.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exJ/HDF4FileCreate.java
+++ b/HDF4Examples/JAVA/exJ/HDF4FileCreate.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exJ/HDF4GroupCreate.java
+++ b/HDF4Examples/JAVA/exJ/HDF4GroupCreate.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exJ/VDReadFromVdata.java
+++ b/HDF4Examples/JAVA/exJ/VDReadFromVdata.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exJ/VDWriteToVdata.java
+++ b/HDF4Examples/JAVA/exJ/VDWriteToVdata.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exSD/h4jex_SD_unlimited_sds.java
+++ b/HDF4Examples/JAVA/exSD/h4jex_SD_unlimited_sds.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/HDF4Examples/JAVA/exVD/h4jex_VD_create_onefield_vdatas.java
+++ b/HDF4Examples/JAVA/exVD/h4jex_VD_create_onefield_vdatas.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import hdf.hdflib.HDFConstants;

--- a/bin/cmakehdf4
+++ b/bin/cmakehdf4
@@ -212,7 +212,7 @@ set (SITE_BUILDNAME_SUFFIX "cmakehdf4")
 
 # -- URL set for internal check, default is to not update
 set (LOCAL_SKIP_UPDATE TRUE)
-set (REPOSITORY_URL "http://svn.hdfgroup.uiuc.edu/hdf4/trunk")
+set (REPOSITORY_URL "https://github.com/HDFGroup/hdf4")
 # -- Standard build options
 set (ADD_BUILD_OPTIONS "-DCMAKE_INSTALL_PREFIX:PATH=${CTEST_BINARY_DIRECTORY} -DHDF4_ALLOW_EXTERNAL_SUPPORT:STRING=\"SVN\" -DHDF4_PACKAGE_EXTLIBS:BOOL=ON")
 

--- a/config/cmake/README.txt.cmake.in
+++ b/config/cmake/README.txt.cmake.in
@@ -75,6 +75,6 @@ For more information see USING_CMake_Examples.txt in the install folder.
 ===========================================================================
 
 Documentation for this release can be found at the following URL:
-    https://portal.hdfgroup.org/display/support
+    https://portal.hdfgroup.org/documentation/index.html#hdf4
 
 Bugs should be reported to help@hdfgroup.org.

--- a/java/src/hdf/hdflib/HDFChunkInfo.java
+++ b/java/src/hdf/hdflib/HDFChunkInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFCompInfo.java
+++ b/java/src/hdf/hdflib/HDFCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFConstants.java
+++ b/java/src/hdf/hdflib/HDFConstants.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFDeflateCompInfo.java
+++ b/java/src/hdf/hdflib/HDFDeflateCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFException.java
+++ b/java/src/hdf/hdflib/HDFException.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFIMCOMPCompInfo.java
+++ b/java/src/hdf/hdflib/HDFIMCOMPCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFJPEGCompInfo.java
+++ b/java/src/hdf/hdflib/HDFJPEGCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFJavaException.java
+++ b/java/src/hdf/hdflib/HDFJavaException.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFLibrary.java
+++ b/java/src/hdf/hdflib/HDFLibrary.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFLibraryException.java
+++ b/java/src/hdf/hdflib/HDFLibraryException.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFNBITChunkInfo.java
+++ b/java/src/hdf/hdflib/HDFNBITChunkInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFNBITCompInfo.java
+++ b/java/src/hdf/hdflib/HDFNBITCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFNewCompInfo.java
+++ b/java/src/hdf/hdflib/HDFNewCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFNotImplementedException.java
+++ b/java/src/hdf/hdflib/HDFNotImplementedException.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFOldCompInfo.java
+++ b/java/src/hdf/hdflib/HDFOldCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFOldRLECompInfo.java
+++ b/java/src/hdf/hdflib/HDFOldRLECompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFRLECompInfo.java
+++ b/java/src/hdf/hdflib/HDFRLECompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFSKPHUFFCompInfo.java
+++ b/java/src/hdf/hdflib/HDFSKPHUFFCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/hdf/hdflib/HDFSZIPCompInfo.java
+++ b/java/src/hdf/hdflib/HDFSZIPCompInfo.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  ****************************************************************************/
 
 package hdf.hdflib;

--- a/java/src/jni/h4jni.h
+++ b/java/src/jni/h4jni.h
@@ -13,7 +13,7 @@
 
 /*
  *  For details of the HDF libraries, see the HDF Documentation at:
- *    https://portal.hdfgroup.org/display/HDF4/HDF4
+ *    https://portal.hdfgroup.org/hdf4/
  *
  */
 

--- a/java/test/TestAll.java
+++ b/java/test/TestAll.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4.java
+++ b/java/test/TestH4.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4ANparams.java
+++ b/java/test/TestH4ANparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4DFPparams.java
+++ b/java/test/TestH4DFPparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4DFRparams.java
+++ b/java/test/TestH4DFRparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4DFparams.java
+++ b/java/test/TestH4DFparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4GRparams.java
+++ b/java/test/TestH4GRparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4HCparams.java
+++ b/java/test/TestH4HCparams.java
@@ -7,8 +7,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4SDparams.java
+++ b/java/test/TestH4SDparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4VSparams.java
+++ b/java/test/TestH4VSparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/TestH4Vparams.java
+++ b/java/test/TestH4Vparams.java
@@ -6,8 +6,8 @@
  * notice, including terms governing use, modification, and redistribution,  *
  * is contained in the file, COPYING.  COPYING can be found at the root of   *
  * the source code distribution tree. You can also access it online  at      *
- * http://www.hdfgroup.org/products/licenses.html.  If you do not have       *
- * access to the file, you may request a copy from help@hdfgroup.org.        *
+ * https://www.hdfgroup.org/licenses.  If you do not have access to the      *
+ * file, you may request a copy from help@hdfgroup.org.                      *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package test;

--- a/java/test/junit.sh.in
+++ b/java/test/junit.sh.in
@@ -7,9 +7,9 @@
 # This file is part of HDF Java Products. The full HDF Java copyright
 # notice, including terms governing use, modification, and redistribution,
 # is contained in the file, COPYING.  COPYING can be found at the root of
-# the source code distribution tree. You can also access it online  at
-# http://www.hdfgroup.org/products/licenses.html.  If you do not have
-# access to the file, you may request a copy from help@hdfgroup.org.
+# the source code distribution tree. You can also access it online at
+# http://www.hdfgroup.org/licenses.  If you do not have access to the file,
+# you may request a copy from help@hdfgroup.org.
 #
 
 top_builddir=@top_builddir@

--- a/release_notes/INSTALL_CMake.txt
+++ b/release_notes/INSTALL_CMake.txt
@@ -88,7 +88,7 @@ To build HDF4 with the SZIP, ZLIB and JPEG external libraries you will need to:
 
    4. Edit the platform configuration file, HDF4options.cmake, if you want to change
       the default build environment.
-      (See  https://portal.hdfgroup.org/display/support/How+to+Change+HDF4+CMake+Build+Options)
+      (See USING_HDF4_CMake.txt in the release_notes/ directory in the source tree.)
 
    5. From the "myhdfstuff" directory execute the CTest Script with the
       following options:

--- a/release_notes/INSTALL_CYGWIN.txt
+++ b/release_notes/INSTALL_CYGWIN.txt
@@ -94,7 +94,7 @@ Build, Test and Install HDF4 on Cygwin
 
    The HDF4 source code can be obtained from:  
 
-      https://portal.hdfgroup.org/display/support/Download+HDF4
+      https://portal.hdfgroup.org/downloads/index.html
 
    Please note that HDF no longer provides precompiled binaries for Cygwin.
 

--- a/release_notes/RELEASE.txt
+++ b/release_notes/RELEASE.txt
@@ -14,7 +14,7 @@ each final release and can be found on the HDF4 support page at:
 
 The official HDF4 releases can be obtained from:
 
-    https://portal.hdfgroup.org/display/support/Download+HDF4
+    https://portal.hdfgroup.org/downloads/index.html
 
 If you have any questions or comments, please send them to the HDF Help Desk:
 

--- a/release_notes/USING_HDF4_CMake.txt
+++ b/release_notes/USING_HDF4_CMake.txt
@@ -229,8 +229,8 @@ command line and the build folder is created as a sub-folder. Windows should
 adjust the forward slash to double backslashes, except for the HDF_DIR
 environment variable.
 
-NOTE: this file is available at the HDF web site:
-    https://portal.hdfgroup.org/display/support/Building+HDF4+with+CMake
+NOTE: this file is available in the HDF4 repository:
+    https://github.com/HDFGroup/hdf4/blob/master/release_notes/USING_HDF4_CMake.txt
 
     HDF4_Examples.cmake
     HDF4_Examples_options.cmake


### PR DESCRIPTION
Mostly links to licenses, download, documentation, dues to the old portal being unavailable.