### PR TITLE
Bring over HDF5 warning macros + cleanup

### DIFF
--- a/hdf/src/cdeflate.c
+++ b/hdf/src/cdeflate.c
@@ -166,7 +166,16 @@ HCIcdeflate_encode(compinfo_t *info, int32 length, const void *buf)
     deflate_info = &(info->cinfo.coder_info.deflate_info);
 
     /* Set up the deflation buffers to point to the user's buffer to empty */
-    deflate_info->deflate_context.next_in  = (void *)buf;
+
+    H4_GCC_CLANG_DIAG_OFF("cast-qual")
+    /* NOTE: The next_in pointer field in the z_stream struct is declared to
+     *       be z_const, which may or may not actually be const, depending on
+     *       how the deflate/zlib library was compiled. There's not much we
+     *       can do about this.
+     */
+    deflate_info->deflate_context.next_in = (void *)buf;
+    H4_GCC_CLANG_DIAG_ON("cast-qual")
+
     deflate_info->deflate_context.avail_in = (uInt)length;
     while (deflate_info->deflate_context.avail_in > 0 || deflate_info->deflate_context.avail_out == 0) {
         /* Write more bytes from the file, if we've filled our buffer */
@@ -542,7 +551,7 @@ HCPcdeflate_read(accrec_t *access_rec, int32 length, void *data)
     int32 HCPcdeflate_write(access_rec,length,data)
     accrec_t *access_rec;   IN: the access record of the data element
     int32 length;           IN: the number of bytes to write
-    void * data;             IN: the buffer to retrieve the bytes written
+    const void * data;      IN: the buffer to retrieve the bytes written
 
  RETURNS
     Returns the number of bytes written or FAIL

--- a/hdf/src/dfconv.c
+++ b/hdf/src/dfconv.c
@@ -400,7 +400,7 @@ DFconvert(uint8 *source, uint8 *dest, int ntype, int sourcetype, int desttype, i
     }
 
     if (sourcetype == desttype) {
-        memcpy(dest, source, size);
+        memcpy(dest, source, (size_t)size);
         return 0;
     }
 

--- a/hdf/src/dfimcomp.c
+++ b/hdf/src/dfimcomp.c
@@ -504,18 +504,18 @@ DFCIunimcomp(int32 xdim, int32 ydim, uint8 in[], uint8 out[])
     for (y = 0; y < (ydim / 4); y++)
         for (x = 0; x < xdim; x = x + 4) {
             k        = y * xdim + x;
-            hi_color = (unsigned char)in[k + 2];
-            lo_color = (unsigned char)in[k + 3];
+            hi_color = in[k + 2];
+            lo_color = in[k + 3];
 
-            bitmap = ((unsigned char)in[k] << 8) | (unsigned char)in[k + 1];
+            bitmap = (in[k] << 8) | in[k + 1];
 
             for (i = (y * 4); i < (y * 4 + 4); i++) {
                 temp = bitmap >> (3 + y * 4 - i) * 4;
                 for (j = x; j < (x + 4); j++) {
                     if ((temp & 8) == 8)
-                        out[i * xdim + j] = (char)hi_color;
+                        out[i * xdim + j] = hi_color;
                     else
-                        out[i * xdim + j] = (char)lo_color;
+                        out[i * xdim + j] = lo_color;
                     temp = temp << 1;
                 }
             }
@@ -953,7 +953,7 @@ find_med(struct box *ptr, int dim)
      * at least we won't segfault...
      */
     if ((NULL == ptr) || (NULL == ptr->pts))
-        return -9999999.99;
+        return -9999999.99F;
 
     rank = (int *)malloc((unsigned)ptr->nmbr_distinct * sizeof(int));
     for (i = 0; i < ptr->nmbr_distinct; i++)

--- a/hdf/src/dfjpeg.c
+++ b/hdf/src/dfjpeg.c
@@ -293,7 +293,7 @@ DFCIjpeg(int32 file_id, uint16 tag, uint16 ref, int32 xdim, int32 ydim, const vo
     while (cinfo_ptr->next_scanline < cinfo_ptr->image_height) {
         row_pointer[0] = (JSAMPROW)(&image_buffer[(size_t)cinfo_ptr->next_scanline * (size_t)row_stride]);
         jpeg_write_scanlines(cinfo_ptr, row_pointer, 1);
-    } /* end while */
+    }
 
     /* Finish writing stuff out */
     jpeg_finish_compress(cinfo_ptr);

--- a/hdf/src/dfrle.c
+++ b/hdf/src/dfrle.c
@@ -60,13 +60,16 @@ DFCIrle(const void *buf, void *bufto, int32 len)
         }
 
         if (q - p > 2) { /* three in a row */
+            ptrdiff_t diff;
+
             if (p > begp) {
                 *cfoll = (uint8)(p - begp);
                 cfoll  = clead;
             }
             *cfoll++ = (uint8)(128 | (uint8)(q - p)); /* len of seq */
             *cfoll++ = *p;                            /* char of seq */
-            len -= q - p;                             /* subtract len of seq */
+            diff     = q - p;                         /* get len of seq */
+            len -= (int32)diff;                       /* subtract len of seq */
             p     = q;
             clead = cfoll + 1;
             begp  = p;

--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -2345,9 +2345,13 @@ DFSDIgetndg(int32 file_id, uint16 tag, uint16 ref, DFSsdg *sdg)
                 if (luf == (-1))
                     luf = LABEL;
 
+                /* FALLTHROUGH */
+
             case DFTAG_SDU: /* units */
                 if (luf == (-1))
                     luf = UNIT;
+
+                /* FALLTHROUGH */
 
             case DFTAG_SDF: /* formats */
                 if (luf == (-1))

--- a/hdf/src/hdf_priv.h
+++ b/hdf/src/hdf_priv.h
@@ -250,6 +250,55 @@ typedef intptr_t hdf_pint_t;
 #endif
 
 /**************************************************************************
+ *  Warning suppression macros
+ **************************************************************************/
+
+/* Macros for enabling/disabling particular GCC / clang warnings
+ *
+ * (see the following web-sites for more info:
+ *      http://www.dbp-consulting.com/tutorials/SuppressingGCCWarnings.html
+ *      http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
+ */
+#define H4_DIAG_JOINSTR(x, y) x y
+#define H4_DIAG_DO_PRAGMA(x)  _Pragma(#x)
+#define H4_DIAG_PRAGMA(x)     H4_DIAG_DO_PRAGMA(GCC diagnostic x)
+
+#define H4_DIAG_OFF(x) H4_DIAG_PRAGMA(push) H4_DIAG_PRAGMA(ignored H4_DIAG_JOINSTR("-W", x))
+#define H4_DIAG_ON(x)  H4_DIAG_PRAGMA(pop)
+
+/* Macros for enabling/disabling particular GCC-only warnings.
+ * These pragmas are only implemented usefully in gcc 4.6+
+ */
+#if (((__GNUC__ * 100) + __GNUC_MINOR__) >= 406)
+#define H4_GCC_DIAG_OFF(x) H4_DIAG_OFF(x)
+#define H4_GCC_DIAG_ON(x)  H4_DIAG_ON(x)
+#else
+#define H4_GCC_DIAG_OFF(x)
+#define H4_GCC_DIAG_ON(x)
+#endif
+
+/* Macros for enabling/disabling particular clang-only warnings.
+ */
+#if defined(__clang__)
+#define H4_CLANG_DIAG_OFF(x) H4_DIAG_OFF(x)
+#define H4_CLANG_DIAG_ON(x)  H4_DIAG_ON(x)
+#else
+#define H4_CLANG_DIAG_OFF(x)
+#define H4_CLANG_DIAG_ON(x)
+#endif
+
+/* Macros for enabling/disabling particular GCC / clang warnings.
+ * These macros should be used for warnings supported by both gcc and clang.
+ */
+#if (((__GNUC__ * 100) + __GNUC_MINOR__) >= 406) || defined(__clang__)
+#define H4_GCC_CLANG_DIAG_OFF(x) H4_DIAG_OFF(x)
+#define H4_GCC_CLANG_DIAG_ON(x)  H4_DIAG_ON(x)
+#else
+#define H4_GCC_CLANG_DIAG_OFF(x)
+#define H4_GCC_CLANG_DIAG_ON(x)
+#endif
+
+/**************************************************************************
  *  JPEG #define's - Look in the JPEG docs before changing - (Q)
  **************************************************************************/
 

--- a/hdf/src/vg_priv.h
+++ b/hdf/src/vg_priv.h
@@ -48,10 +48,10 @@ typedef VDATA              VSUBGROUP;
  */
 
 typedef struct symdef_struct {
-    char  *name;  /* symbol name */
-    int16  type;  /* whether int, char, float etc */
-    uint16 isize; /* field size as stored in vdata */
-    uint16 order; /* order of field */
+    const char *name;  /* symbol name */
+    int16       type;  /* whether int, char, float etc */
+    uint16      isize; /* field size as stored in vdata */
+    uint16      order; /* order of field */
 } SYMDEF;
 
 typedef struct write_struct {

--- a/hdf/src/vrw.c
+++ b/hdf/src/vrw.c
@@ -262,7 +262,7 @@ VSread(int32 vkey,  /* IN: vdata key */
             chunk = buf_size / hsize + 1;
 
             /* get a buffer big enough to hold the values */
-            Vtbufsize = (size_t)chunk * (size_t)hsize;
+            Vtbufsize = (uint32)(chunk * hsize);
             free(Vtbuf);
             if ((Vtbuf = (uint8 *)malloc(Vtbufsize)) == NULL)
                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
@@ -294,7 +294,7 @@ VSread(int32 vkey,  /* IN: vdata key */
 
             /* CASE  (E): Only a single field in the Vdata */
             if (w->n == 1) {
-                DFKconvert(Vtbuf, Src, w->type[0], (uint32)w->order[0] * (uint32)chunk, DFACC_READ, 0, 0);
+                DFKconvert(Vtbuf, Src, w->type[0], (int32)w->order[0] * chunk, DFACC_READ, 0, 0);
             } /* case (e) */
             /* ----------------------------------------------------------------- */
             /* CASE  (C):  iu=full, iv=full */
@@ -310,7 +310,7 @@ VSread(int32 vkey,  /* IN: vdata key */
                     order = (int)w->order[i];
 
                     for (index = 0; index < order; index++) {
-                        DFKconvert(b2, b1, type, (uint32)chunk, DFACC_READ, (uint32)hsize, (uint32)uvsize);
+                        DFKconvert(b2, b1, type, chunk, DFACC_READ, hsize, uvsize);
                         b1 += (int)esize / order;
                         b2 += (int)isize / order;
                     }
@@ -333,7 +333,7 @@ VSread(int32 vkey,  /* IN: vdata key */
 
         /* alloc space (Vtbuf) for reading in the raw data from vdata */
         if (Vtbufsize < (size_t)nelt * (size_t)hsize) {
-            Vtbufsize = (size_t)nelt * (size_t)hsize;
+            Vtbufsize = (uint32)(nelt * hsize);
             free(Vtbuf);
             if ((Vtbuf = (uint8 *)malloc(Vtbufsize)) == NULL)
                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
@@ -362,7 +362,7 @@ VSread(int32 vkey,  /* IN: vdata key */
                 order = (int)w->order[i];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert(b2, b1, type, (uint32)nelt, DFACC_READ, (uint32)hsize, (uint32)esize);
+                    DFKconvert(b2, b1, type, nelt, DFACC_READ, hsize, esize);
                     b2 += isize / order;
                     b1 += esize / order;
                 }
@@ -383,7 +383,7 @@ VSread(int32 vkey,  /* IN: vdata key */
                 order = (int)w->order[i];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert(b2, b1, type, (uint32)nelt, DFACC_READ, (uint32)isize, (uint32)esize);
+                    DFKconvert(b2, b1, type, nelt, DFACC_READ, isize, esize);
                     b1 += esize / order;
                     b2 += isize / order;
                 }
@@ -409,7 +409,7 @@ VSread(int32 vkey,  /* IN: vdata key */
                 order = (int)w->order[i];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert(b2, b1, type, (uint32)nelt, DFACC_READ, (uint32)isize, (uint32)uvsize);
+                    DFKconvert(b2, b1, type, nelt, DFACC_READ, isize, uvsize);
                     b1 += esize / order;
                     b2 += isize / order;
                 }
@@ -572,7 +572,7 @@ VSwrite(int32       vkey,  /* IN: vdata key */
             chunk = buf_size / hdf_size + 1;
 
             /* get a buffer big enough to hold the values */
-            Vtbufsize = (size_t)chunk * (size_t)hdf_size;
+            Vtbufsize = (uint32)(chunk * hdf_size);
             free(Vtbuf);
             if ((Vtbuf = (uint8 *)malloc(Vtbufsize)) == NULL)
                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
@@ -606,8 +606,13 @@ VSwrite(int32       vkey,  /* IN: vdata key */
                 order = (int)w->order[j];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert((void *)src, dest, type, (uint32)chunk, DFACC_WRITE, (uint32)int_size,
-                               (uint32)hdf_size);
+                    H4_GCC_CLANG_DIAG_OFF("cast-qual")
+                    /* HDF4 convert functions are often bidirectional and
+                     * raise warnings when passed const pointers for writing,
+                     * even though the data will not be modified
+                     */
+                    DFKconvert((void *)src, dest, type, chunk, DFACC_WRITE, int_size, hdf_size);
+                    H4_GCC_CLANG_DIAG_ON("cast-qual")
                     dest += isize / order;
                     src += esize / order;
                 }
@@ -656,8 +661,13 @@ VSwrite(int32       vkey,  /* IN: vdata key */
                 order = (int)w->order[j];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert((void *)src, dest, type, (uint32)nelt, DFACC_WRITE, (uint32)esize,
-                               (uint32)hdf_size);
+                    H4_GCC_CLANG_DIAG_OFF("cast-qual")
+                    /* HDF4 convert functions are often bidirectional and
+                     * raise warnings when passed const pointers for writing,
+                     * even though the data will not be modified
+                     */
+                    DFKconvert((void *)src, dest, type, nelt, DFACC_WRITE, esize, hdf_size);
+                    H4_GCC_CLANG_DIAG_ON("cast-qual")
                     src += esize / order;
                     dest += isize / order;
                 }
@@ -679,8 +689,13 @@ VSwrite(int32       vkey,  /* IN: vdata key */
                 order = (int)w->order[j];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert((void *)src, dest, type, (uint32)nelt, DFACC_WRITE, (uint32)esize,
-                               (uint32)isize);
+                    H4_GCC_CLANG_DIAG_OFF("cast-qual")
+                    /* HDF4 convert functions are often bidirectional and
+                     * raise warnings when passed const pointers for writing,
+                     * even though the data will not be modified
+                     */
+                    DFKconvert((void *)src, dest, type, nelt, DFACC_WRITE, esize, isize);
+                    H4_GCC_CLANG_DIAG_ON("cast-qual")
                     dest += isize / order;
                     src += esize / order;
                 }
@@ -702,8 +717,13 @@ VSwrite(int32       vkey,  /* IN: vdata key */
                 order = (int)w->order[j];
 
                 for (index = 0; index < order; index++) {
-                    DFKconvert((void *)src, dest, type, (uint32)nelt, DFACC_WRITE, (uint32)int_size,
-                               (uint32)isize);
+                    H4_GCC_CLANG_DIAG_OFF("cast-qual")
+                    /* HDF4 convert functions are often bidirectional and
+                     * raise warnings when passed const pointers for writing,
+                     * even though the data will not be modified
+                     */
+                    DFKconvert((void *)src, dest, type, nelt, DFACC_WRITE, int_size, isize);
+                    H4_GCC_CLANG_DIAG_ON("cast-qual")
                     dest += isize / order;
                     src += esize / order;
                 }

--- a/hdf/src/vsfld.c
+++ b/hdf/src/vsfld.c
@@ -989,7 +989,7 @@ VSfpack(int32 vsid, int packtype, const char *fields_in_buf, void *buf, int bufs
         /* memory copy fields data to vdata buf */
         for (i = 0; i < n_records; i++) {
             for (j = 0; j < ac; j++) {
-                memcpy(bufp + foffs[j], fbufps[j], fmsizes[j]);
+                memcpy(bufp + foffs[j], fbufps[j], (size_t)fmsizes[j]);
                 fbufps[j] += fmsizes[j];
             }
             bufp += b_rec_size;
@@ -998,7 +998,7 @@ VSfpack(int32 vsid, int packtype, const char *fields_in_buf, void *buf, int bufs
     else { /* unpack from buf to fields */
         for (i = 0; i < n_records; i++) {
             for (j = 0; j < ac; j++) {
-                memcpy(fbufps[j], bufp + foffs[j], fmsizes[j]);
+                memcpy(fbufps[j], bufp + foffs[j], (size_t)fmsizes[j]);
                 fbufps[j] += fmsizes[j];
             }
             bufp += b_rec_size;

--- a/mfhdf/src/dim.c
+++ b/mfhdf/src/dim.c
@@ -29,7 +29,7 @@ NC_new_dim(const char *name, long size)
     if (ret->name == NULL)
         goto alloc_err;
 
-    ret->size  = size;
+    ret->size  = (int32)size;
     ret->vgid  = 0; /* no vgroup representing this dimension yet -BMR 2010/12/29 */
     ret->count = 1;
     /*        ret->dim00_compat = (size == NC_UNLIMITED)? 0 : 1;  */
@@ -43,8 +43,7 @@ alloc_err:
 /*
  * Free dim
  *
- * NOTE: Changed return value to return 'int'
- *       If successful returns SUCCEED else FAIL -GV 9/19/97
+ * If successful returns SUCCEED else FAIL
  */
 int
 NC_free_dim(NC_dim *dim)
@@ -127,7 +126,7 @@ ncdimdef(int cdfid, const char *name, long size)
         if (NC_incr_array(handle->dims, (uint8_t *)dim) == NULL)
             return -1;
     }
-    return handle->dims->count - 1;
+    return (int)handle->dims->count - 1;
 }
 
 int
@@ -140,7 +139,7 @@ NC_dimid(NC *handle, char *name)
     dp  = (NC_dim **)handle->dims->values;
     for (unsigned ii = 0; ii < handle->dims->count; ii++, dp++) {
         if (len == (*dp)->name->len && strncmp(name, (*dp)->name->values, len) == 0)
-            return ii;
+            return (int)ii;
     }
     NCadvise(NC_EBADDIM, "dim \"%s\" not found", name);
     return -1;
@@ -164,7 +163,7 @@ ncdimid(int cdfid, const char *name)
     dp  = (NC_dim **)handle->dims->values;
     for (unsigned ii = 0; ii < handle->dims->count; ii++, dp++) {
         if (len == (*dp)->name->len && strncmp(name, (*dp)->name->values, len) == 0)
-            return ii;
+            return (int)ii;
     }
     NCadvise(NC_EBADDIM, "dim \"%s\" not found", name);
     return -1;

--- a/mfhdf/src/mfsd.c
+++ b/mfhdf/src/mfsd.c
@@ -1508,8 +1508,8 @@ SDsetrange(int32 sdsid, /* IN: dataset ID */
         HGOTO_ERROR(DFE_ARGS, FAIL);
     }
 
-    memcpy(data, pmin, sz);
-    memcpy(data + sz, pmax, sz);
+    memcpy(data, pmin, (size_t)sz);
+    memcpy(data + sz, pmax, (size_t)sz);
 
     /* call common code */
     if (SDIputattr(&var->attrs, _HDF_ValidRange, var->HDFtype, (int)2, data) == FAIL) {
@@ -2263,11 +2263,11 @@ SDgetdatastrs(int32 sdsid, /* IN:  dataset ID */
         attr = (NC_attr **)NC_findattr(&(var->attrs), _HDF_LongName);
         if (attr != NULL) {
             if ((*attr)->data->count < (unsigned)len) {
-                strncpy((char *)l, (*attr)->data->values, (*attr)->data->count);
+                strncpy((char *)l, (char *)((*attr)->data->values), (*attr)->data->count);
                 l[(*attr)->data->count] = '\0';
             }
             else
-                strncpy((char *)l, (*attr)->data->values, len);
+                strncpy((char *)l, (char *)((*attr)->data->values), (size_t)len);
         }
         else
             l[0] = '\0';
@@ -2277,11 +2277,11 @@ SDgetdatastrs(int32 sdsid, /* IN:  dataset ID */
         attr = (NC_attr **)NC_findattr(&(var->attrs), _HDF_Units);
         if (attr != NULL) {
             if ((*attr)->data->count < (unsigned)len) {
-                strncpy((char *)u, (*attr)->data->values, (*attr)->data->count);
+                strncpy((char *)u, (char *)((*attr)->data->values), (*attr)->data->count);
                 u[(*attr)->data->count] = '\0';
             }
             else
-                strncpy((char *)u, (*attr)->data->values, len);
+                strncpy((char *)u, (char *)((*attr)->data->values), (size_t)len);
         }
         else
             u[0] = '\0';
@@ -2291,11 +2291,11 @@ SDgetdatastrs(int32 sdsid, /* IN:  dataset ID */
         attr = (NC_attr **)NC_findattr(&(var->attrs), _HDF_Format);
         if (attr != NULL) {
             if ((*attr)->data->count < (unsigned)len) {
-                strncpy((char *)f, (*attr)->data->values, (*attr)->data->count);
+                strncpy((char *)f, (char *)((*attr)->data->values), (*attr)->data->count);
                 f[(*attr)->data->count] = '\0';
             }
             else
-                strncpy((char *)f, (*attr)->data->values, len);
+                strncpy((char *)f, (char *)((*attr)->data->values), (size_t)len);
         }
         else
             f[0] = '\0';
@@ -2305,11 +2305,11 @@ SDgetdatastrs(int32 sdsid, /* IN:  dataset ID */
         attr = (NC_attr **)NC_findattr(&(var->attrs), _HDF_CoordSys);
         if (attr != NULL) {
             if ((*attr)->data->count < (unsigned)len) {
-                strncpy((char *)c, (*attr)->data->values, (*attr)->data->count);
+                strncpy((char *)c, (char *)((*attr)->data->values), (*attr)->data->count);
                 c[(*attr)->data->count] = '\0';
             }
             else
-                strncpy((char *)c, (*attr)->data->values, len);
+                strncpy((char *)c, (char *)((*attr)->data->values), (size_t)len);
         }
         else
             c[0] = '\0';
@@ -2988,7 +2988,7 @@ SDgetdimstrs(int32 id, /* IN:  dataset ID */
             if (attr != NULL) {
                 int minlen;
                 minlen = ((unsigned)len > (*attr)->data->count) ? (*attr)->data->count : (unsigned)len;
-                strncpy((char *)l, (*attr)->data->values, minlen);
+                strncpy((char *)l, (char *)((*attr)->data->values), (size_t)minlen);
                 if ((*attr)->data->count < (unsigned)len)
                     l[(*attr)->data->count] = '\0';
             }
@@ -3001,7 +3001,7 @@ SDgetdimstrs(int32 id, /* IN:  dataset ID */
             if (attr != NULL) {
                 int minlen;
                 minlen = (len > (*attr)->data->count) ? (*attr)->data->count : (unsigned)len;
-                strncpy((char *)u, (*attr)->data->values, minlen);
+                strncpy((char *)u, (char *)((*attr)->data->values), (size_t)minlen);
                 if ((*attr)->data->count < (unsigned)len)
                     u[(*attr)->data->count] = '\0';
             }
@@ -3014,7 +3014,7 @@ SDgetdimstrs(int32 id, /* IN:  dataset ID */
             if (attr != NULL) {
                 int minlen;
                 minlen = (len > (*attr)->data->count) ? (*attr)->data->count : (unsigned)len;
-                strncpy((char *)f, (*attr)->data->values, minlen);
+                strncpy((char *)f, (char *)((*attr)->data->values), (size_t)minlen);
                 if ((*attr)->data->count < (unsigned)len)
                     f[(*attr)->data->count] = '\0';
             }
@@ -3258,7 +3258,7 @@ SDgetexternalinfo(int32    id,           /* IN: dataset ID */
                     actual_fname_len = (int)buf_size < tmp_len ? (int)buf_size : tmp_len;
 
                     /* Get the name */
-                    strncpy(ext_filename, info_block.path, actual_fname_len);
+                    strncpy(ext_filename, info_block.path, (size_t)actual_fname_len);
 
                     /* Get offset/length of the external data if requested */
                     if (offset != NULL)
@@ -3380,7 +3380,7 @@ SDgetexternalfile(int32  id,           /* IN: dataset ID */
                         HGOTO_ERROR(DFE_ARGS, FAIL);
 
                     /* Get the name and its length */
-                    strncpy(ext_filename, info_block.path, buf_size);
+                    strncpy(ext_filename, info_block.path, (size_t)buf_size);
                     actual_len = buf_size < ext_file_len ? buf_size : ext_file_len;
 
                     /* Get the offset in the external file if it's requested */
@@ -4780,7 +4780,7 @@ SDsetchunk(int32         sdsid,     /* IN: sds access id */
     }
 
     /* Now start setting chunk info */
-    ndims = var->assoc->count; /* set number of dims i.e. rank */
+    ndims = (int32)var->assoc->count; /* set number of dims i.e. rank */
 
     /* allocate space for chunk dimensions */
     if ((chunk[0].pdims = malloc((size_t)ndims * sizeof(DIM_DEF))) == NULL) {
@@ -4894,8 +4894,8 @@ SDsetchunk(int32         sdsid,     /* IN: sds access id */
     }
 
     if (convert) { /* convert fill value */
-        if (FAIL == DFKconvert(fill_val, tBuf, var->HDFtype, (uint32)(fill_val_len / var->HDFsize),
-                               DFACC_WRITE, 0, 0)) {
+        if (FAIL ==
+            DFKconvert(fill_val, tBuf, var->HDFtype, fill_val_len / var->HDFsize, DFACC_WRITE, 0, 0)) {
             HGOTO_ERROR(DFE_INTERNAL, FAIL);
         }
 
@@ -5280,7 +5280,7 @@ SDwritechunk(int32       sdsid,  /* IN: access aid to SDS */
                 csize *= var->HDFsize;
 
                 /* figure out if data needs to be converted */
-                byte_count = csize;
+                byte_count = (uint32)csize;
 
                 if (FAIL == (platntsubclass = DFKgetPNSC(var->HDFtype, DF_MT))) {
                     HGOTO_ERROR(DFE_INTERNAL, FAIL);
@@ -5313,10 +5313,16 @@ SDwritechunk(int32       sdsid,  /* IN: access aid to SDS */
                 /* Write chunk out, */
                 if (convert) {
                     /* convert it */
-                    if (FAIL == DFKconvert((void *)datap, tBuf, var->HDFtype, (byte_count / var->HDFsize),
-                                           DFACC_WRITE, 0, 0)) {
+                    H4_GCC_CLANG_DIAG_OFF("cast-qual")
+                    /* HDF4 convert functions are often bidirectional and
+                     * raise warnings when passed const pointers for writing,
+                     * even though the data will not be modified
+                     */
+                    if (FAIL == DFKconvert((void *)datap, tBuf, var->HDFtype,
+                                           (int32)byte_count / var->HDFsize, DFACC_WRITE, 0, 0)) {
                         HGOTO_ERROR(DFE_INTERNAL, FAIL);
                     }
+                    H4_GCC_CLANG_DIAG_ON("cast-qual")
 
                     /* write it out now */
                     if ((ret_value = HMCwriteChunk(var->aid, origin, tBuf)) != FAIL) {
@@ -5471,7 +5477,7 @@ SDreadchunk(int32  sdsid,  /* IN: access aid to SDS */
                 csize *= var->HDFsize;
 
                 /* figure out if data needs to be converted */
-                byte_count = csize;
+                byte_count = (uint32)csize;
 
                 if (FAIL == (platntsubclass = DFKgetPNSC(var->HDFtype, DF_MT))) {
                     HGOTO_ERROR(DFE_INTERNAL, FAIL);
@@ -5504,7 +5510,7 @@ SDreadchunk(int32  sdsid,  /* IN: access aid to SDS */
                     /* read it in */
                     if ((ret_value = HMCreadChunk(var->aid, origin, tBuf)) != FAIL) {
                         /* convert chunk */
-                        if (FAIL == DFKconvert(tBuf, datap, var->HDFtype, (byte_count / var->HDFsize),
+                        if (FAIL == DFKconvert(tBuf, datap, var->HDFtype, (int32)byte_count / var->HDFsize,
                                                DFACC_READ, 0, 0)) {
                             HGOTO_ERROR(DFE_INTERNAL, FAIL);
                         }

--- a/mfhdf/src/var.c
+++ b/mfhdf/src/var.c
@@ -255,7 +255,7 @@ ncvardef(int cdfid, const char *name, nc_type type, int ndims, const int dims[])
     }
     else {
         /* check for name in use */
-        len = strlen(name);
+        len = (int)strlen(name);
         dp  = (NC_var **)handle->vars->values;
         for (int ii = 0; ii < handle->vars->count; ii++, dp++) {
             if (len == (*dp)->name->len && strncmp(name, (*dp)->name->values, len) == 0) {
@@ -333,7 +333,7 @@ ncvarid(int cdfid, const char *name)
         return -1;
     if (handle->vars == NULL)
         return -1;
-    len = strlen(name);
+    len = (int)strlen(name);
     dp  = (NC_var **)handle->vars->values;
     for (int ii = 0; ii < handle->vars->count; ii++, dp++) {
         if (len == (*dp)->name->len && strncmp(name, (*dp)->name->values, len) == 0) {
@@ -439,7 +439,7 @@ ncvarrename(int cdfid, int varid, const char *newname)
         return -1;
 
     /* check for name in use */
-    len = strlen(newname);
+    len = (int)strlen(newname);
     vpp = (NC_var **)handle->vars->values;
     for (int ii = 0; ii < handle->vars->count; ii++, vpp++) {
         if (len == (*vpp)->name->len && strncmp(newname, (*vpp)->name->values, len) == 0) {

--- a/mfhdf/test/texternal.c
+++ b/mfhdf/test/texternal.c
@@ -569,7 +569,7 @@ test_special_combos()
     int32 sd_id, sds2_id, sds3_id, sds4_id;
     int32 num_sds = 0, num_attrs = 0;
     int32 ap_start[3], ap_edges[3], dim_sizes[3];
-    int32 sds2_size = 0, sds3_size = 0, sds4_size = 0, size_written = 0;
+    int32 sds2_size = 0, sds3_size = 0, sds4_size = 0;
     int   status = 0;
     int   ii, jj, kk;
     int   num_errs = 0; /* number of errors in compression test so far */


### PR DESCRIPTION
* Brings over H5_GCC_CLANG_DIAG_OFF, etc. macros
* Clean up more warnings
* Suppress a few unavoidable warnings, mainly functions taking const pointers via in/out pointers when the context is "write" and the buffer will be unmodified. We can't fix this without public API changes.