### PR TITLE
Add subdir-objects to AM_INIT_AUTOMAKE

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,12 +24,6 @@ echo "NOTE: You can ignore the warning about adding -I m4."
 echo "      We already do this in an included file."
 echo
 
-echo
-echo "NOTE: You can ignore the warning about adding subdir-objects."
-echo "      This currently causes failures on older systems. It will"
-echo "      be added once we fix the problem."
-echo
-
 # The "obsolete" warnings category flags our Java macros as obsolete.
 # Since there is no clear way to upgrade them (Java support in the Autotools
 # is not great) and they work well enough for now, we suppress those warnings.

--- a/configure.ac
+++ b/configure.ac
@@ -34,11 +34,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 ## AM_INIT_AUTOMAKE takes a list of options that should be applied to
 ## every Makefile.am when automake is run.
-##
-## NOTE: Don't add subdir-objects here just yet. Modern Automake will
-##       complain that it's missing, but adding it causes failures on
-##       older systems.
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) # use silent rules where available - automake 1.11
 
 ## AM_MAINTAINER_MODE determines the behavior of "rebuild rules" that contain


### PR DESCRIPTION
This caused problems with ancient machines. It's being restored as we rework the build system for 4.4.0.