### PR TITLE
Fix invalid read error

### DIFF
--- a/.github/workflows/hdfeos2.yml
+++ b/.github/workflows/hdfeos2.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Autotools Dependencies (Linux)
         run: |
           sudo apt update
-          sudo apt install automake autoconf libtool libtool-bin
+          sudo apt install automake autoconf libtool libtool-bin libjpeg-dev
           sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen openssl libtool libtool-bin
       - name: Install HDF4
         run: |

--- a/hdf/src/hfiledd.c
+++ b/hdf/src/hfiledd.c
@@ -1844,8 +1844,8 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, uintn *all_cnt,
 
                         dd_ptr = block->ddlist;
                         for (idx = 0; idx < block->ndds; idx++, dd_ptr++)
-                            if ((dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
-                                && dd_ptr->ref == cnt_ref)
+                            if ((dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag) &&
+                                dd_ptr->ref == cnt_ref)
                                 t_real_cnt++;
                     }
                 }

--- a/hdf/src/hfiledd.c
+++ b/hdf/src/hfiledd.c
@@ -1830,26 +1830,14 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, uintn *all_cnt,
             else {
                 if (cnt_ref == DFREF_WILDCARD) {
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {
-                        t_all_cnt += (uintn)block->ndds;
+                        t_all_cnt += (unsigned)block->ndds;
 
-                        idx    = 0;
                         dd_ptr = block->ddlist;
-                        if (block->ndds % 2 == 1)
-                            if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag) {
-                                t_real_cnt++;
-                                idx++;
-                                dd_ptr++;
-                            } /* end if */
-                        for (; idx < block->ndds; idx++, dd_ptr++) {
-                            if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
-                                t_real_cnt++;
-                            idx++;
-                            dd_ptr++;
+                        for (idx = 0; idx < block->ndds; idx++, dd_ptr++)
                             if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
                                 t_real_cnt++;
                         } /* end for */
-                    }     /* end for */
-                }         /* end if */
+                    }     /* end if */
                 else {
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {
                         t_all_cnt += (uintn)block->ndds;

--- a/hdf/src/hfiledd.c
+++ b/hdf/src/hfiledd.c
@@ -1825,8 +1825,8 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, uintn *all_cnt,
                     for (idx = 0; idx < block->ndds; idx++, dd_ptr++)
                         if (dd_ptr->tag == cnt_tag && (dd_ptr->ref == cnt_ref || cnt_ref == DFREF_WILDCARD))
                             t_real_cnt++;
-                } /* end for */
-            }     /* end if */
+                }
+            }
             else {
                 if (cnt_ref == DFREF_WILDCARD) {
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {
@@ -1836,20 +1836,20 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, uintn *all_cnt,
                         for (idx = 0; idx < block->ndds; idx++, dd_ptr++)
                             if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
                                 t_real_cnt++;
-                        } /* end for */
-                    }     /* end if */
+                    }
+                }
                 else {
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {
                         t_all_cnt += (uintn)block->ndds;
 
                         dd_ptr = block->ddlist;
                         for (idx = 0; idx < block->ndds; idx++, dd_ptr++)
-                            if ((dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag) &&
-                                dd_ptr->ref == cnt_ref)
+                            if ((dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
+                                && dd_ptr->ref == cnt_ref)
                                 t_real_cnt++;
-                    } /* end for */
-                }     /* end else */
-            }         /* end else */
+                    }
+                }
+            }
             break;
     } /* end switch */
 


### PR DESCRIPTION
HTIcount_dd had a block of incorrect code that caused invalid read errors.
Contacted the original author who provided the modified code that removed the invalid read errors.

Addressed GH-808