### PR TITLE
Fix hdp to display correct test information

### DIFF
--- a/.github/workflows/hdfeos2.yml
+++ b/.github/workflows/hdfeos2.yml
@@ -13,6 +13,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install automake autoconf libtool libtool-bin
+          sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen openssl libtool libtool-bin
       - name: Install HDF4
         run: |
           ./autogen.sh

--- a/mfhdf/dumper/testhdp.sh.in
+++ b/mfhdf/dumper/testhdp.sh.in
@@ -75,7 +75,7 @@ TEST()
   shift
 
   # print a id banner
-  # MESG 6 "$@"
+  MESG 6 "$@"
 
   # run the test
   ( 

--- a/mfhdf/dumper/testhdp.sh.in
+++ b/mfhdf/dumper/testhdp.sh.in
@@ -74,6 +74,9 @@ TEST()
   expected="$srcdir/testfiles/$1"
   shift
 
+  # print a id banner
+  # MESG 6 "$@"
+
   # run the test
   ( 
     cd $srcdir/testfiles


### PR DESCRIPTION
Put back a line, which was accidentally removed in a commit in 2014, to print the detail of hdp test.