### PR TITLE
Fix a memory leak

### DIFF
--- a/mfhdf/libsrc/file.c
+++ b/mfhdf/libsrc/file.c
@@ -90,7 +90,7 @@ NC_reset_maxopenfiles(intn req_max)
     intn sys_limit = MAX_AVAIL_OPENFILES;
     intn alloc_size;
     NC **newlist;
-    intn i;
+    intn cdfi;
     int  ret_value = SUCCEED;
 
     /* Verify arguments */
@@ -106,15 +106,19 @@ NC_reset_maxopenfiles(intn req_max)
         if (!_cdfs) {
             _cdfs = malloc(sizeof(NC *) * (max_NC_open));
 
-            /* If allocation fails, return 0 for no allocation */
+            /* If allocation fails, return failed status, otherwise, initialize
+               each NC pointer to NULL, and return the default max */
             if (_cdfs == NULL) {
                 /* NC_EINVAL is Invalid Argument, but must decide if
                 we just want to return 0 without error or not */
                 NCadvise(NC_EINVAL, "Unable to allocate a cdf list of %d elements", max_NC_open);
                 HGOTO_DONE(-1);
             }
-            else
+            else {
+                for (cdfi = 0; cdfi < max_NC_open; cdfi++)
+                    _cdfs[cdfi] = NULL;
                 HGOTO_DONE(max_NC_open);
+            }
         }
         else /* return the current limit */
             HGOTO_DONE(max_NC_open);
@@ -137,18 +141,22 @@ NC_reset_maxopenfiles(intn req_max)
     newlist = malloc(sizeof(NC *) * alloc_size);
 
     /* If allocation fails, return 0 for no allocation */
+    /* If allocation fails, return failed status, otherwise, initialize
+               each NC pointer to NULL, and return the default max */
     if (newlist == NULL) {
         /* NC_EINVAL is Invalid Argument, but must decide if
         we just want to return 0 without error or not */
         NCadvise(NC_EINVAL, "Unable to allocate a cdf list of %d elements", alloc_size);
         HGOTO_DONE(-1);
     }
+    for (cdfi = 0; cdfi < alloc_size; cdfi++)
+        newlist[cdfi] = NULL;
 
     /* If _cdfs is already allocated, transfer pointers over to the
     new list and deallocate the old list of pointers */
     if (_cdfs != NULL) {
-        for (i = 0; i < _ncdf; i++)
-            newlist[i] = _cdfs[i];
+        for (cdfi = 0; cdfi < _ncdf; cdfi++)
+            newlist[cdfi] = _cdfs[cdfi];
         free(_cdfs);
     }
 
@@ -171,7 +179,7 @@ done:
 intn
 NC_get_maxopenfiles(void)
 {
-    return (max_NC_open);
+    return max_NC_open;
 } /* NC_get_maxopenfiles */
 
 /*
@@ -180,7 +188,7 @@ NC_get_maxopenfiles(void)
 intn
 NC_get_systemlimit(void)
 {
-    return (MAX_AVAIL_OPENFILES);
+    return MAX_AVAIL_OPENFILES;
 } /* NC_get_systemlimit */
 
 /*
@@ -189,7 +197,7 @@ NC_get_systemlimit(void)
 int
 NC_get_numopencdfs(void)
 {
-    return (_curr_opened);
+    return _curr_opened;
 } /* NC_get_numopencdfs */
 
 /*
@@ -204,9 +212,9 @@ NC_check_id(int cdfid)
     handle = (cdfid >= 0 && cdfid < _ncdf) ? _cdfs[cdfid] : NULL;
     if (handle == NULL) {
         NCadvise(NC_EBADID, "%d is not a valid cdfid", cdfid);
-        return (NULL);
+        return NULL;
     }
-    return (handle);
+    return handle;
 }
 
 /*
@@ -224,7 +232,7 @@ NC_indefine(int cdfid, bool_t iserr) /* Should be a Macro ? */
         else
             NCadvise(NC_ENOTINDEFINE, "%s Not in define mode", _cdfs[cdfid]->path);
     }
-    return (ret);
+    return ret;
 }
 
 /*
@@ -242,7 +250,7 @@ NC_open(const char *path, int mode)
     if (_cdfs == NULL) {
         if (FAIL == (cdfs_size = NC_reset_maxopenfiles(0))) {
             NCadvise(NC_ENFILE, "Could not reset max open files limit");
-            return (-1);
+            return -1;
         }
     }
 
@@ -259,12 +267,12 @@ NC_open(const char *path, int mode)
         if (max_NC_open == MAX_AVAIL_OPENFILES) {
             NCadvise(NC_ENFILE, "maximum number of open cdfs allowed already reaches system limit %d",
                      MAX_AVAIL_OPENFILES);
-            return (-1);
+            return -1;
         }
         /* otherwise, increase the current max to the system limit */
         if (FAIL == NC_reset_maxopenfiles(MAX_AVAIL_OPENFILES)) {
             NCadvise(NC_ENFILE, "Could not reset max open files limit");
-            return (-1);
+            return -1;
         }
     }
 
@@ -273,7 +281,7 @@ NC_open(const char *path, int mode)
         /* if the failure was due to "too many open files," simply return */
         if (errno == EMFILE) {
             nc_serror("maximum number of open files allowed has been reached\"%s\"", path);
-            return (-1);
+            return -1;
         }
 
         if ((mode & 0x0f) == NC_CLOBBER) {
@@ -283,7 +291,7 @@ NC_open(const char *path, int mode)
                 if (remove(path) != 0)
                     nc_serror("couldn't remove filename \"%s\"", path);
         }
-        return (-1);
+        return -1;
     }
 
     (void)strncpy(handle->path, path, FILENAME_MAX);
@@ -291,7 +299,7 @@ NC_open(const char *path, int mode)
     if (cdfid == _ncdf)
         _ncdf++;
     _curr_opened++;
-    return (cdfid);
+    return cdfid;
 } /* NC_open */
 
 int
@@ -301,10 +309,10 @@ nccreate(const char *path, int cmode)
     cdf_routine_name = "nccreate";
 
     if (cmode & NC_CREAT) {
-        return (NC_open(path, cmode));
+        return NC_open(path, cmode);
     }
     NCadvise(NC_EINVAL, "Bad Flag");
-    return (-1);
+    return -1;
 }
 
 int
@@ -314,9 +322,9 @@ ncopen(const char *path, int mode)
     cdf_routine_name = "ncopen";
     if (mode & NC_CREAT) {
         NCadvise(NC_EINVAL, "Bad Flag");
-        return (-1);
+        return -1;
     }
-    return (NC_open(path, mode));
+    return NC_open(path, mode);
 }
 
 int
@@ -328,23 +336,23 @@ ncsync(int cdfid)
 
     handle = NC_check_id(cdfid);
     if (handle == NULL)
-        return (-1);
+        return -1;
 
     if (handle->flags & NC_INDEF) {
         NCadvise(NC_EINDEFINE, "Unfinished definition");
-        return (-1);
+        return -1;
     }
 
     if (handle->flags & NC_RDWR) {
         handle->xdrs->x_op = XDR_ENCODE;
         if (handle->flags & NC_HDIRTY) {
             if (!xdr_cdf(handle->xdrs, &handle))
-                return (-1);
+                return -1;
             handle->flags &= ~(NC_NDIRTY | NC_HDIRTY);
         }
         else if (handle->flags & NC_NDIRTY) {
             if (!xdr_numrecs(handle->xdrs, handle))
-                return (-1);
+                return -1;
             if (handle->file_type != HDF_FILE)
                 handle->flags &= ~(NC_NDIRTY);
         }
@@ -361,15 +369,15 @@ ncsync(int cdfid)
             nc_serror("xdr_cdf");
             NC_free_cdf(handle); /* ?? what should we do now? */
 
-            return (-1);
+            return -1;
         }
         if (NC_computeshapes(handle) == -1)
-            return (-1);
+            return -1;
     }
 
     (void)NCxdrfile_sync(handle->xdrs);
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -389,7 +397,7 @@ ncabort(int cdfid)
 
     handle = NC_check_id(cdfid);
     if (handle == NULL)
-        return (-1);
+        return -1;
 
     flags = handle->flags; /* need to save past free_cdf */
 
@@ -404,22 +412,17 @@ ncabort(int cdfid)
             if (handle->redefid == _ncdf - 1)
                 _ncdf--;
             handle->redefid = -1;
-            _curr_opened--; /* one less file currently opened */
-
-            /* if the _cdf list is empty, deallocate and reset it to NULL */
-            if (_ncdf == 0)
-                ncreset_cdflist();
         }
     }
     else if (handle->flags & NC_RDWR) {
         handle->xdrs->x_op = XDR_ENCODE;
         if (handle->flags & NC_HDIRTY) {
             if (!xdr_cdf(handle->xdrs, &handle))
-                return (-1);
+                return -1;
         }
         else if (handle->flags & NC_NDIRTY) {
             if (!xdr_numrecs(handle->xdrs, handle))
-                return (-1);
+                return -1;
         }
     }
 
@@ -449,10 +452,10 @@ ncabort(int cdfid)
     _curr_opened--; /* one less file currently being opened */
 
     /* if the _cdf list is empty, deallocate and reset it to NULL */
-    if (_ncdf == 0)
+    if (_curr_opened == 0)
         ncreset_cdflist();
 
-    return (0);
+    return 0;
 } /* ncabort */
 
 /*
@@ -467,9 +470,9 @@ ncnobuf(int cdfid)
 
     handle = NC_check_id(cdfid);
     if (handle == NULL)
-        return (-1);
+        return -1;
     /* NOOP */
-    return (0);
+    return 0;
 }
 
 /*
@@ -552,23 +555,23 @@ ncredef(int cdfid)
 
     handle = NC_check_id(cdfid);
     if (handle == NULL)
-        return (-1);
+        return -1;
     if (handle->flags & NC_INDEF) /* in define mode already */
     {
         NC *stash = STASH(cdfid);
         if (stash)
             NCadvise(NC_EINDEFINE, "%s: in define mode already", stash->path);
-        return (-1);
+        return -1;
     }
     if (!(handle->flags & NC_RDWR)) {
         NCadvise(NC_EPERM, "%s: NC_NOWRITE", handle->path);
-        return (-1);
+        return -1;
     }
 
     if (handle->file_type == HDF_FILE) {
         handle->flags |= NC_INDEF;
         handle->redefid = TRUE;
-        return (0);
+        return 0;
     }
 
     /* find first available id */
@@ -579,7 +582,7 @@ ncredef(int cdfid)
     if (id == _ncdf && _ncdf >= max_NC_open) /* will need a new one */
     {
         NCadvise(NC_ENFILE, "maximum number of open cdfs %d exceeded", _ncdf);
-        return (-1);
+        return -1;
     }
 
     if (ncopts & NC_NOFILL) {
@@ -587,7 +590,7 @@ ncredef(int cdfid)
         handle->xdrs->x_op = XDR_ENCODE;
         if (handle->flags & NC_NDIRTY) {
             if (!xdr_numrecs(handle->xdrs, handle))
-                return (-1);
+                return -1;
             handle->flags &= ~(NC_NDIRTY);
         }
     }
@@ -596,7 +599,7 @@ ncredef(int cdfid)
 
     new = NC_dup_cdf(scratchfile, NC_NOCLOBBER, handle);
     if (new == NULL) {
-        return (-1);
+        return -1;
     }
 
     handle->flags |= NC_INDEF;
@@ -613,7 +616,7 @@ ncredef(int cdfid)
 
     new->redefid = id;
 
-    return (0);
+    return 0;
 }
 
 /*
@@ -690,10 +693,10 @@ NC_dcpy(XDR *target, XDR *source, long nbytes)
         goto err;
     if (!h4_xdr_putbytes(target, buf, nbytes))
         goto err;
-    return (TRUE);
+    return TRUE;
 err:
     NCadvise(NC_EXDR, "NC_dcpy");
-    return (FALSE);
+    return FALSE;
 }
 
 /*
@@ -708,10 +711,10 @@ NC_vcpy(XDR *target, NC *old, int varid)
 
     if (!h4_xdr_setpos(old->xdrs, (*vpp)->begin)) {
         NCadvise(NC_EXDR, "NC_vcpy: h4_xdr_setpos");
-        return (FALSE);
+        return FALSE;
     }
 
-    return (NC_dcpy(target, old->xdrs, (*vpp)->len));
+    return NC_dcpy(target, old->xdrs, (*vpp)->len);
 }
 
 /*
@@ -726,10 +729,10 @@ NC_reccpy(XDR *target, NC *old, int varid, int recnum)
 
     if (!h4_xdr_setpos(old->xdrs, (*vpp)->begin + old->recsize * recnum)) {
         NCadvise(NC_EXDR, "NC_reccpy: h4_xdr_setpos");
-        return (FALSE);
+        return FALSE;
     }
 
-    return (NC_dcpy(target, old->xdrs, (*vpp)->len));
+    return NC_dcpy(target, old->xdrs, (*vpp)->len);
 }
 
 /*
@@ -752,7 +755,7 @@ NC_endef(int cdfid, NC *handle)
 
     if (!xdr_cdf(xdrs, &handle)) {
         nc_serror("xdr_cdf");
-        return (-1);
+        return -1;
     }
 
     /* Get rid of the temporary buffer allocated for I/O */
@@ -760,7 +763,7 @@ NC_endef(int cdfid, NC *handle)
 
     if (handle->file_type == HDF_FILE) {
         handle->flags &= ~(NC_CREAT | NC_INDEF | NC_NDIRTY | NC_HDIRTY);
-        return (0);
+        return 0;
     }
 
     if (handle->vars == NULL)
@@ -776,13 +779,13 @@ NC_endef(int cdfid, NC *handle)
         if (!(handle->flags & NC_CREAT) && stash->vars != NULL && ii < stash->vars->count) {
             /* copy data */
             if (!NC_vcpy(xdrs, stash, ii))
-                return (-1);
+                return -1;
             continue;
         } /* else */
 
         if (!(handle->flags & NC_NOFILL))
             if (!xdr_NC_fill(xdrs, *vpp))
-                return (-1);
+                return -1;
     }
 
     if (!(handle->flags & NC_CREAT)) /* after redefinition */
@@ -796,17 +799,17 @@ NC_endef(int cdfid, NC *handle)
                 if (stash->vars != NULL && ii < stash->vars->count) {
                     /* copy data */
                     if (!NC_reccpy(xdrs, stash, ii, jj))
-                        return (-1);
+                        return -1;
                     continue;
                 } /* else */
                 if (!(handle->flags & NC_NOFILL))
                     if (!xdr_NC_fill(xdrs, *vpp))
-                        return (-1);
+                        return -1;
             }
         }
         handle->numrecs = stash->numrecs;
         if (!xdr_numrecs(handle->xdrs, handle))
-            return (-1);
+            return -1;
     }
 
     if (!(handle->flags & NC_CREAT)) /* redefine */
@@ -832,10 +835,10 @@ NC_endef(int cdfid, NC *handle)
             NC_free_cdf(handle);
 
             /* if the _cdf list is empty, deallocate and reset it to NULL */
-            if (_ncdf == 0)
+            if (_curr_opened == 0)
                 ncreset_cdflist();
 
-            return (-1);
+            return -1;
         }
         (void)strncpy(handle->path, realpath, FILENAME_MAX);
 #ifdef H4_HAVE_WIN32_API
@@ -850,13 +853,13 @@ NC_endef(int cdfid, NC *handle)
         handle->redefid = -1;
 
         /* if the _cdf list is empty, deallocate and reset it to NULL */
-        if (_ncdf == 0)
+        if (_curr_opened == 0)
             ncreset_cdflist();
     }
 
 done:
     handle->flags &= ~(NC_CREAT | NC_INDEF | NC_NDIRTY | NC_HDIRTY);
-    return (0);
+    return 0;
 }
 
 int
@@ -868,10 +871,10 @@ ncendef(int cdfid)
 
     handle = NC_check_id(cdfid);
     if (handle == NULL)
-        return (-1);
+        return -1;
     if (!NC_indefine(cdfid, TRUE))
-        return (-1);
-    return (NC_endef(cdfid, handle));
+        return -1;
+    return NC_endef(cdfid, handle);
 }
 
 /*
@@ -886,22 +889,22 @@ ncclose(int cdfid)
 
     handle = NC_check_id(cdfid);
     if (handle == NULL)
-        return (-1);
+        return -1;
 
     if (handle->flags & NC_INDEF) {
         if (NC_endef(cdfid, handle) == -1) {
-            return (ncabort(cdfid));
+            return ncabort(cdfid);
         }
     }
     else if (handle->flags & NC_RDWR) {
         handle->xdrs->x_op = XDR_ENCODE;
         if (handle->flags & NC_HDIRTY) {
             if (!xdr_cdf(handle->xdrs, &handle))
-                return (-1);
+                return -1;
         }
         else if (handle->flags & NC_NDIRTY) {
             if (!xdr_numrecs(handle->xdrs, handle))
-                return (-1);
+                return -1;
         }
     }
 
@@ -912,14 +915,17 @@ ncclose(int cdfid)
 
     _cdfs[cdfid] = NULL; /* reset pointer */
 
+    /* update water mark */
     if (cdfid == _ncdf - 1)
         _ncdf--;
-    _curr_opened--; /* one less file currently opened */
+
+    /* update number of files currently opened */
+    _curr_opened--;
 
     /* if the _cdf list is empty, deallocate and reset it to NULL */
-    if (_ncdf == 0)
+    if (_curr_opened == 0)
         ncreset_cdflist();
-    return (0);
+    return 0;
 }
 
 int
@@ -932,7 +938,7 @@ ncsetfill(int id, int fillmode)
 
     handle = NC_check_id(id);
     if (handle == NULL)
-        return (-1);
+        return -1;
 
     if (!(handle->flags & NC_RDWR)) {
         /* file isn't writable */
@@ -957,12 +963,12 @@ ncsetfill(int id, int fillmode)
                 handle->xdrs->x_op = XDR_ENCODE; /*  to the file */
             if (handle->flags & NC_HDIRTY) {
                 if (!xdr_cdf(handle->xdrs, &handle))
-                    return (-1);
+                    return -1;
                 handle->flags &= ~(NC_NDIRTY | NC_HDIRTY);
             }
             else if (handle->flags & NC_NDIRTY) {
                 if (!xdr_numrecs(handle->xdrs, handle))
-                    return (-1);
+                    return -1;
                 if (handle->file_type != HDF_FILE)
                     handle->flags &= ~(NC_NDIRTY);
             }

--- a/mfhdf/test/tfile.c
+++ b/mfhdf/test/tfile.c
@@ -48,7 +48,6 @@
 
 #define FILE_NAME "bug376.hdf" /* data file to test */
 #define DIM0      10
-static idlist[600];
 
 static intn
 test_file_inuse()
@@ -132,6 +131,7 @@ test_file_inuse()
 
     return num_errs;
 } /* test_file_inuse */
+
 /********************************************************************
    Name: test_max_open_files() - tests the new API SDreset_maxopenfiles,
                 SDget_maxopenfiles, SDget_numopenfiles,
@@ -174,6 +174,7 @@ test_file_inuse()
 #define NUM_FILES_LOW 35
 #define NUM_FILES_HI  1024
 
+static int
 test_max_open_files()
 {
     int32 fids[NUM_FILES_HI];         /* holds IDs of opened files */

--- a/mfhdf/test/tfile.c
+++ b/mfhdf/test/tfile.c
@@ -48,6 +48,7 @@
 
 #define FILE_NAME "bug376.hdf" /* data file to test */
 #define DIM0      10
+static idlist[600];
 
 static intn
 test_file_inuse()
@@ -131,7 +132,6 @@ test_file_inuse()
 
     return num_errs;
 } /* test_file_inuse */
-
 /********************************************************************
    Name: test_max_open_files() - tests the new API SDreset_maxopenfiles,
                 SDget_maxopenfiles, SDget_numopenfiles,
@@ -174,7 +174,6 @@ test_file_inuse()
 #define NUM_FILES_LOW 35
 #define NUM_FILES_HI  1024
 
-static int
 test_max_open_files()
 {
     int32 fids[NUM_FILES_HI];         /* holds IDs of opened files */
@@ -222,7 +221,7 @@ test_max_open_files()
     /* Get the current max and system limit */
     status = SDget_maxopenfiles(&curr_max, &sys_limit);
     CHECK(status, FAIL, "test_maxopenfiles: SDget_maxopenfiles");
-    VERIFY(curr_max, sys_limit, "test_maxopenfiles: SDreset_maxopenfiles");
+    VERIFY(curr_max, sys_limit, "test_maxopenfiles: SDget_maxopenfiles");
 
     /* Get the current max another way, it should be the system limit */
     curr_max = SDreset_maxopenfiles(0);
@@ -299,6 +298,7 @@ test_max_open_files()
         CHECK(status, FAIL, "test_maxopenfiles: SDend");
         remove(filename[index]);
     }
+
     return num_errs;
 }
 


### PR DESCRIPTION
- An if statement used the water mark variable instead of the number of opened files to determine when to release the list of file structs.  As a result, sometime the list was never released.  Fixed to use the correct variable.
- After that fix, some tests produced segfault because there was an extra call to release the list of file structs.  The extra code was removed.
- Other code tidying

This PR addressed GH-825