### PR TITLE
Re-enable test_sd() in hdftest

### DIFF
--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -195,10 +195,7 @@ main(void)
        library is not present or only decoder is available. */
     num_errs = num_errs + test_szip_compression();
 
-    /* NOTE: This test had a history of failing on some systems when the user
-     * is logged in as root. It has been re-enabled and we'll investigate
-     * if it starts failing again.
-     */
+    /* Tests SDstart for files with no write permission */
     num_errs = num_errs + test_sd();
 
     if (num_errs == 0) {

--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -20,24 +20,12 @@
 
 #define NBITFILE "nbit.hdf"
 
-/* Which tests to run? */
-#define EXTERNAL_TEST
-#define NBIT_TEST
-#define COMP_TEST
-#define CHUNK_TEST
-/*  commented out for now because of 'long' handling on 64-bit
-    machines by this version of the netCDF library is broken.
-    The new version of the netCDF library(2.4.3?) has fixed
-    this I think. To fix it here requires merging in those fixes.*/
-
-#define NETCDF_READ_TEST
-
-/* all test functions to be called in main */
+/* All test functions to be called in main */
 extern int test_netcdf_reading();
 extern int test_szip_compression();
 extern int test_checkempty();
 extern int test_idtest();
-/* extern int test_sd(); - removed temporarily, see note in main(...) */
+extern int test_sd();
 extern int test_mixed_apis();
 extern int test_files();
 extern int test_SDSprops();
@@ -50,6 +38,9 @@ extern int test_datasizes();
 extern int test_datainfo();
 extern int test_external();
 extern int test_att_ann_datainfo();
+
+/* FIXME: Disabled due to test failures */
+/* extern int test_rank0(); */
 
 static int
 test_nbit()
@@ -150,29 +141,17 @@ main(void)
 {
     int num_errs = 0; /* number of errors so far */
 
-#ifdef NBIT_TEST
     /* Test nbits functions */
     num_errs = num_errs + test_nbit();
 
-#endif /* NBIT_TEST */
-
-#ifdef COMP_TEST
     /* Test the compressed storage routines */
     num_errs = num_errs + test_compression();
 
-#endif /* COMP_TEST */
-
-#ifdef CHUNK_TEST
     /* Tests chunking functions */
     num_errs = num_errs + test_chunk();
 
-#endif /* CHUNK_TEST */
-
-#ifdef NETCDF_READ_TEST
     /* Tests reading netCDF file using SD interface */
     num_errs = num_errs + test_netcdf_reading();
-
-#endif /* NETCDF_READ_TEST */
 
     /* Tests dimension functions (in tdim.c) */
     num_errs = num_errs + test_dimensions();
@@ -199,11 +178,9 @@ main(void)
     /* Tests miscellaneous file-related APIs (in tfiles.c) */
     num_errs = num_errs + test_files();
 
-    /* BMR: Added a test routine dedicated for testing the behavior of
-     * several functions when the SDS has rank=0. (in trank0.c) - 02/4/05 */
-    /* BMR: SDcreate fails on Copper when rank=0.  EP decided to remove
-     * this test until further study can be made on this feature.
-    num_errs = num_errs + test_rank0(); */
+    /* Test the behavior of several functions when the SDS has rank=0 (in trank0.c) */
+    /* FIXME: Currently failing - fix ASAP */
+    /* num_errs = num_errs + test_rank0(); */
 
     /* Tests functionality related to SDS' properties (in tsdsprops.c) */
     num_errs = num_errs + test_SDSprops();
@@ -218,10 +195,11 @@ main(void)
        library is not present or only decoder is available. */
     num_errs = num_errs + test_szip_compression();
 
-    /* BMR: This test fails on some systems when the user are logged in
-     * as root.  We decided to comment it out until further work can be
-     * attempted. (in tsd.c) 11/04/05 */
-    /* num_errs = num_errs + test_sd(); */
+    /* NOTE: This test had a history of failing on some systems when the user
+     * is logged in as root. It has been re-enabled and we'll investigate
+     * if it starts failing again.
+     */
+    num_errs = num_errs + test_sd();
 
     if (num_errs == 0) {
         printf("*** HDF-SD test passes ***\n");

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -24,7 +24,8 @@
 #include "hdftest.h"
 #include "hfile_priv.h"
 
-#define FILE_NAME "sdtest.hdf" /* data file to test ID types */
+/* Data file to test ID types */
+#define FILE_NAME "sdtest.hdf"
 
 extern int
 test_sd()
@@ -38,7 +39,7 @@ test_sd()
 #endif
 
     FILE *ff;
-    int   num_errs = 0; /* number of errors so far */
+    int   num_errs = 0; /* Number of errors so far */
 
     /* Output message about test being performed */
     TESTING("SDstart for file with no write permission (tsd.c)");

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -44,7 +44,7 @@ test_sd()
     /* Output message about test being performed */
     TESTING("SDstart for file with no write permission (tsd.c)");
 
-#ifdef H4_HAVE_UNISTD_H
+#if defined(H4_HAVE_UNISTD_H) && !defined(__MINGW32__) && !defined(__CYGWIN__)
     /* Root users on POSIX systems may have privileges that allow the
      * second SDstart() call to pass, so we'll skip the test.
      */

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -12,7 +12,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /****************************************************************************
- * tsd.c - tests SDstart for file with no write permission
+ * tsd.c    Tests SDstart for files with no write permission
  *
  * NOTE:    This test is very flaky since it depends on the user's
  *          permissions. When run as root, for example, the call to
@@ -100,7 +100,7 @@ test_sd()
         HI_CLOSE(ff);
     }
 
-#if defined(H4_HAVE_WIN32_API) && !defined(__MINGW32__)
+#if defined(H4_HAVE_WIN32_API)
     mode = _S_IWRITE;
 #else
     mode = S_IWUSR;

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -51,7 +51,7 @@ test_sd()
 
 #ifdef __CYGWIN__
     /* Default Cygwin permissions will allow SDstart() to open read-only files
-     * for writing, so we'll skipt the test.
+     * for writing, so we'll skip the test.
      */
     SKIPPED();
     return 0;

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -57,7 +57,7 @@ test_sd()
     return 0;
 #endif
 
-#if defined(H4_HAVE_UNISTD_H)
+#if defined(H4_HAVE_UNISTD_H) && !defined(__MINGW32__)
     /* Root users on POSIX systems may have privileges that allow SDstart()
      * to open read-only files for writing, so we'll skip the test.
      */

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -47,7 +47,7 @@ test_sd()
     /* Root users on POSIX systems may have privileges that allow the
      * second SDstart() call to pass, so we'll skip the test.
      */
-    uid_t uid  = getuid();
+    uid_t uid = getuid();
 
     if (uid == 0) {
         SKIPPED();

--- a/mfhdf/test/tsd.c
+++ b/mfhdf/test/tsd.c
@@ -15,6 +15,10 @@
  * tsd.c - tests SDstart for file with no write permission
  ****************************************************************************/
 
+#ifdef H4_HAVE_UNISTD_H
+#include <unistd.h.>
+#endif
+
 #include "mfhdf.h"
 
 #include "hdftest.h"
@@ -39,6 +43,18 @@ test_sd()
     /* Output message about test being performed */
     TESTING("SDstart for file with no write permission (tsd.c)");
 
+#ifdef H4_HAVE_UNISTD_H
+    /* Root users on POSIX systems may have privileges that allow the
+     * second SDstart() call to pass, so we'll skip the test.
+     */
+    uid_t uid  = getuid();
+
+    if (uid == 0) {
+        SKIPPED();
+        return 0;
+    }
+#endif
+
     /* delete the file just to be sure */
     unlink(FILE_NAME);
 
@@ -49,6 +65,7 @@ test_sd()
     /* Close the file */
     status = SDend(fid);
     CHECK(status, FAIL, "SDend");
+
 #if defined H4_HAVE_WIN32_API
     mode = _S_IREAD;
 #else

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -154,6 +154,11 @@ This version has been tested in the following platforms:
 
 Known problems
 ==============
+o  The test_sd() test in mfhdf's hdftest can fail depending on the privileges
+   of the account running the test. We've engineered around cases like running
+   as root, but you may still encounter test failures when running that test
+   from highly privileged accounts that can open read-only files for writing.
+
 o  The Fortran interface does not work on 64-bit systems as it stores addresses
    in memory as Fortran INTEGER values, which are typically 32-bit. The
    Fortran interface is currently disabled by default due to this. It should


### PR DESCRIPTION
This test was commented out due to failures when running as root. I've added a new hack that skips the second SDstart() call, which can succeed (considered a failure) when a user has root privileges.