### PR TITLE
Fix an example

### DIFF
--- a/HDF4Examples/C/VD/h4ex_VD_read_from_vdata.c
+++ b/HDF4Examples/C/VD/h4ex_VD_read_from_vdata.c
@@ -48,10 +48,9 @@ main()
      * Attach to the vdata for reading if it is found, otherwise
      * exit the program.
      */
-    if (vdata_ref == 0)
-    {
+    if (vdata_ref == 0) {
         printf("*** vdata %s is not found in file %s\n", VDATA_NAME, FILE_NAME);
-        return(1);
+        return (1);
     }
     vdata_id = VSattach(file_id, vdata_ref, "r");
 

--- a/HDF4Examples/C/VD/h4ex_VD_read_from_vdata.c
+++ b/HDF4Examples/C/VD/h4ex_VD_read_from_vdata.c
@@ -3,7 +3,7 @@
 
 #include "hdf.h"
 
-#define FILE_NAME      "General_Vdatas.hdf"
+#define FILE_NAME      "General_Vdatas3.hdf"
 #define VDATA_NAME     "Solid Particle"
 #define N_RECORDS      5                      /* number of records the vdata contains */
 #define RECORD_INDEX   3                      /* position where reading starts - 4th record */
@@ -49,7 +49,10 @@ main()
      * exit the program.
      */
     if (vdata_ref == 0)
-        return 0;
+    {
+        printf("*** vdata %s is not found in file %s\n", VDATA_NAME, FILE_NAME);
+        return(1);
+    }
     vdata_id = VSattach(file_id, vdata_ref, "r");
 
     /*


### PR DESCRIPTION
An incorrect input file was used for this example.  The example h4ex_VD_write_to_vdata.c generated the file General_Vdatas3.hdf but this example used General_Vdatas.hdf, which didn't have the data the read example expected, which was the same as in h4ex_VD_write_to_vdata.c

Also changed to return an error when the vdata_ref was not found. However, unless the correct file is not available or somehow corrupted, this should never happen.

Addressed HDFFR-1543