### PR TITLE
Fixed SDgetcompinfo incorrect behavior

### DIFF
--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -143,14 +143,6 @@ funclist_t comp_funcs = {
 static int32
 HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type, comp_info *c_info)
 {
-    uint32 comp_config_info;
-
-    HCget_config_info(coder_type, &comp_config_info);
-    if ((comp_config_info & (COMP_DECODER_ENABLED | COMP_ENCODER_ENABLED)) == 0) {
-        /* coder not present */
-        HRETURN_ERROR(DFE_BADCODER, FAIL);
-    }
-
     switch (coder_type) {                        /* determine the type of encoding */
         case COMP_CODE_NONE:                     /* "none" (i.e. no) encoding */
             cinfo->coder_type  = COMP_CODE_NONE; /* set coding type */

--- a/hdf/src/hcomp.c
+++ b/hdf/src/hcomp.c
@@ -138,7 +138,7 @@ funclist_t comp_funcs = {
         this function somehow.  Yet, I'm not sure exactly how it should
         be added because this function is called in both cases, writing
         and reading.  At this time, the function will fail if it encounters
-        COMP_CODE_IMCOMP. -BMR, Jul 11, 2012
+        COMP_CODE_IMCOMP.
 --------------------------------------------------------------------------*/
 static int32
 HCIinit_coder(int16 acc_mode, comp_coder_info_t *cinfo, comp_coder_t coder_type, comp_info *c_info)

--- a/mfhdf/dumper/testfiles/dumpsds-15.out
+++ b/mfhdf/dumper/testfiles/dumpsds-15.out
@@ -79,7 +79,11 @@ Variable Name = SDSszip
 	 Type= 32-bit signed integer
 	 Ref. = 6
 	 Compression method = SZIP
-		 Compression information is unavailable (no SZIP library)
+		 Option mask = H4_SZ_EC_OPTION_MASK|H4_SZ_RAW_OPTION_MASK (132)
+		 Pixels per block = 2
+		 Pixels per scanline = 5
+		 Bits per pixel = 32
+		 Pixels = 80
 	 Compression ratio (original:compressed) = 2.67:1
 	 Rank = 2
 	 Number of attributes = 0


### PR DESCRIPTION
When SZIP library is not available, SDgetcompinfo() fails even though it only needs to retrieve compression metadata, not actually compress/decompress data. The function should succeed in returning compression information regardless of whether the SZIP library is present.

This PR removes check from HCIinit_coder() to allow metadata queries without the szip library.
Fixes #867 

Known issue: Reading szip-compressed data from files opened with DFACC_RDWR when only decoder is available may fail. This is a pre-existing architectural issue where file open mode is conflated with operation type. This issue turned out to be too complicated to include in this PR, it will be addressed in a future fix, GH #870.