### PR TITLE
Fix netCDF-cmake.yml workflow to enable dap_remote_tests only if server is responsive

### DIFF
--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -541,7 +541,7 @@ jobs:
   # Windows w/ OneAPI + CMake
   #
     name: "Windows Intel CTest"
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [check-secret]
     steps:
       - name: Install Dependencies (Windows_intel)

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -326,7 +326,7 @@ jobs:
   # Windows w/ OneAPI + CMake
   #
     name: "Windows Intel CTest"
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Install Dependencies (Windows_intel)
         run: choco install ninja

--- a/.github/workflows/intel-cmake.yml
+++ b/.github/workflows/intel-cmake.yml
@@ -73,7 +73,7 @@ jobs:
 
   Intel_oneapi_windows:
     name: "windows-oneapi ${{ inputs.build_mode }}"
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Get Sources (Windows)
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -12,6 +12,16 @@ on:
         description: "shared true/false"
         required: true
         type: string
+      win_runner:
+        description: "Windows runner version to use (windows-2022, windows-latest, etc.)"
+        required: false
+        default: "windows-latest"
+        type: string
+      win_vs_generator:
+        description: "CMake generator to use for Visual Studio"
+        required: false
+        default: "Visual Studio 18 2026"
+        type: string
 
 permissions:
   contents: read
@@ -35,7 +45,8 @@ jobs:
           - "MacOS Clang"
 
         # This is where we list the bulk of the options for each configuration.
-        # The key-value pair values are usually appropriate for being CMake.
+        # The key-value pair values are usually appropriate for being CMake
+        # configure values, so be aware of that.
 
         include:
 
@@ -43,7 +54,7 @@ jobs:
           #
           # No Fortran or parallel
           - name: "Windows MSVC"
-            os: windows-latest
+            os: ${{ inputs.win_runner }}
             toolchain: ""
             fortran: OFF
             java: ON
@@ -52,7 +63,7 @@ jobs:
             locallibaec: OFF
             localzlib: OFF
             cacheinit: "-C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake"
-            generator: "-G \"Visual Studio 17 2022\" -A x64"
+            generator: "-G \"${{ inputs.win_vs_generator }}\" -A x64"
             run_tests: true
 
           # Linux (Ubuntu) w/ gcc + CMake

--- a/.github/workflows/netcdf-cmake.yml
+++ b/.github/workflows/netcdf-cmake.yml
@@ -105,10 +105,24 @@ jobs:
         repository: unidata/netcdf-c
         path: netcdf-c
 
+    - name: Check DAP4 remote test server
+      id: check_dap4_server
+      run: |
+        if curl --silent --max-time 10 --head "http://remotetest.unidata.ucar.edu/d4ts" | grep -q "200\|301\|302"; then
+          echo "dap4_remote=ON" >> $GITHUB_OUTPUT
+        else
+          echo "dap4_remote=OFF" >> $GITHUB_OUTPUT
+        fi
+
+
     - name: Test netCDF
       run: |
         mkdir "netcdf-c/build"
         cd "netcdf-c/build"
-        cmake .. -DUILD_SHARED_LIBS=ON -DNETCDF_ENABLE_HDF4=ON -DNETCDF_ENABLE_HDF5=ON
+        cmake .. \
+          -DBUILD_SHARED_LIBS=ON \
+          -DNETCDF_ENABLE_HDF4=ON \
+          -DNETCDF_ENABLE_HDF5=ON \
+          -DNETCDF_ENABLE_DAP_REMOTE_TESTS=${{ steps.check_dap4_server.outputs.dap4_remote }}
         make
         make test

--- a/.github/workflows/ppc64.yml
+++ b/.github/workflows/ppc64.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
+      - name: Download JPEG source tarball
+        run: wget -q https://www.ijg.org/files/jpegsrc.v9e.tar.gz
+
       - uses: uraimo/run-on-arch-action@v3
         name: Run commands
         id: runcmd
@@ -53,7 +56,7 @@ jobs:
                 -DHDF4_BUILD_FORTRAN=OFF \
                 -DHDF4_BUILD_JAVA=OFF \
                 -DHDF4_BUILD_DOC=OFF \
-                -DJPEG_USE_LOCALCONTENT=OFF \
+                -DJPEG_USE_LOCALCONTENT=ON \
                 -DLIBAEC_USE_LOCALCONTENT=OFF \
                 -DZLIB_USE_LOCALCONTENT=OFF \
                 -DHDF4_PACK_EXAMPLES:BOOL=ON \

--- a/.github/workflows/ppc64.yml
+++ b/.github/workflows/ppc64.yml
@@ -21,8 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - name: Download JPEG source tarball
-        run: wget -q https://www.ijg.org/files/jpegsrc.v9e.tar.gz
+      - name: Download external library source tarballs
+        run: |
+          wget -q https://www.ijg.org/files/jpegsrc.v9e.tar.gz
+          wget -q https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
+          wget -q https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3/libaec-1.1.3.tar.gz
 
       - uses: uraimo/run-on-arch-action@v3
         name: Run commands
@@ -58,8 +61,8 @@ jobs:
                 -DHDF4_BUILD_DOC=OFF \
                 -DJPEG_USE_LOCALCONTENT=ON \
                 -DTGZPATH=${{ github.workspace }} \
-                -DLIBAEC_USE_LOCALCONTENT=OFF \
-                -DZLIB_USE_LOCALCONTENT=OFF \
+                -DLIBAEC_USE_LOCALCONTENT=ON \
+                -DZLIB_USE_LOCALCONTENT=ON \
                 -DHDF4_PACK_EXAMPLES:BOOL=ON \
                 -DHDF4_PACKAGE_EXTLIBS:BOOL=ON \
                 ..

--- a/.github/workflows/ppc64.yml
+++ b/.github/workflows/ppc64.yml
@@ -57,6 +57,7 @@ jobs:
                 -DHDF4_BUILD_JAVA=OFF \
                 -DHDF4_BUILD_DOC=OFF \
                 -DJPEG_USE_LOCALCONTENT=ON \
+                -DTGZPATH=${{ github.workspace }} \
                 -DLIBAEC_USE_LOCALCONTENT=OFF \
                 -DZLIB_USE_LOCALCONTENT=OFF \
                 -DHDF4_PACK_EXAMPLES:BOOL=ON \


### PR DESCRIPTION
Otherwise those tests fail.  They pass if the server is responsive.