### PR TITLE
ci(ppc64): remove unused cmake option

### DIFF
--- a/.github/workflows/ppc64.yml
+++ b/.github/workflows/ppc64.yml
@@ -50,7 +50,6 @@ jobs:
                 -DCMAKE_TOOLCHAIN_FILE=../config/toolchain/gcc.cmake \
                 -DBUILD_SHARED_LIBS:BOOL=ON \
                 -DHDF4_BUILD_EXAMPLES=ON \
-                -DBUILD_JPEG_WITH_PIC:BOOL=ON \
                 -DHDF4_BUILD_FORTRAN=OFF \
                 -DHDF4_BUILD_JAVA=OFF \
                 -DHDF4_BUILD_DOC=OFF \


### PR DESCRIPTION
```
CMake Warning:
    Manually-specified variables were not used by the project:
  
      BUILD_JPEG_WITH_PIC
```