### PR TITLE
Fix failure in test_rank0

### DIFF
--- a/hdf/src/dfsd.c
+++ b/hdf/src/dfsd.c
@@ -735,6 +735,10 @@ DFSDsetdims(intn rank, int32 dimsizes[])
     if (Sfile_id != DF_NOFILE)
         HGOTO_ERROR(DFE_BADCALL, FAIL);
 
+    /* Disallow rank = 0 in DFSD API (see HDFFR-1291) */
+    if (rank == 0)
+        HGOTO_ERROR(DFE_ARGS, FAIL);
+
     if (Writesdg.rank == rank) /* check if dimensions same */
     {
         if (Writesdg.dimsizes) {

--- a/mfhdf/libsrc/hdfsds.c
+++ b/mfhdf/libsrc/hdfsds.c
@@ -1062,18 +1062,24 @@ hdf_read_ndgs(NC *handle)
                         if (err_code != DFE_NONE)
                             HGOTO_ERROR(err_code, FAIL);
 
-                        /* get space for dimensions */
-                        dimsizes = malloc((uint32)rank * sizeof(int32));
+                        /* get space for dimensions, variable dimensions, and scale types */
+                        if (rank > 0) {
+                            dimsizes = malloc((uint32)rank * sizeof(int32));
+                            vardims = malloc((uint32)rank * sizeof(intn));
+                            scaletypes = malloc((uint32)rank * sizeof(int32));
+                        }
+                        else {
+                            /* when rank = 0, use rank = 1, assuming the data is scalar */
+                            dimsizes = malloc(sizeof(int32));
+                            vardims = malloc(sizeof(intn));
+                            scaletypes = malloc(sizeof(int32));
+                        }
                         if (dimsizes == NULL) {
                             HGOTO_ERROR(DFE_NOSPACE, FAIL);
                         }
-
-                        vardims = malloc((uint32)rank * sizeof(intn));
                         if (vardims == NULL) {
                             HGOTO_ERROR(DFE_NOSPACE, FAIL);
                         }
-
-                        scaletypes = malloc((uint32)rank * sizeof(int32));
                         if (scaletypes == NULL) {
                             HGOTO_ERROR(DFE_NOSPACE, FAIL);
                         }

--- a/mfhdf/libsrc/hdfsds.c
+++ b/mfhdf/libsrc/hdfsds.c
@@ -1064,14 +1064,14 @@ hdf_read_ndgs(NC *handle)
 
                         /* get space for dimensions, variable dimensions, and scale types */
                         if (rank > 0) {
-                            dimsizes = malloc((uint32)rank * sizeof(int32));
-                            vardims = malloc((uint32)rank * sizeof(intn));
+                            dimsizes   = malloc((uint32)rank * sizeof(int32));
+                            vardims    = malloc((uint32)rank * sizeof(intn));
                             scaletypes = malloc((uint32)rank * sizeof(int32));
                         }
                         else {
                             /* when rank = 0, use rank = 1, assuming the data is scalar */
-                            dimsizes = malloc(sizeof(int32));
-                            vardims = malloc(sizeof(intn));
+                            dimsizes   = malloc(sizeof(int32));
+                            vardims    = malloc(sizeof(intn));
                             scaletypes = malloc(sizeof(int32));
                         }
                         if (dimsizes == NULL) {

--- a/mfhdf/libsrc/mfsd.c
+++ b/mfhdf/libsrc/mfsd.c
@@ -1092,7 +1092,11 @@ SDcreate(int32       fid,  /* IN: file ID */
     }
 
     /* make fake dimensions which may or may not be over-ridden later */
-    dims = malloc(rank * sizeof(intn));
+    if (rank > 0)
+        dims = malloc(rank * sizeof(intn));
+    else
+        /* when rank = 0, use rank = 1, assuming the data is scalar */
+        dims = malloc(sizeof(intn));
     if (dims == NULL) {
         HGOTO_ERROR(DFE_NOSPACE, FAIL);
     }

--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -1314,8 +1314,9 @@ main(void)
      * several functions when the SDS has rank=0. (in trank0.c) - 02/4/05 */
     /* BMR: SDcreate fails on Copper when rank=0.  EP decided to remove
      * this test until further study can be made on this feature.
+*/
     status = test_rank0();
-    num_errs = num_errs + status; */
+    num_errs = num_errs + status;
 
     /* Tests functionality related to SDS' properties (in tsdsprops.c) */
     status   = test_SDSprops();

--- a/mfhdf/test/hdftest.c
+++ b/mfhdf/test/hdftest.c
@@ -1314,8 +1314,8 @@ main(void)
      * several functions when the SDS has rank=0. (in trank0.c) - 02/4/05 */
     /* BMR: SDcreate fails on Copper when rank=0.  EP decided to remove
      * this test until further study can be made on this feature.
-*/
-    status = test_rank0();
+     */
+    status   = test_rank0();
     num_errs = num_errs + status;
 
     /* Tests functionality related to SDS' properties (in tsdsprops.c) */

--- a/mfhdf/test/trank0.c
+++ b/mfhdf/test/trank0.c
@@ -89,7 +89,7 @@ test_rank0()
     /**** Verify that SDwritedata succeeds when dataset has rank 0 ****/
 
     /* Initialize input buffer to write, and output buffer to verify the reading */
-    inbuf[0] = 99;
+    inbuf[0]  = 99;
     outbuf[0] = 0;
 
     /* Select the first dataset */


### PR DESCRIPTION
Followed the decision documented in HDFFR-1291 to fix the test with rank=0, and to prevent passing rank=0 into malloc calls.  Even though it is valid to do so, the behavior is implementation-defined.

This addressed GH-699.