### PR TITLE
Disable the 2 netCDF tests using an inconsistently available DAP4 server.

### DIFF
--- a/.github/workflows/netcdf-cmake.yml
+++ b/.github/workflows/netcdf-cmake.yml
@@ -105,16 +105,6 @@ jobs:
         repository: unidata/netcdf-c
         path: netcdf-c
 
-    - name: Check DAP4 remote test server
-      id: check_dap4_server
-      run: |
-        if curl --silent --max-time 10 --head "http://remotetest.unidata.ucar.edu/d4ts" | grep -q "200\|301\|302"; then
-          echo "dap4_remote=ON" >> $GITHUB_OUTPUT
-        else
-          echo "dap4_remote=OFF" >> $GITHUB_OUTPUT
-        fi
-
-
     - name: Test netCDF
       run: |
         mkdir "netcdf-c/build"
@@ -123,6 +113,6 @@ jobs:
           -DBUILD_SHARED_LIBS=ON \
           -DNETCDF_ENABLE_HDF4=ON \
           -DNETCDF_ENABLE_HDF5=ON \
-          -DNETCDF_ENABLE_DAP_REMOTE_TESTS=${{ steps.check_dap4_server.outputs.dap4_remote }}
+          -DNETCDF_ENABLE_DAP_REMOTE_TESTS=OFF
         make
         make test


### PR DESCRIPTION
The 2 disabled tests are netCDF tests that aren't testing any hdf4 code.  The server vacillated between responsive and unresponsive;  when slow to respond the tests would fail,  which happened for a significant percentage of test runs.