### PR TITLE
Fixed double blank issue entries

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+


### PR DESCRIPTION
When New issue is clicked on, there are two entries of the blank issue options shown in the chooser.  That is because GitHub implicitly assumes blank_issues_enabled: true.  This PR added a config.yml file to explicitly tell GitHub not to use its own native "Open a blank issue" option.