### PR TITLE
Fix memory leak in mfhdf test

### DIFF
--- a/mfhdf/src/file.c
+++ b/mfhdf/src/file.c
@@ -44,8 +44,8 @@ struct rlimit rlim;
 #define MAX_AVAIL_OPENFILES                                                                                  \
     (((MAX_SYS_OPENFILES - 3) > H4_MAX_AVAIL_OPENFILES) ? H4_MAX_AVAIL_OPENFILES : (MAX_SYS_OPENFILES - 3))
 
-static int _curr_opened = 0; /* the number of files currently opened */
-static int  _ncdf = 0; /*  high water mark on open cdf's */
+static int  _curr_opened = 0; /* the number of files currently opened */
+static int  _ncdf        = 0; /*  high water mark on open cdf's */
 static NC **_cdfs;
 
 #define HNDLE(id) (((id) >= 0 && (id) < _ncdf) ? _cdfs[(id)] : NULL)


### PR DESCRIPTION
An incorrect variable was used to detect when the list of opened files became empty and needed to be deallocated.  That resulted in a list of allocated pointers not freed.

==154211==    still reachable: 8,168 bytes in 1 blocks

After the correct variable was used, valgrind showed the memory leak gone.

==163740== All heap blocks were freed -- no leaks are possible