### PR TITLE
CMake: refactor for clarity and generality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,5 @@
 cmake_minimum_required (VERSION 3.18)
-project (HDF4 C)
-
-if (POLICY CMP0074)
-  # find_package() uses <PackageName>_ROOT variables.
-  cmake_policy (SET CMP0074 NEW)
-endif ()
-
-if (POLICY CMP0083)
-  # To control generation of Position Independent Executable (PIE) or not,
-  # some flags are required at link time.
-  cmake_policy (SET CMP0083 NEW)
-endif ()
+project (HDF4 LANGUAGES C)
 
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
-cmake_minimum_required (VERSION 3.18)
+cmake_minimum_required (VERSION 3.18...3.24)
 project (HDF4 LANGUAGES C)
-
-# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-    cmake_policy(SET CMP0135 NEW)
-endif()
 
 #-----------------------------------------------------------------------------
 # Instructions for use : Normal Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ endif ()
 
 set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-add_definitions (-DHAVE_CONFIG_H)
+add_compile_definitions (HAVE_CONFIG_H)
 
 #-----------------------------------------------------------------------------
 # Temporary disable optimization flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ add_subdirectory (mfhdf/src)
 # Option to build documentation
 #-----------------------------------------------------------------------------
 option (HDF4_BUILD_DOC "Build documentation" OFF)
-if (HDF4_BUILD_DOC AND EXISTS "${HDF4_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF4_DOXYGEN_DIR}")
+if (HDF4_BUILD_DOC AND IS_DIRECTORY "${HDF4_DOXYGEN_DIR}")
 # check if Doxygen is installed
   find_package(Doxygen)
   if (DOXYGEN_FOUND)
@@ -603,10 +603,10 @@ if (BUILD_TESTING)
   endif ()
 
   if (NOT HDF4_EXTERNALLY_CONFIGURED)
-    if (EXISTS "${HDF4_SOURCE_DIR}/hdf/test" AND IS_DIRECTORY "${HDF4_SOURCE_DIR}/hdf/test")
+    if (IS_DIRECTORY "${HDF4_SOURCE_DIR}/hdf/test")
       add_subdirectory (hdf/test)
     endif ()
-    if (EXISTS "${HDF4_SOURCE_DIR}/mfhdf/test" AND IS_DIRECTORY "${HDF4_SOURCE_DIR}/mfhdf/test")
+    if (IS_DIRECTORY "${HDF4_SOURCE_DIR}/mfhdf/test")
       add_subdirectory (mfhdf/test)
     endif ()
   endif ()
@@ -623,7 +623,7 @@ endif ()
 # Set default name mangling : overridden by Fortran detection in fortran dir
 set (H4_F77_FUNC "H4_F77_FUNC(name,NAME) name ## _")
 set (H4_F77_FUNC_ "H4_F77_FUNC_(name,NAME) name ## __")
-if (EXISTS "${HDF4_SOURCE_DIR}/mfhdf/fortran" AND IS_DIRECTORY "${HDF4_SOURCE_DIR}/mfhdf/fortran")
+if (IS_DIRECTORY "${HDF4_SOURCE_DIR}/mfhdf/fortran")
   option (HDF4_BUILD_FORTRAN "Build FORTRAN support" OFF)
   if (HDF4_BUILD_FORTRAN)
     if (WIN32)
@@ -651,7 +651,7 @@ add_subdirectory (mfhdf)
 #-----------------------------------------------------------------------------
 # Option to build HDF4 Java Library
 #-----------------------------------------------------------------------------
-if (EXISTS "${HDF4_SOURCE_DIR}/java" AND IS_DIRECTORY "${HDF4_SOURCE_DIR}/java")
+if (IS_DIRECTORY "${HDF4_SOURCE_DIR}/java")
   option (HDF4_BUILD_JAVA "Build Java HDF Library" OFF)
   if (HDF4_BUILD_JAVA)
     if (NOT BUILD_SHARED_LIBS)
@@ -670,7 +670,7 @@ configure_file (${HDF_RESOURCES_DIR}/h4config.h.in ${PROJECT_BINARY_DIR}/h4confi
 #-----------------------------------------------------------------------------
 # Option to build examples
 #-----------------------------------------------------------------------------
-if (EXISTS "${HDF4_SOURCE_DIR}/HDF4Examples" AND IS_DIRECTORY "${HDF4_SOURCE_DIR}/HDF4Examples")
+if (IS_DIRECTORY "${HDF4_SOURCE_DIR}/HDF4Examples")
   option (HDF4_BUILD_EXAMPLES  "Build HDF4 Library Examples" ON)
   if (HDF4_BUILD_EXAMPLES)
     include (${HDF_RESOURCES_DIR}/HDF4ExampleCache.cmake)

--- a/HDF4Examples/CMakeLists.txt
+++ b/HDF4Examples/CMakeLists.txt
@@ -49,7 +49,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # All examples need the main include directories
 #-----------------------------------------------------------------------------
-set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES 
+set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES
     "${H4EX_HDF4_INCLUDE_DIRS}"
 )
 
@@ -75,7 +75,7 @@ endif ()
 # Set default name mangling : overridden by Fortran detection in fortran dir
 set (H4_F77_FUNC "H4_F77_FUNC(name,NAME) name ## _")
 set (H4_F77_FUNC_ "H4_F77_FUNC_(name,NAME) name ## __")
-if (EXISTS "${H4EXAMPLES_SOURCE_DIR}/mfhdf/FORTRAN" AND IS_DIRECTORY "${H4EXAMPLES_SOURCE_DIR}/mfhdf/FORTRAN")
+if (IS_DIRECTORY "${H4EXAMPLES_SOURCE_DIR}/mfhdf/FORTRAN")
   option (HDF_BUILD_FORTRAN "Build FORTRAN support" OFF)
   if (HDF_BUILD_FORTRAN AND HDF4_BUILD_FORTRAN)
     set (H4EX_LINK_Fortran_LIBS ${H4EX_HDF4_LINK_LIBS})
@@ -94,7 +94,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # Option to build JAVA examples
 #-----------------------------------------------------------------------------
-if (EXISTS "${H4EXAMPLES_SOURCE_DIR}/JAVA" AND IS_DIRECTORY "${H4EXAMPLES_SOURCE_DIR}/JAVA")
+if (IS_DIRECTORY "${H4EXAMPLES_SOURCE_DIR}/JAVA")
   option (HDF_BUILD_JAVA "Build JAVA support" OFF)
 else ()
   set (HDF_BUILD_JAVA OFF CACHE BOOL "Build examples JAVA support" FORCE)
@@ -112,4 +112,3 @@ endif ()
 if (HDF_BUILD_JAVA AND HDF4_BUILD_JAVA)
   add_subdirectory (JAVA)
 endif ()
-

--- a/config/cmake/JPEG/CMakeLists.txt
+++ b/config/cmake/JPEG/CMakeLists.txt
@@ -125,9 +125,9 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 set (EXE_EXT "")
 if (WIN32)
   set (EXE_EXT ".exe")
-  add_definitions (-D_BIND_TO_CURRENT_VCLIBS_VERSION=1)
-  add_definitions (-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions (-D_CONSOLE)
+  add_compile_definitions (_BIND_TO_CURRENT_VCLIBS_VERSION=1)
+  add_compile_definitions (_CRT_SECURE_NO_WARNINGS)
+  add_compile_definitions (_CONSOLE)
 endif ()
 
 if (MSVC)
@@ -162,7 +162,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # All libs/tests/examples need the main include directories
 #-----------------------------------------------------------------------------
-set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES 
+set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES
     "${JPEG_BINARY_DIR};${JPEG_SOURCE_DIR};${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
 )
 

--- a/config/cmake/LIBAEC/CMakeLists.txt
+++ b/config/cmake/LIBAEC/CMakeLists.txt
@@ -114,9 +114,9 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 set (EXE_EXT "")
 if (WIN32)
   set (EXE_EXT ".exe")
-  add_definitions (-D_BIND_TO_CURRENT_VCLIBS_VERSION=1)
-  add_definitions (-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions (-D_CONSOLE)
+  add_compile_definitions (_BIND_TO_CURRENT_VCLIBS_VERSION=1)
+  add_compile_definitions (_CRT_SECURE_NO_WARNINGS)
+  add_compile_definitions (_CONSOLE)
 endif ()
 
 if (MSVC)
@@ -146,7 +146,7 @@ configure_file (${LIBAEC_RESOURCES_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/
 #-----------------------------------------------------------------------------
 # All libs/tests/examples need the main include directories
 #-----------------------------------------------------------------------------
-set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES 
+set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES
     "${LIBAEC_BINARY_DIR};${LIBAEC_SOURCE_DIR}/src;${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
 )
 

--- a/config/cmake/ZLIB/CMakeLists.txt
+++ b/config/cmake/ZLIB/CMakeLists.txt
@@ -115,10 +115,10 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 set (EXE_EXT "")
 if (WIN32)
   set (EXE_EXT ".exe")
-  add_definitions (-D_BIND_TO_CURRENT_VCLIBS_VERSION=1)
-  add_definitions (-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions (-D_CONSOLE)
-  add_definitions (-D_CRT_NONSTDC_NO_DEPRECATE)
+  add_compile_definitions (_BIND_TO_CURRENT_VCLIBS_VERSION=1)
+  add_compile_definitions (_CRT_SECURE_NO_WARNINGS)
+  add_compile_definitions (_CONSOLE)
+  add_compile_definitions (_CRT_NONSTDC_NO_DEPRECATE)
 endif ()
 
 if (MSVC)
@@ -146,7 +146,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # All libs/tests/examples need the main include directories
 #-----------------------------------------------------------------------------
-set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES 
+set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES
     "${ZLIB_BINARY_DIR};${ZLIB_SOURCE_DIR};${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
 )
 

--- a/hdf/CMakeLists.txt
+++ b/hdf/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_DIRECTORY_LABELS “HDF”)
 #-----------------------------------------------------------------------------
 # Option to build HDF4 Utilities
 #-----------------------------------------------------------------------------
-if (EXISTS "${HDF4_HDF_SOURCE_DIR}/util" AND IS_DIRECTORY "${HDF4_HDF_SOURCE_DIR}/util")
+if (IS_DIRECTORY "${HDF4_HDF_SOURCE_DIR}/util")
   option (HDF4_BUILD_UTILS  "Build HDF4 Utilities" OFF)
   if (HDF4_BUILD_UTILS OR HDF4_BUILD_TOOLS)
     add_subdirectory (util)


### PR DESCRIPTION
Each commit is independent, combined into one PR for convenience

* add_definitions() => add_compile_definitions() recommended for generality across compilers
* set policy implicitly, remove no-op policies already implied
* remove redundant directory checks