### PR TITLE
Fix typo unzipf in publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -48,7 +48,7 @@ jobs:
                 aws s3 sync ./HDF4 s3://${{ secrets.AWS_S3_BUCKET }}/${{ vars.TARGET_PATH }}/${{ inputs.target_dir }}/downloads --delete
 
         - name: Uncompress source (Linux)
-          run: unzipf ${{ github.workspace }}/HDF4/${{ inputs.use_tag }}.doxygen.zip
+          run: unzip ${{ github.workspace }}/HDF4/${{ inputs.use_tag }}.doxygen.zip
 
         - name: Sync userguide to S3 bucket
           run: |


### PR DESCRIPTION
`unzipf` -> `unzip`
