### PR TITLE
Set buf to NULL after free in vconv vimakecompat.

### DIFF
--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -222,6 +222,7 @@ vimakecompat(HFILEID f)
         ret = Hputelement(f, VGDESCTAG, ref, (uint8 *)buf, bsize);
         free(buf);
         buf = NULL;
+
         if (ret == FAIL)
             HRETURN_ERROR(DFE_WRITEERROR, 0);
 

--- a/hdf/src/vconv.c
+++ b/hdf/src/vconv.c
@@ -221,6 +221,7 @@ vimakecompat(HFILEID f)
 
         ret = Hputelement(f, VGDESCTAG, ref, (uint8 *)buf, bsize);
         free(buf);
+        buf = NULL;
         if (ret == FAIL)
             HRETURN_ERROR(DFE_WRITEERROR, 0);
 


### PR DESCRIPTION
I think `vimakecompat`  can be simplified more, but this is the smallest change possible to avoid a possible double free situation.