### PR TITLE
Fix off-by-1 max file name len in dfp/dfr8

### DIFF
--- a/hdf/src/dfp.c
+++ b/hdf/src/dfp.c
@@ -35,7 +35,7 @@ static uint16 Writeref = 0;
 static uint16 Refset   = 0; /* Ref of palette to get next */
 static uint16 Lastref  = 0; /* Last ref read/written */
 
-static char Lastfile[DF_MAXFNLEN] = ""; /* last file opened */
+static char Lastfile[DF_MAXFNLEN + 1] = ""; /* last file opened */
 
 static int32 DFPIopen(const char *filename, int acc_mode);
 
@@ -276,7 +276,7 @@ DFPnpals(const char *filename)
     }
 
     /* Get space to store the palette offsets */
-    if ((pal_off = (int32 *)malloc(npals * sizeof(int32))) == NULL)
+    if ((pal_off = (int32 *)malloc((size_t)npals * sizeof(int32))) == NULL)
         HGOTO_ERROR(DFE_NOSPACE, FAIL);
 
     /* go through the IP8s */
@@ -286,7 +286,7 @@ DFPnpals(const char *filename)
                  DF_FORWARD) == SUCCEED) {
         pal_off[curr_pal] = find_off; /* store offset */
         curr_pal++;
-    } /* end while */
+    }
 
     /* go through the LUTs */
     find_tag = find_ref = 0;
@@ -405,10 +405,7 @@ DFPwriteref(const char *filename, uint16 ref)
     Restart reading/writing palettes to a file.
  GLOBAL VARIABLES
     Lastfile
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
---------------------------------------------------------------------------*/
+ --------------------------------------------------------------------------*/
 int
 DFPrestart(void)
 {
@@ -476,8 +473,6 @@ DFPlastref(void)
  COMMENTS, BUGS, ASSUMPTIONS
     This is a hook for someday providing more efficient ways to
     reopen a file, to avoid re-reading all the headers
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 static int32
 DFPIopen(const char *filename, int acc_mode)
@@ -492,14 +487,15 @@ DFPIopen(const char *filename, int acc_mode)
             HGOTO_ERROR(DFE_BADOPEN, FAIL);
         Refset  = 0; /* no ref to get set for this file */
         Readref = 0;
-    } /* end if */
+    }
     else if ((file_id = Hopen(filename, acc_mode, 0)) == FAIL)
         HGOTO_ERROR(DFE_BADOPEN, FAIL);
 
     /* remember filename, so reopen may be used next time if same file */
     strncpy(Lastfile, filename, DF_MAXFNLEN);
+    Lastfile[DF_MAXFNLEN] = '\0';
 
-    ret_value = (file_id);
+    ret_value = file_id;
 
 done:
     return ret_value;

--- a/hdf/src/dfr8.c
+++ b/hdf/src/dfr8.c
@@ -56,12 +56,12 @@ static int Newpalette = -1;    /* -1 = no palette is associated
                                     0 = palette already written out
                                     1 = new palette, not yet written out */
 
-static int CompressSet = FALSE;         /* Whether the compression parameters have
-                                             been set for the next image */
-static int32 CompType = COMP_NONE;      /* What compression to use for the next
-                                            image */
-static comp_info CompInfo;              /* Params for compression to perform */
-static char      Lastfile[DF_MAXFNLEN]; /* last file opened */
+static int CompressSet = FALSE;             /* Whether the compression parameters have
+                                                 been set for the next image */
+static int32 CompType = COMP_NONE;          /* What compression to use for the next
+                                                image */
+static comp_info CompInfo;                  /* Params for compression to perform */
+static char      Lastfile[DF_MAXFNLEN + 1]; /* last file opened */
 static DFRrig    Readrig = {
     /* information about RIG being read */
     NULL,
@@ -1112,9 +1112,6 @@ done:
     Restarts reading and writing of RIGs from file from the beginning.
  GLOBAL VARIABLES
     Lastfile
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 int
 DFR8restart(void)
@@ -1211,8 +1208,6 @@ done:
  COMMENTS, BUGS, ASSUMPTIONS
     This is a hook for someday providing more efficient ways to
     reopen a file, to avoid re-reading all the headers.
- EXAMPLES
- REVISION LOG
 --------------------------------------------------------------------------*/
 static int32
 DFR8Iopen(const char *filename, int acc_mode)
@@ -1236,11 +1231,11 @@ DFR8Iopen(const char *filename, int acc_mode)
     else {
         if ((file_id = Hopen(filename, acc_mode, 0)) == FAIL)
             HGOTO_ERROR(DFE_BADOPEN, FAIL);
-    } /* end else */
+    }
 
     /* remember filename, so reopen may be used next time if same file */
     strncpy(Lastfile, filename, DF_MAXFNLEN);
-    Lastfile[DF_MAXFNLEN - 1] = '\0';
+    Lastfile[DF_MAXFNLEN] = '\0';
 
     ret_value = file_id;
 


### PR DESCRIPTION
The "last file name" arrays in both dfp.c and dfr8.c can only hold DF_MAXFNLEN - 1 characters, so a file name of of length DF_MAXFNLEN (defined in hlimits.h) would be truncated.

This has little practical effect, as it's just used in a shortcut used when reopening files, but it's incorrect behavior and raises warnings. Other "last file" shortcut code uses correctly-sized arrays.