### PR TITLE
Fix memory leak and segfault from out-of-order NC file closure

### DIFF
--- a/hdf/src/hchunks.c
+++ b/hdf/src/hchunks.c
@@ -2357,6 +2357,9 @@ HMCgetdatasize(int32 file_id, uint8 *p, /* IN: access id of header info */
         if (VSdetach(chktab_id) == FAIL)
             HGOTO_ERROR(DFE_CANTENDACCESS, FAIL);
 
+        if (Vend(file_id) == FAIL)
+            HGOTO_ERROR(DFE_CANTFLUSH, FAIL);
+
     } /* it is a vdata */
     else
         HGOTO_ERROR(DFE_INTERNAL, FAIL);

--- a/hdf/src/vhi.c
+++ b/hdf/src/vhi.c
@@ -151,7 +151,7 @@ int32
 VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *vgname, const char *vgclass)
 {
     int32 ref, i;
-    int32 vg;
+    int32 vg = FAIL;
     int32 ret_value = SUCCEED;
 
     if ((vg = Vattach(f, -1, "w")) == FAIL)
@@ -177,6 +177,8 @@ VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *
     ret_value = (ref);
 
 done:
+    if (vg != FAIL)
+        Vdetach(vg);
     return ret_value;
 } /* VHmakegroup */
 

--- a/hdf/src/vhi.c
+++ b/hdf/src/vhi.c
@@ -151,7 +151,7 @@ int32
 VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *vgname, const char *vgclass)
 {
     int32 ref, i;
-    int32 vg = FAIL;
+    int32 vg        = FAIL;
     int32 ret_value = SUCCEED;
 
     if ((vg = Vattach(f, -1, "w")) == FAIL)

--- a/mfhdf/src/file.c
+++ b/mfhdf/src/file.c
@@ -80,6 +80,11 @@ ncreset_cdflist(void)
         _cdfs      = NULL;
         _cdfs_size = 0;
     }
+    
+    /* Reset the high-water marks completely */
+    _ncdf = 0; 
+    _curr_opened = 0; 
+    
     return 0;
 }
 
@@ -113,7 +118,7 @@ NC_reset_maxopenfiles(int req_max)
         else
             _cdfs_size = req_max;
 
-        _cdfs = malloc(sizeof(NC *) * (size_t)_cdfs_size);
+        _cdfs = calloc((size_t)_cdfs_size, sizeof(NC *));
 
         /* If allocation fails, return with failure */
         if (_cdfs == NULL) {
@@ -123,9 +128,6 @@ NC_reset_maxopenfiles(int req_max)
             HGOTO_DONE(-1);
         }
         else {
-            for (i = 0; i < _cdfs_size; i++)
-                _cdfs[i] = NULL;
-
             /* Reset current max files opened allowed in HDF to the new max */
             max_NC_open = _cdfs_size;
 
@@ -389,7 +391,7 @@ ncabort(int cdfid)
                 _curr_opened--; /* one less file currently opened */
 
                 /* if the _cdf list is empty, deallocate and reset it to NULL */
-                if (_ncdf == 0)
+                if (_curr_opened == 0)
                     if (ncreset_cdflist() == -1) {
                         fprintf(stderr, "unable to reset _cdfs list\n");
                         return -1;
@@ -436,7 +438,7 @@ ncabort(int cdfid)
     _curr_opened--; /* one less file currently being opened */
 
     /* if the _cdf list is empty, deallocate and reset it to NULL */
-    if (_ncdf == 0)
+    if (_curr_opened == 0)
         if (ncreset_cdflist() == -1) {
             fprintf(stderr, "unable to reset _cdfs list\n");
             return -1;
@@ -660,7 +662,7 @@ NC_endef(int cdfid, NC *handle)
             NC_free_cdf(handle);
 
             /* if the _cdf list is empty, deallocate and reset it to NULL */
-            if (_ncdf == 0)
+            if (_curr_opened == 0)
                 if (ncreset_cdflist() == -1) {
                     fprintf(stderr, "unable to reset _cdfs list\n");
                     return -1;
@@ -681,7 +683,7 @@ NC_endef(int cdfid, NC *handle)
         handle->redefid = -1;
 
         /* if the _cdf list is empty, deallocate and reset it to NULL */
-        if (_ncdf == 0)
+        if (_curr_opened == 0)
             ncreset_cdflist();
     }
 

--- a/mfhdf/src/file.c
+++ b/mfhdf/src/file.c
@@ -80,11 +80,11 @@ ncreset_cdflist(void)
         _cdfs      = NULL;
         _cdfs_size = 0;
     }
-    
+
     /* Reset the high-water marks completely */
-    _ncdf = 0; 
-    _curr_opened = 0; 
-    
+    _ncdf        = 0;
+    _curr_opened = 0;
+
     return 0;
 }
 


### PR DESCRIPTION
When opened files were closed in different order than when they were created, segfault and memory leaks occurred.

The global variables
`static int  _curr_opened = 0; `   /* the number of files currently opened \*/
`static int  _ncdf        = 0; `   /* high water mark on open cdf's */
are used to track open files, but they diverge under out-of-order closure: `_curr_opened` correctly drops to `0`, while
`_ncdf` does not. A prior memory leak fix changed the teardown check from `_curr_opened == 0` to `_ncdf == 0`, so teardown
never fires in this case — leaking the `_cdfs` allocation and leaving stale handles that skip validation, causing a segfault later.

This PR reverts the previous change to check `_curr_opened == 0` and resets `_ncdf` and `_curr_opened` to 0 in `ncreset_cdflist` on teardown, which would have been correct in the previous fix.

The fix has been verified with an out-of-order LIFO file-closure program under Valgrind.

Fixes #862