### PR TITLE
Fix stack buffer overflow in Vgetname/Vgetclass/Vinquire

### DIFF
--- a/HDF4Examples/C/VG/h4ex_VG_get_vgroup_info.c
+++ b/HDF4Examples/C/VG/h4ex_VG_get_vgroup_info.c
@@ -65,25 +65,25 @@ main()
              * moving to the next.
              */
             vgroup_id = Vattach(file_id, ref_array[lone_vg_number], "r");
-            if (Vgetnamelen(vgroup_id, &name_len) == FAIL)
-                printf("*** ERROR from Vgetnamelen\n");
+            if ((name_len = Vgetname(vgroup_id, 0, NULL)) == FAIL)
+                printf("*** ERROR from Vgetname to get length of vgroup name\n");
             vgroup_name = (char *)malloc(sizeof(char *) * (name_len + 1));
             if (vgroup_name == NULL) {
                 fprintf(stderr, "Not enough memory for vgroup_name!\n");
                 exit(1);
             }
-            if (Vgetname(vgroup_id, vgroup_name) == FAIL)
-                printf("*** ERROR from Vgetname\n");
+            if (Vgetname(vgroup_id, name_len + 1, vgroup_name) == FAIL)
+                printf("*** ERROR from Vgetname to get vgroup name\n");
 
-            if (Vgetclassnamelen(vgroup_id, &name_len) == FAIL)
-                printf("*** ERROR from Vgetclassnamelen\n");
+            if ((name_len = Vgetclass(vgroup_id, 0, NULL)) == FAIL)
+                printf("*** ERROR from Vgetclass to get length of vgroup class\n");
             vgroup_class = (char *)malloc(sizeof(char *) * (name_len + 1));
             if (vgroup_class == NULL) {
                 fprintf(stderr, "Not enough memory for vgroup_class!\n");
                 exit(1);
             }
-            if (Vgetclass(vgroup_id, vgroup_class) == FAIL)
-                printf("*** ERROR from Vgetclass\n");
+            if (Vgetclass(vgroup_id, name_len + 1, vgroup_class) == FAIL)
+                printf("*** ERROR from Vgetclass to get vgroup class\n");
             fprintf(stderr, "   Vgroup name %s and class %s\n", vgroup_name, vgroup_class);
             if (Vdetach(vgroup_id) == FAIL)
                 printf("*** ERROR from Vdetach\n");

--- a/hdf/src/hdf.h
+++ b/hdf/src/hdf.h
@@ -20,6 +20,7 @@
 #include "h4config.h"
 
 #include <inttypes.h>
+#include <stddef.h> /* for ptrdiff_t, used as a portable substitute for POSIX ssize_t */
 
 /* Library limits */
 #include "hlimits.h"

--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -1402,15 +1402,11 @@ HDFLIBAPI int32 Vgetid(HFILEID f, int32 vgid);
 
 HDFLIBAPI int32 Vgetnext(int32 vkey, int32 id);
 
-HDFLIBAPI int32 Vgetname(int32 vkey, char *vgname);
+HDFLIBAPI ssize_t Vgetname(int32 vkey, size_t buf_size, char *vgname);
 
-HDFLIBAPI int32 Vgetnamelen(int32 vkey, uint16 *name_len);
+HDFLIBAPI ssize_t Vgetclass(int32 vkey, size_t buf_size, char *vgclass);
 
-HDFLIBAPI int32 Vgetclassnamelen(int32 vkey, uint16 *classname_len);
-
-HDFLIBAPI int32 Vgetclass(int32 vkey, char *vgclass);
-
-HDFLIBAPI int Vinquire(int32 vkey, int32 *nentries, char *vgname);
+HDFLIBAPI ssize_t Vinquire(int32 vkey, int32 *nentries, size_t buf_size, char *vgname);
 
 HDFLIBAPI int32 Vdelete(int32 f, int32 ref);
 

--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -1402,11 +1402,12 @@ HDFLIBAPI int32 Vgetid(HFILEID f, int32 vgid);
 
 HDFLIBAPI int32 Vgetnext(int32 vkey, int32 id);
 
-HDFLIBAPI ssize_t Vgetname(int32 vkey, size_t buf_size, char *vgname);
+/* ptrdiff_t used below as a portable, standard-C substitute for POSIX ssize_t */
+HDFLIBAPI ptrdiff_t Vgetname(int32 vkey, size_t buf_size, char *vgname);
 
-HDFLIBAPI ssize_t Vgetclass(int32 vkey, size_t buf_size, char *vgclass);
+HDFLIBAPI ptrdiff_t Vgetclass(int32 vkey, size_t buf_size, char *vgclass);
 
-HDFLIBAPI ssize_t Vinquire(int32 vkey, int32 *nentries, size_t buf_size, char *vgname);
+HDFLIBAPI ptrdiff_t Vinquire(int32 vkey, int32 *nentries, size_t buf_size, char *vgname);
 
 HDFLIBAPI int32 Vdelete(int32 f, int32 ref);
 

--- a/hdf/src/hproto_fortran.h
+++ b/hdf/src/hproto_fortran.h
@@ -944,11 +944,11 @@ HDFFCLIBAPI intf nvatchc(intf *f, intf *vgid, _fcd accesstype);
 
 HDFFCLIBAPI intf nvdtchc(intf *vkey);
 
-HDFFCLIBAPI intf nvgnamc(intf *vkey, _fcd vgname);
+HDFFCLIBAPI intf nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen);
 
-HDFFCLIBAPI intf nvgclsc(intf *vkey, _fcd vgclass);
+HDFFCLIBAPI intf nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen);
 
-HDFFCLIBAPI intf nvinqc(intf *vkey, intf *nentries, _fcd vgname);
+HDFFCLIBAPI intf nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen);
 
 HDFFCLIBAPI intf nvdeletec(intf *f, intf *vkey);
 

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -621,8 +621,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 switch (grp_tag) {
                     case DFTAG_VG: /* should be an image */
                         if ((img_key = Vattach(file_id, grp_ref, "r")) != FAIL) {
-                            char *class      = NULL;
-                            ssize_t buf_size = 0;
+                            char     *class    = NULL;
+                            ptrdiff_t buf_size = 0; /* portable substitute for POSIX ssize_t */
 
                             /* If unable to get class len, release vg, move on to next vg */
                             if ((buf_size = Vgetclass(img_key, 0, NULL)) == FAIL) {
@@ -847,7 +847,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                     uint8      GRtbuf[64];                /* local buffer for reading RIG info */
 
                     if ((img_key = Vattach(file_id, (int32)img_info[i].grp_ref, "r")) != FAIL) {
-                        ssize_t buf_size;
+                        ptrdiff_t buf_size;
                         if ((new_image = (ri_info_t *)malloc(sizeof(ri_info_t))) == NULL) {
                             free(img_info); /* free offsets */
                             Hclose(file_id);

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -621,7 +621,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 switch (grp_tag) {
                     case DFTAG_VG: /* should be an image */
                         if ((img_key = Vattach(file_id, grp_ref, "r")) != FAIL) {
-                            char     *class    = NULL;
+                            char *class        = NULL;
                             ptrdiff_t buf_size = 0; /* portable substitute for POSIX ssize_t */
 
                             /* If unable to get class len, release vg, move on to next vg */

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -561,7 +561,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
     int32      nri, nci, nri8, nci8, nii8, nvg; /* number of RIs, CIs, RI8s, CI8s & II8s & Vgroups */
     uint16     find_tag, find_ref;              /* storage for tag/ref pairs found */
     int32      find_off, find_len;              /* storage for offset/lengths of tag/refs found */
-    imginfo_t *img_info;                        /* image info list */
+    int32      img_key  = FAIL;                 /* Vgroup key of an image */
+    imginfo_t *img_info = NULL;                 /* image info list */
     int        i, j;                            /* local counting variable */
     int        ret_value = SUCCEED;
 
@@ -609,7 +610,6 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
         gr_ptr->gr_ref = gr_ref; /* squirrel this away for later use */
         if ((gr_key = Vattach(file_id, (int32)gr_ref, "r")) != FAIL) {
             int32 nobjs = Vntagrefs(gr_key); /* The number of objects in the Vgroup */
-            int32 img_key;                   /* Vgroup key of an image */
             int32 grp_tag, grp_ref;          /* a tag/ref in the Vgroup */
             int32 img_tag, img_ref;          /* image tag/ref in the Vgroup */
             char  textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
@@ -621,11 +621,24 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 switch (grp_tag) {
                     case DFTAG_VG: /* should be an image */
                         if ((img_key = Vattach(file_id, grp_ref, "r")) != FAIL) {
-                            if (Vgetclass(img_key, textbuf) != FAIL) {
-                                if (!strcmp(textbuf, RI_NAME)) { /* it is an image, get the image's tag/ref */
+                            char *class      = NULL;
+                            ssize_t buf_size = 0;
+
+                            /* If unable to get class len, release vg, move on to next vg */
+                            if ((buf_size = Vgetclass(img_key, 0, NULL)) == FAIL) {
+                                Vdetach(img_key);
+                                continue;
+                            }
+                            if ((class = (char *)malloc(sizeof(char) * (buf_size + 1))) == NULL) {
+                                Vdetach(img_key);
+                                HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                            }
+                            if (Vgetclass(img_key, (size_t)buf_size + 1, class) != FAIL) {
+                                if (!strcmp(class, RI_NAME)) { /* it is an image, get the image's tag/ref */
                                     for (j = 0; j < Vntagrefs(img_key); j++) {
-                                        if (Vgettagref(img_key, j, &img_tag, &img_ref) == FAIL)
+                                        if (Vgettagref(img_key, j, &img_tag, &img_ref) == FAIL) {
                                             continue;
+                                        }
                                         /* Make sure the tag is correct, then
                                            store the image's info and the
                                            tag/ref of the vgroup that represents
@@ -643,6 +656,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                 }         /* end if */
                             }             /* end if */
                             Vdetach(img_key);
+                            free(class);
                         }      /* end if */
                         break; /* case DFTAG_VG, an image */
 
@@ -701,6 +715,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                         /* increment the number of GR global attributes */
                         gr_ptr->gattr_count++;
+
                     } /* end case DFTAG_VH, a global attribute */
                     break;
 
@@ -826,14 +841,13 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 case DFTAG_VG: /* New style raster image, found in a Vgroup */
                 {
                     ri_info_t *new_image;                 /* ptr to the image to read in */
-                    int32      img_key;                   /* Vgroup key of an image */
                     int32      img_tag, img_ref;          /* image tag/ref in the Vgroup */
                     char       textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
                     uint8      ntstring[4];               /* buffer to store NT info */
                     uint8      GRtbuf[64];                /* local buffer for reading RIG info */
 
                     if ((img_key = Vattach(file_id, (int32)img_info[i].grp_ref, "r")) != FAIL) {
-                        uint16 name_len;
+                        ssize_t buf_size;
                         if ((new_image = (ri_info_t *)malloc(sizeof(ri_info_t))) == NULL) {
                             free(img_info); /* free offsets */
                             Hclose(file_id);
@@ -844,11 +858,11 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                         memset(new_image, 0, sizeof(ri_info_t));
 
                         /* Get the name of the image */
-                        if (Vgetnamelen(img_key, &name_len) == FAIL)
-                            name_len = 20; /* for "Raster Image #%d" */
-                        if ((new_image->name = (char *)malloc(name_len + 1)) == NULL)
+                        if ((buf_size = Vgetname(img_key, 0, NULL)) == FAIL)
+                            buf_size = 20; /* for "Raster Image #%d" */
+                        if ((new_image->name = (char *)malloc(buf_size + 1)) == NULL)
                             HGOTO_ERROR(DFE_NOSPACE, FAIL);
-                        if (Vgetname(img_key, new_image->name) == FAIL)
+                        if (Vgetname(img_key, (size_t)buf_size + 1, new_image->name) == FAIL)
                             sprintf(new_image->name, "Raster Image #%d", (int)i);
 
                         /* Initialize the local attribute tree */
@@ -1033,7 +1047,9 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                         new_image->gr_ptr = gr_ptr;                /* point up the tree */
                         tbbtdins(gr_ptr->grtree, new_image, NULL); /* insert the new image into B-tree */
                         gr_ptr->gr_count++;
-                        Vdetach(img_key);
+                        if (Vdetach(img_key) == FAIL)
+                            HGOTO_ERROR(DFE_CANTDETACH, FAIL);
+                        img_key = FAIL;
                     } /* end if */
                 }     /* end case DFTAG_VG */
                 break;
@@ -1271,6 +1287,11 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
     free(img_info); /* free image info structures */
 
 done:
+    if (ret_value == FAIL) {
+        Vdetach(img_key);
+        free(img_info); /* free image info structures */
+    }
+
     return ret_value;
 } /* end GRIget_image_list() */
 
@@ -1780,8 +1801,6 @@ GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr)
 {
     int32 GroupID; /* RI vgroup id */
     int   ret_value = SUCCEED;
-    int32 temp_ref; /* used to hold the returned value from a function
-                            that may return a ref or a FAIL - BMR */
 
     HEclear();
     if (!HDvalidfid(hdf_file_id) || img_ptr == NULL)
@@ -1799,7 +1818,8 @@ GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr)
     /* grab the ref. # of the new Vgroup */
     if (img_ptr->ri_ref == DFREF_WILDCARD) {
         /* due to uint16 type of ref, check return value of VQueryref
-             and assign it to ri_ref only when it's not FAIL - BMR */
+             and assign it to ri_ref only when it's not FAIL */
+        int32 temp_ref;
         temp_ref = VQueryref(GroupID);
         if (temp_ref == FAIL)
             HGOTO_ERROR(DFE_BADREF, FAIL);
@@ -1947,8 +1967,6 @@ GRend(int32 grid)
     filerec_t *file_rec;    /* File record */
     void     **t1;
     int        ret_value = SUCCEED;
-    int32      temp_ref; /* used to hold the returned value from a function
-                                 that may return a ref or a FAIL - BMR */
 
     /* clear error stack and check validity of file id */
     HEclear();
@@ -1970,6 +1988,7 @@ GRend(int32 grid)
     if (((file_rec->access) & DFACC_WRITE) != 0) {
         /* Check if the GR group exists, and create it if not */
         if (gr_ptr->gr_ref == DFREF_WILDCARD) {
+            int32 temp_ref;
             if ((GroupID = Vattach(gr_ptr->hdf_file_id, -1, "w")) == FAIL)
                 HGOTO_ERROR(DFE_CANTATTACH, FAIL);
 
@@ -2232,8 +2251,7 @@ GRcreate(int32 grid, const char *name, int32 ncomp, int32 nt, int32 il, int32 di
     gr_info_t *gr_ptr;  /* ptr to the GR information for this grid */
     ri_info_t *ri_ptr;  /* ptr to the image to work with */
     int32      ret_value = SUCCEED;
-    int32      temp_ref; /* used to hold the returned value from a function
-                                 that may return a ref or a FAIL - BMR */
+    int32      temp_ref;
 
     /* clear error stack */
     HEclear();

--- a/hdf/src/vg_priv.h
+++ b/hdf/src/vg_priv.h
@@ -255,6 +255,10 @@ HDFLIBAPI vginstance_t *vginst(HFILEID f, uint16 vgid);
 
 HDFLIBAPI DYN_VWRITELIST *vswritelist(int32 vskey);
 
+HDFLIBAPI char *vgetvgname(int32 vkey);
+
+HDFLIBAPI char *vgetvgclass(int32 vkey);
+
 HDFLIBAPI int vpackvg(VGROUP *vg, uint8 buf[], int32 *size);
 
 HDFLIBAPI int32 vinsertpair(VGROUP *vg, uint16 tag, uint16 ref);

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -143,9 +143,21 @@ nvdtchc(intf *vkey)
  */
 
 intf
-nvgnamc(intf *vkey, _fcd vgname)
+nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
 {
-    return Vgetname(*vkey, _fcdtocp(vgname));
+    char   *tvgname;
+    ssize_t len;
+
+    tvgname = (char *)malloc(*vgnamelen + 1);
+    if (!tvgname)
+        HRETURN_ERROR(DFE_NOSPACE, FAIL);
+
+    len = Vgetname((int32)*vkey, (size_t)(*vgnamelen + 1), tvgname);
+    if (len != FAIL)
+        HDpackFstring(tvgname, _fcdtocp(vgname), (int)*vgnamelen);
+
+    free(tvgname);
+    return (len == FAIL) ? FAIL : SUCCEED;
 } /* VGNAMC */
 
 /* ------------------------------------------------------------------ */
@@ -155,9 +167,21 @@ nvgnamc(intf *vkey, _fcd vgname)
  */
 
 intf
-nvgclsc(intf *vkey, _fcd vgclass)
+nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 {
-    return Vgetclass(*vkey, _fcdtocp(vgclass));
+    char   *tvgclass;
+    ssize_t len;
+
+    tvgclass = (char *)malloc(*vgclasslen + 1);
+    if (!tvgclass)
+        HRETURN_ERROR(DFE_NOSPACE, FAIL);
+
+    len = Vgetclass((int32)*vkey, (size_t)(*vgclasslen + 1), tvgclass);
+    if (len != FAIL)
+        HDpackFstring(tvgclass, _fcdtocp(vgclass), (int)*vgclasslen);
+
+    free(tvgclass);
+    return (len == FAIL) ? FAIL : SUCCEED;
 } /* VGCLSC */
 
 /* ------------------------------------------------------------------ */
@@ -167,9 +191,24 @@ nvgclsc(intf *vkey, _fcd vgclass)
  */
 
 intf
-nvinqc(intf *vkey, intf *nentries, _fcd vgname)
+nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen)
 {
-    return (intf)Vinquire(*vkey, (int32 *)nentries, _fcdtocp(vgname));
+    char   *tvgname;
+    int32   tnentries;
+    ssize_t len;
+
+    tvgname = (char *)malloc(*vgnamelen + 1);
+    if (!tvgname)
+        HRETURN_ERROR(DFE_NOSPACE, FAIL);
+
+    len = Vinquire((int32)*vkey, &tnentries, (size_t)(*vgnamelen + 1), tvgname);
+    if (len != FAIL) {
+        *nentries = (intf)tnentries;
+        HDpackFstring(tvgname, _fcdtocp(vgname), (int)*vgnamelen);
+    }
+
+    free(tvgname);
+    return (len == FAIL) ? FAIL : SUCCEED;
 } /* VINQC */
 
 /* ------------------------------------------------------------------ */

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -145,8 +145,8 @@ nvdtchc(intf *vkey)
 intf
 nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
 {
-    char   *tvgname;
-    ssize_t len;
+    char     *tvgname;
+    ptrdiff_t len; /* portable substitute for POSIX ssize_t */
 
     tvgname = (char *)malloc(*vgnamelen + 1);
     if (!tvgname)
@@ -169,8 +169,8 @@ nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
 intf
 nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 {
-    char   *tvgclass;
-    ssize_t len;
+    char     *tvgclass;
+    ptrdiff_t len;
 
     tvgclass = (char *)malloc(*vgclasslen + 1);
     if (!tvgclass)
@@ -193,9 +193,9 @@ nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 intf
 nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen)
 {
-    char   *tvgname;
-    int32   tnentries;
-    ssize_t len;
+    char     *tvgname;
+    int32     tnentries;
+    ptrdiff_t len;
 
     tvgname = (char *)malloc(*vgnamelen + 1);
     if (!tvgname)

--- a/hdf/src/vgff.f
+++ b/hdf/src/vgff.f
@@ -57,7 +57,7 @@ c	related: Vgetname--vgnamc--VFGNAM
       character*(*)   vgname
       integer         vgnamc
 
-      vfgnam = vgnamc (vg, vgname)
+      vfgnam = vgnamc (vg, vgname, len(vgname))
       end
 c	------------------------------------------------------------
 c	get the class name of a vgroup
@@ -69,7 +69,7 @@ c	related: Vgetclass--vgclsc--VFGCLS
       character*(*)   vgclass
       integer       vgclsc
 
-      vfgcls = vgclsc  (vg, vgclass)
+      vfgcls = vgclsc  (vg, vgclass, len(vgclass))
       end
 c   ------------------------------------------------------------
 c	general inquiry on a vgroup
@@ -80,7 +80,7 @@ c	related: Vinquire--vinqc--VFINQ
       character*(*)   vgname
       integer   vinqc
 
-      vfinq = vinqc (vg, nentries, vgname)
+      vfinq = vinqc (vg, nentries, vgname, len(vgname))
       end
 
 c   ------------------------------------------------------------

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -2559,14 +2559,15 @@ RETURNS
    Length of vgroup name / FAIL
 
 *******************************************************************************/
-ssize_t
+/* ptrdiff_t used here as a portable, standard-C substitute for POSIX ssize_t */
+ptrdiff_t
 Vgetname(int32  vkey,     /* IN: vgroup key */
          size_t buf_size, /* IN: name buffer size */
          char  *vgname /* OUT: vgroup name */)
 {
     VGROUP *vg        = NULL;
     size_t  name_len  = 0;
-    ssize_t ret_value = SUCCEED;
+    ptrdiff_t ret_value = SUCCEED;
 
     /* Clear error stack */
     HEclear();
@@ -2584,7 +2585,7 @@ Vgetname(int32  vkey,     /* IN: vgroup key */
 
     /* If vgname is NULL or buf_size is 0, return the length of the name */
     if (vgname == NULL || buf_size == 0)
-        HGOTO_DONE((ssize_t)name_len);
+        HGOTO_DONE((ptrdiff_t)name_len);
 
     /* Copy vgroup name, truncating if necessary */
     if (vg->vgname != NULL) {
@@ -2594,7 +2595,7 @@ Vgetname(int32  vkey,     /* IN: vgroup key */
     else
         vgname[0] = '\0';
 
-    ret_value = (ssize_t)name_len;
+    ret_value = (ptrdiff_t)name_len;
 
 done:
     return ret_value;
@@ -2616,14 +2617,14 @@ RETURNS
    Length of the class's name / FAIL
 
 *******************************************************************************/
-ssize_t
+ptrdiff_t
 Vgetclass(int32  vkey,     /* IN: vgroup key */
           size_t buf_size, /* IN: class buffer size */
           char  *vgclass /* OUT: vgroup class */)
 {
     VGROUP *vg        = NULL;
     size_t  class_len = 0;
-    ssize_t ret_value = SUCCEED;
+    ptrdiff_t ret_value = SUCCEED;
 
     /* Clear error stack */
     HEclear();
@@ -2641,7 +2642,7 @@ Vgetclass(int32  vkey,     /* IN: vgroup key */
 
     /* If vgclass is NULL or buf_size is 0, return the length of the class */
     if (vgclass == NULL || buf_size == 0)
-        HGOTO_DONE((ssize_t)class_len);
+        HGOTO_DONE((ptrdiff_t)class_len);
 
     /* Copy vgroup class, truncating if necessary */
     if (vg->vgclass != NULL) {
@@ -2651,7 +2652,7 @@ Vgetclass(int32  vkey,     /* IN: vgroup key */
     else
         vgclass[0] = '\0';
 
-    ret_value = (ssize_t)class_len;
+    ret_value = (ptrdiff_t)class_len;
 
 done:
     return ret_value;
@@ -2674,7 +2675,7 @@ RETURNS
     The length of the vgroup name / FAIL on failure
 
 *******************************************************************************/
-ssize_t
+ptrdiff_t
 Vinquire(int32  vkey,     /* IN: vgroup key */
          int32 *nentries, /* OUT: number of entries in vgroup */
          size_t buf_size, /* IN: size of vgname buffer */
@@ -2682,7 +2683,7 @@ Vinquire(int32  vkey,     /* IN: vgroup key */
 {
     VGROUP *vg        = NULL;
     size_t  name_len  = 0;
-    ssize_t ret_value = SUCCEED;
+    ptrdiff_t ret_value = SUCCEED;
 
     /* Clear error stack */
     HEclear();
@@ -2704,7 +2705,7 @@ Vinquire(int32  vkey,     /* IN: vgroup key */
 
     /* If vgname is NULL or buf_size is 0, return the length of the name */
     if (vgname == NULL || buf_size == 0)
-        HGOTO_DONE((ssize_t)name_len);
+        HGOTO_DONE((ptrdiff_t)name_len);
 
     /* Copy vgroup name, truncating if necessary */
     if (vg->vgname != NULL) {
@@ -2714,7 +2715,7 @@ Vinquire(int32  vkey,     /* IN: vgroup key */
     else
         vgname[0] = '\0';
 
-    ret_value = (ssize_t)name_len;
+    ret_value = (ptrdiff_t)name_len;
 
 done:
     return ret_value;

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -29,6 +29,7 @@ LOCAL ROUTINES
  New_vfile    -- create new vgroup file record
  Load_vfile   -- loads vgtab table with info of all vgroups in file.
  Remove_vfile -- removes the file ptr from the vfile[] table.
+ VIGet_vgdesc -- get and verify the vgroup
 
  VPgetinfo  --  Read in the "header" information about the Vgroup.
  VIstart    --  V-level initialization routine
@@ -36,7 +37,7 @@ LOCAL ROUTINES
 
 EXPORTED ROUTINES
 =================
- Following 4 routines are solely for B-tree routines.
+ Following 5 routines are solely for B-tree routines.
  vcompare     -- Compares two TBBT-tree keys for equality.  Similar to memcmp.
  vprint       -- Prints out the key and reference number of VDatas and Vgroups
  vdestroynode -- destroy vgroup node in TBBT
@@ -49,6 +50,8 @@ EXPORTED ROUTINES
  vginstance   -- Looks thru vgtab for vgid and return the addr of the vg
                   instance where vgid is found.
  vexistvg     -- Tests if a vgroup with id "vgid" is in the file's vgtab.
+ vgetvgname   -- Returns the name of a vgroup
+ vgetvgclass  -- Returns the class of a vgroup
  vpackvg      -- Extracts fields from a VGROUP struct "vg" and packs the
                   fields into array buf in preparation for storage in the
                   HDF file.
@@ -73,19 +76,17 @@ EXPORTED ROUTINES
  Vaddtagref   -- Inserts a tag/ref pair into the attached vgroup vg.
  vinsertpair  -- Inserts a tag/ref pair into the attached vgroup vg.
  Ventries     -- Returns the num of entries (+ve integer) in the vgroup vgid.
- Vsetname     -- Gives a name to the VGROUP vg.
- Vsetclass    -- Assigns a class name to the VGROUP vg.
+ Vsetname     -- Gives a name to the Vgroup vg.
+ Vsetclass    -- Assigns a class name to the Vgroup vg.
  Visvg        -- Tests if the given entry in the vgroup vg is a VGROUP.
  Visvs        -- Checks if an id in a vgroup refers to a VDATA.
  Vgetid       -- Given a vgroup's id, returns the next vgroup's id in the file.
  Vgetnext     -- Given the id of an entry from a vgroup vg, looks in vg
                   for the next entry after it, and returns its id.
- Vgetnamelen  -- Retrieves the length of the vgroup's name.
- Vgetclassnamelen  -- Retrieves the length of the vgroup's classname.
  Vgetname     -- Returns the vgroup's name.
- Vgetclass    -- Returns the vgroup's class name .
+ Vgetclass    -- Returns the vgroup's class.
  Vgetvgroups  -- Gets user-created vgroups in a file or in a vgroup
- Vinquire     -- General inquiry routine for VGROUP.
+ Vinquire     -- General inquiry routine for Vgroup.
  Vopen        -- This routine opens the HDF file and initializes it for
                   Vset operations.(i.e." Hopen(); Vinitialize(f)").
  Vclose       -- This routine closes the HDF file, after it has freed
@@ -95,9 +96,6 @@ EXPORTED ROUTINES
                   remove the Vgoup from the internal Vset data structures
                   as well as from the file.
  Vdeletetagref - delete tag/ref pair in Vgroup
-
- NOTE: Another pass needs to made through this file to update some of
-       the comments about certain sections of the code. -GV 9/8/97
 
 *************************************************************************/
 
@@ -237,6 +235,39 @@ done:
     return ret_value;
 } /* VIget_vginstance_node */
 
+/*******************************************************************************
+ NAME
+    VIget_vgdesc -- get and verify the vgroup
+
+ DESCRIPTION
+    Return a pointer to a VGROUP for subsequent accesses of the vgroup.
+
+ RETURNS
+    VGROUP record pointer or NULL if failed.
+
+*******************************************************************************/
+VGROUP *
+VIGet_vgdesc(int32 vkey /* IN: vgroup key */)
+{
+
+    vginstance_t *v         = NULL;
+    VGROUP       *vg        = NULL;
+    VGROUP       *ret_value = NULL;
+
+    /* get and verify the vgroup */
+    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
+        HGOTO_ERROR(DFE_NOVS, NULL);
+    vg = v->vg;
+    if (vg == NULL)
+        HGOTO_ERROR(DFE_BADPTR, NULL);
+    if (vg->otag != DFTAG_VG)
+        HGOTO_ERROR(DFE_ARGS, NULL);
+
+    ret_value = vg;
+done:
+    return ret_value;
+}
+
 /******************************************************************************
  NAME
     VIrelease_vginstance_node -- Releases a vginstance node
@@ -321,8 +352,7 @@ DESCRIPTION
    Will allocate a new vfile_t, then proceed to load vg instances.
 
 RETURNS
-   RETURNS FAIL if error or no more file slots available.
-   RETURNS SUCCEED if ok.
+   Returns SUCCEED if ok, FAIL if error or no more file slots available.
 
 *******************************************************************************/
 static int
@@ -372,7 +402,7 @@ Load_vfile(HFILEID f /* IN: file handle */)
 
     ret = aid = Hstartread(f, DFTAG_VG, DFREF_WILDCARD);
     while (ret != FAIL) {
-        /* get tag/ref for this vgroup */
+        /* get tag/ref for this Vgroup */
         HQuerytagref(aid, &tag, &ref);
 
         /* get a vgroup struct to fill */
@@ -398,8 +428,10 @@ Load_vfile(HFILEID f /* IN: file handle */)
         ret = Hnextread(aid, DFTAG_VG, DFREF_WILDCARD, DF_CURRENT);
     }
 
-    if (aid != FAIL)
+    if (aid != FAIL) {
         Hendaccess(aid);
+        aid = FAIL;
+    }
 
     /* clear error stack - this is to remove the faux errors about DD not
        found from when Hstartread is called on a new file */
@@ -445,8 +477,10 @@ Load_vfile(HFILEID f /* IN: file handle */)
         ret = Hnextread(aid, VSDESCTAG, DFREF_WILDCARD, DF_CURRENT);
     }
 
-    if (aid != FAIL)
+    if (aid != FAIL) {
         Hendaccess(aid);
+        aid = FAIL;
+    }
 
     /* clear error stack - this is to remove the faux errors about DD not
        found from when Hstartread is called on a new file */
@@ -462,6 +496,10 @@ Load_vfile(HFILEID f /* IN: file handle */)
     }
 
 done:
+    if (ret_value == FAIL) {
+        if (aid != FAIL)
+            Hendaccess(aid);
+    }
     return ret_value;
 } /* Load_vfile */
 
@@ -474,6 +512,7 @@ DESCRIPTION
    *** Only called by Vfinish() ***
 
 RETURNS
+    SUCCEED / FAIL
 
 *******************************************************************************/
 static int
@@ -525,6 +564,7 @@ DESCRIPTION
    *** Only called by B-tree routines, should _not_ be called externally ***
 
 RETURNS
+    Negative if k1 < k2, zero if equal, positive if k1 > k2.
 
 *******************************************************************************/
 int
@@ -699,8 +739,7 @@ DESCRIPTION
    where vgid is found.
 
 RETURNS
-   RETURNS NULL if error or not found.
-   RETURNS vginstance_t pointer if ok.
+   Returns vginstance_t pointer if found, and NULL if error or not found.
 
 *******************************************************************************/
 vginstance_t *
@@ -742,8 +781,7 @@ DESCRIPTION
    Tests if a vgroup with id vgid is in the file's vgtab.
 
 RETURNS
-   returns FAIL if not found,
-   returns TRUE if found.
+   Returns TRUE if found, otherwise FAIL.
 
 *******************************************************************************/
 int32
@@ -759,6 +797,108 @@ vexistvg(HFILEID f, /* IN: file handle */
 
     return ret_value;
 } /* vexistvg */
+
+/*******************************************************************************
+NAME
+   vgetvgclass
+
+DESCRIPTION
+   A utility function that returns the class of a vgroup, allocating the buffer
+   internally so the caller does not need to know the length of the class in
+   advance.  Intended for use within the library and tools only; the caller is
+   responsible for freeing the returned buffer.
+
+RETURNS
+   If successful, returns the vgroup's class, which can be an empty string if
+   there is no class. Otherwise, returns NULL.
+
+*******************************************************************************/
+char *
+vgetvgclass(int32 vkey)
+{
+    VGROUP *vg        = NULL;
+    size_t  class_len = 0;
+    char   *vgclass   = NULL;
+    char   *ret_value = NULL;
+
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP)
+        HGOTO_ERROR(DFE_ARGS, NULL);
+
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
+        HGOTO_ERROR(DFE_BADPTR, NULL);
+
+    /* Get length of vgroup class and allocate memory for it */
+    class_len = (vg->vgclass != NULL) ? strlen(vg->vgclass) : 0;
+    vgclass   = (char *)malloc(class_len + 1);
+    if (!vgclass)
+        HGOTO_ERROR(DFE_NOSPACE, NULL);
+
+    /* Copy vgroup name or set it null-terminated */
+    if (class_len > 0)
+        strcpy(vgclass, vg->vgclass);
+    else
+        vgclass[0] = '\0';
+
+    ret_value = vgclass;
+
+done:
+    if (ret_value == NULL)
+        free(vgclass);
+    return ret_value;
+}
+
+/*******************************************************************************
+NAME
+   vgetvgname
+
+DESCRIPTION
+   A utility function that returns the name of a vgroup, allocating the buffer
+   internally so the caller does not need to know the length of the name in
+   advance.  Intended for use within the library and tools only; the caller is
+   responsible for freeing the returned buffer.
+
+RETURNS
+   If successful, returns the vgroup's name, which can be an empty string if
+   there is no name. Otherwise, returns NULL.
+
+*******************************************************************************/
+char *
+vgetvgname(int32 vkey)
+{
+    VGROUP *vg        = NULL;
+    size_t  name_len  = 0;
+    char   *vgname    = NULL;
+    char   *ret_value = NULL;
+
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP)
+        HGOTO_ERROR(DFE_ARGS, NULL);
+
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
+        HGOTO_ERROR(DFE_BADPTR, NULL);
+
+    /* Get length of vgroup name and allocate memory for it */
+    name_len = (vg->vgname != NULL) ? strlen(vg->vgname) : 0;
+    vgname   = (char *)malloc(name_len + 1);
+    if (!vgname)
+        HGOTO_ERROR(DFE_NOSPACE, NULL);
+
+    /* Copy vgroup name or set it null-terminated */
+    if (name_len > 0)
+        strcpy(vgname, vg->vgname);
+    else
+        vgname[0] = '\0';
+
+    ret_value = vgname;
+
+done:
+    if (ret_value == NULL)
+        free(vgname);
+    return ret_value;
+}
 
 /* ==================================================================== */
 /*
@@ -2034,13 +2174,13 @@ NAME
    Vsetname
 
 DESCRIPTION
-   gives a name to the VGROUP vg.
+   Assigns a name to the vgroup vkey.
 
 RETURNS
     RETURN VALUES: SUCCEED/FAIL
 
 *******************************************************************************/
-int32
+int
 Vsetname(int32       vkey, /* IN: vgroup key */
          const char *vgname /* IN: name to set for vgroup */)
 {
@@ -2093,16 +2233,16 @@ NAME
    Vsetclass
 
 DESCRIPTION
-    Assigns a class name to the VGROUP vg.
+    Assigns a class name to the vgroup vkey
 
 RETURNS
-    RETURN VALUES: SUCCEED for success, FAIL for failure
+    SUCCEED/FAIL
 
 MODIFICATION
     2010/01/26 No longer truncates classname to max length of VGNAMELENMAX.
 
 *******************************************************************************/
-int32
+int
 Vsetclass(int32       vkey, /* IN: vgroup key */
           const char *vgclass /* IN: class to set for vgroup */)
 {
@@ -2405,144 +2545,56 @@ done:
 
 /*******************************************************************************
 NAME
-   Vgetnamelen
+   Vgetname - Retrieves the vgroup's name
 
 DESCRIPTION
-   Retrieves the length of the vgroup's name.
+    Retrieves the name of a vgroup. When vgname is NULL or buf_size is 0,
+    the function returns the length of the vgroup name without copying.
+    Otherwise, up to buf_size-1 characters are copied into vgname followed
+    by a null terminator. If the name is longer than buf_size-1 characters,
+    it will be truncated. The actual name length is returned on success,
+    or FAIL on failure.
 
 RETURNS
-   Returns SUCCEED/FAIL
-   BMR - 2006/09/10
+   Length of vgroup name / FAIL
 
 *******************************************************************************/
-int32
-Vgetnamelen(int32   vkey, /* IN: vgroup key */
-            uint16 *name_len /* OUT: length of vgroup's name */)
+ssize_t
+Vgetname(int32  vkey,     /* IN: vgroup key */
+         size_t buf_size, /* IN: name buffer size */
+         char  *vgname /* OUT: vgroup name */)
 {
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
+    VGROUP *vg        = NULL;
+    size_t  name_len  = 0;
+    ssize_t ret_value = SUCCEED;
 
-    /* clear error stack */
+    /* Clear error stack */
     HEclear();
 
-    /* check if vgroup is valid and the vgname */
+    /* Check arguments */
     if (HAatom_group(vkey) != VGIDGROUP)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
-    /*
-     * Obtain the name length
-     */
+    /* Get the length of the vgroup name */
+    name_len = (vg->vgname != NULL) ? strlen(vg->vgname) : 0;
 
-    if (vg->vgname == NULL)
-        /* if there is no name... */
-        *name_len = 0;
-    else
-        /* if name had been set... */
-        *name_len = (uint16)strlen(vg->vgname);
+    /* If vgname is NULL or buf_size is 0, return the length of the name */
+    if (vgname == NULL || buf_size == 0)
+        HGOTO_DONE((ssize_t)name_len);
 
-done:
-    return ret_value;
-} /* Vgetnamelen */
-
-/*******************************************************************************
-NAME
-   Vgetclassnamelen
-
-DESCRIPTION
-   Retrieves the length of the vgroup's name.
-
-RETURNS
-   Returns SUCCEED/FAIL
-   BMR - 2006/09/10
-
-*******************************************************************************/
-int32
-Vgetclassnamelen(int32   vkey, /* IN: vgroup key */
-                 uint16 *classname_len /* OUT: length of vgroup's classname */)
-{
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
-
-    /* clear error stack */
-    HEclear();
-
-    /* check if vgroup is valid and the vgname */
-    if (HAatom_group(vkey) != VGIDGROUP)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
-        HGOTO_ERROR(DFE_BADPTR, FAIL);
-
-    /* obtain the class name length */
-    if (vg->vgclass == NULL)
-        *classname_len = 0;
-    else
-        /* if name had been set... */
-        *classname_len = (uint16)strlen(vg->vgclass);
-
-done:
-    return ret_value;
-} /* Vgetclassnamelen */
-
-/*******************************************************************************
-NAME
-   Vgetname
-
-DESCRIPTION
-   returns the vgroup's name
-   ASSUME that vgname has been allocated large enough to hold
-   the name
-
-RETURNS
-   SUCCEED / FAIL
-
-*******************************************************************************/
-int32
-Vgetname(int32 vkey, /* IN: vgroup key */
-         char *vgname /* IN/OUT: vgroup name */)
-{
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
-
-    /* clear error stack */
-    HEclear();
-
-    /* check if vgroup is valid and the vgname */
-    if (HAatom_group(vkey) != VGIDGROUP || vgname == NULL)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
-        HGOTO_ERROR(DFE_BADPTR, FAIL);
-
-    /* copy vgroup name over if it had been set */
-    if (vg->vgname != NULL)
-        strcpy(vgname, vg->vgname);
+    /* Copy vgroup name, truncating if necessary */
+    if (vg->vgname != NULL) {
+        strncpy(vgname, vg->vgname, buf_size - 1);
+        vgname[buf_size - 1] = '\0';
+    }
     else
         vgname[0] = '\0';
+
+    ret_value = (ssize_t)name_len;
 
 done:
     return ret_value;
@@ -2550,46 +2602,56 @@ done:
 
 /*******************************************************************************
 NAME
-   Vgetclass
+   Vgetclass - Retrieves the vgroup's class
 
 DESCRIPTION
-   returns the vgroup's class name
-   ASSUME that vgclass has been allocated large enough to hold
-   the name
+    Retrieves the class of a vgroup. When vgclass is NULL or buf_size is 0,
+    the function returns the length of the class without copying. Otherwise,
+    up to buf_size-1 characters are copied into vgclass followed by a null
+    terminator. If the class name is longer than buf_size-1 characters, it
+    will be truncated. The actual class name length is returned on success,
+    or FAIL on failure.
 
 RETURNS
-   SUCCEED/FAIL
+   Length of the class's name / FAIL
 
 *******************************************************************************/
-int32
-Vgetclass(int32 vkey, /* IN: vgroup key */
-          char *vgclass /* IN/OUT: vgroup class */)
+ssize_t
+Vgetclass(int32  vkey,     /* IN: vgroup key */
+          size_t buf_size, /* IN: class buffer size */
+          char  *vgclass /* OUT: vgroup class */)
 {
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
+    VGROUP *vg        = NULL;
+    size_t  class_len = 0;
+    ssize_t ret_value = SUCCEED;
 
-    /* clear error stack */
+    /* Clear error stack */
     HEclear();
 
-    /* check if vgroup is valid and also vgroup class */
-    if (HAatom_group(vkey) != VGIDGROUP || vgclass == NULL)
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
-    /* copy class over if it had been set */
-    if (vg->vgclass != NULL)
-        strcpy(vgclass, vg->vgclass);
+    /* Get the length of the vgroup class */
+    class_len = (vg->vgclass != NULL) ? strlen(vg->vgclass) : 0;
+
+    /* If vgclass is NULL or buf_size is 0, return the length of the class */
+    if (vgclass == NULL || buf_size == 0)
+        HGOTO_DONE((ssize_t)class_len);
+
+    /* Copy vgroup class, truncating if necessary */
+    if (vg->vgclass != NULL) {
+        strncpy(vgclass, vg->vgclass, buf_size - 1);
+        vgclass[buf_size - 1] = '\0';
+    }
     else
         vgclass[0] = '\0';
+
+    ret_value = (ssize_t)class_len;
 
 done:
     return ret_value;
@@ -2597,55 +2659,62 @@ done:
 
 /*******************************************************************************
 NAME
-   Vinquire
+   Vinquire - General inquiry routine for vgroup
 
 DESCRIPTION
-   General inquiry routine for VGROUP.
-   output parameters:
-         nentries - no of entries in the vgroup
-         vgname  - the vgroup's name
+   Returns the length of the vgroup name on success, or FAIL on failure.
+   If vgname is NULL or buf_size is 0, only the name length is returned without
+   copying.
+
+   Output parameters:
+      nentries - no of entries in the vgroup
+      vgname  - the vgroup's name
 
 RETURNS
-   RETURNS FAIL if error
-   RETURNS SUCCEED if ok
+    The length of the vgroup name / FAIL on failure
 
 *******************************************************************************/
-int
+ssize_t
 Vinquire(int32  vkey,     /* IN: vgroup key */
-         int32 *nentries, /* IN/OUT: number of entries in vgroup */
-         char  *vgname /* IN/OUT: vgroup name */)
+         int32 *nentries, /* OUT: number of entries in vgroup */
+         size_t buf_size, /* IN: size of vgname buffer */
+         char  *vgname /* OUT: vgroup name */)
 {
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int           ret_value = SUCCEED;
+    VGROUP *vg        = NULL;
+    size_t  name_len  = 0;
+    ssize_t ret_value = SUCCEED;
 
-    /* clear error stack */
+    /* Clear error stack */
     HEclear();
 
-    /* check if vgroup is valid */
+    /* Check argument */
     if (HAatom_group(vkey) != VGIDGROUP)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
-    /* check tag of vgroup */
-    if (vg->otag != DFTAG_VG)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* copy vgroup name if requested.  Assumes 'vgname' has sufficient space */
-    if (vgname != NULL)
-        strcpy(vgname, vg->vgname);
-
-    /* set number of entries in vgroup if requested */
+    /* Get the number of entries in vgroup, if requested */
     if (nentries != NULL)
         *nentries = (int32)vg->nvelt;
+
+    /* Get the length of the vgroup name */
+    name_len = (vg->vgname != NULL) ? strlen(vg->vgname) : 0;
+
+    /* If vgname is NULL or buf_size is 0, return the length of the name */
+    if (vgname == NULL || buf_size == 0)
+        HGOTO_DONE((ssize_t)name_len);
+
+    /* Copy vgroup name, truncating if necessary */
+    if (vg->vgname != NULL) {
+        strncpy(vgname, vg->vgname, buf_size - 1);
+        vgname[buf_size - 1] = '\0';
+    }
+    else
+        vgname[0] = '\0';
+
+    ret_value = (ssize_t)name_len;
 
 done:
     return ret_value;
@@ -2664,8 +2733,6 @@ DESCRIPTION
    This routine opens the HDF file and initializes it for Vset operations.
 
    See also Vclose().
-
-   By: Jason Ng 10 Aug 92
 
 RETURNS
     RETURN VALUE:
@@ -3019,9 +3086,10 @@ Vgetvgroups(int32    id,       /* IN: file id or vgroup id */
             uint16  *refarray /* IN/OUT: ref array to fill */)
 {
     vginstance_t *vg_inst = NULL;
+    VGROUP       *vg      = NULL;
     int32         vg_ref;
-    int           nactual_vgs, user_vgs, ii;
-    VGROUP       *vg        = NULL;
+    unsigned      nactual_vgs, user_vgs;
+    int           ii;
     int           ret_value = SUCCEED;
 
     /* Clear error stack */
@@ -3158,7 +3226,7 @@ Vgetvgroups(int32    id,       /* IN: file id or vgroup id */
            number of user-created vgroups, otherwise, return the number of
            vgroups that are actually stored in refarray */
         if (refarray == NULL)
-            ret_value = user_vgs - (int)start_vg;
+            ret_value = (int)(user_vgs - start_vg);
         else
             ret_value = nactual_vgs;
     } /* vgroup id is given */

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -2565,8 +2565,8 @@ Vgetname(int32  vkey,     /* IN: vgroup key */
          size_t buf_size, /* IN: name buffer size */
          char  *vgname /* OUT: vgroup name */)
 {
-    VGROUP *vg        = NULL;
-    size_t  name_len  = 0;
+    VGROUP   *vg        = NULL;
+    size_t    name_len  = 0;
     ptrdiff_t ret_value = SUCCEED;
 
     /* Clear error stack */
@@ -2622,8 +2622,8 @@ Vgetclass(int32  vkey,     /* IN: vgroup key */
           size_t buf_size, /* IN: class buffer size */
           char  *vgclass /* OUT: vgroup class */)
 {
-    VGROUP *vg        = NULL;
-    size_t  class_len = 0;
+    VGROUP   *vg        = NULL;
+    size_t    class_len = 0;
     ptrdiff_t ret_value = SUCCEED;
 
     /* Clear error stack */
@@ -2681,8 +2681,8 @@ Vinquire(int32  vkey,     /* IN: vgroup key */
          size_t buf_size, /* IN: size of vgname buffer */
          char  *vgname /* OUT: vgroup name */)
 {
-    VGROUP *vg        = NULL;
-    size_t  name_len  = 0;
+    VGROUP   *vg        = NULL;
+    size_t    name_len  = 0;
     ptrdiff_t ret_value = SUCCEED;
 
     /* Clear error stack */

--- a/hdf/src/vhi.c
+++ b/hdf/src/vhi.c
@@ -154,7 +154,7 @@ int32
 VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *vgname, const char *vgclass)
 {
     int32 ref, i;
-    int32 vg        = FAIL;
+    int32 vg;
     int32 ret_value = SUCCEED;
 
     if ((vg = Vattach(f, -1, "w")) == FAIL)
@@ -180,8 +180,9 @@ VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *
     ret_value = (ref);
 
 done:
-    if (vg != FAIL)
+    if (ret_value == FAIL && vg != FAIL)
         Vdetach(vg);
+
     return ret_value;
 } /* VHmakegroup */
 

--- a/hdf/test/bitio.c
+++ b/hdf/test/bitio.c
@@ -445,7 +445,6 @@ test_bitio(void)
     test_bitio_write();
     test_bitio_seek();
 
-done:
     /* Release resources */
     free(outbuf);
     free(inbuf);

--- a/hdf/test/tvnameclass.c
+++ b/hdf/test/tvnameclass.c
@@ -206,13 +206,13 @@ done:
 static void
 test_undefined(void)
 {
-    int32   status;         /* Status values from routines */
-    int32   file_id = FAIL; /* File ID */
-    int32   vg1     = FAIL; /* Vdata ID */
-    int32   ref;            /* Vdata ref */
-    int     is_internal;    /* to test Vgisinternal */
-    ssize_t name_len;       /* Length of a vgroup's name or class name */
-    char   *vgname = NULL, *vgclass = NULL;
+    int32     status;         /* Status values from routines */
+    int32     file_id = FAIL; /* File ID */
+    int32     vg1     = FAIL; /* Vdata ID */
+    int32     ref;            /* Vdata ref */
+    int       is_internal;    /* to test Vgisinternal */
+    ptrdiff_t name_len;       /* Length of a vgroup's name or class name (portable ssize_t substitute) */
+    char     *vgname = NULL, *vgclass = NULL;
 
     /* Open the HDF file. */
     file_id = Hopen(NONAMECLASS, DFACC_CREATE, 0);

--- a/hdf/test/tvnameclass.c
+++ b/hdf/test/tvnameclass.c
@@ -33,7 +33,7 @@ test_vglongnames(void)
     int32  file_id = FAIL; /* File ID */
     int32  vg1     = FAIL; /* Vdata ID */
     int32  ref;            /* Vdata ref */
-    uint16 name_len;       /* Length of a vgroup's name or class name */
+    size_t buf_size = 0;   /* Size for name or class buffer */
     char  *vgname = NULL, *vgclass = NULL;
     int    is_internal;
     int32  status; /* Status values from routines */
@@ -101,29 +101,33 @@ test_vglongnames(void)
     CHECK(is_internal, FAIL, "Vgisinternal");
     VERIFY(is_internal, FALSE, "Vgisinternal");
 
-    /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    /* Get the vgroup's name */
+    buf_size = Vgetname(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetname");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size = Vgetname(vg1, buf_size + 1, vgname);
+    CHECK(buf_size, FAIL, "Vgetname:vg1");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vgetname");
     VERIFY_CHAR(vgname, VG_LONGNAME, "Vgetname");
 
     free(vgname);
     vgname = NULL;
 
-    /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    /* Get the vgroup's class */
+    buf_size = Vgetclass(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetclass");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size = Vgetclass(vg1, buf_size + 1, vgclass);
+    CHECK(buf_size, FAIL, "Vgetclass:vg1");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
     VERIFY_CHAR(vgclass, VG_LONGCLASS, "Vgetclass");
 
     free(vgclass);
@@ -140,40 +144,40 @@ test_vglongnames(void)
     vg1 = Vattach(file_id, ref, "r");
     CHECK(vg1, FAIL, "VSattach");
 
-    /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    /* Get the vgroup's name */
+    buf_size = Vgetname(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetname");
+    VERIFY(buf_size, strlen(VGROUP1), "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size = Vgetname(vg1, buf_size + 1, vgname);
+    CHECK(buf_size, FAIL, "Vgetname:vg1");
+    VERIFY(buf_size, strlen(VGROUP1), "Vgetname");
+    VERIFY_CHAR(vgname, VGROUP1, "Vgetname");
 
-    if (strcmp(vgname, VGROUP1)) {
-        num_errs++;
-        printf(">>> Got bogus Vgroup name : %s\n", vgname);
-    }
+    /* Should have the same class */
+    buf_size = Vgetclass(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetclass");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
 
-    free(vgname);
-    vgname = NULL;
-
-    /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
-
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size = Vgetclass(vg1, buf_size + 1, vgclass);
+    CHECK(buf_size, FAIL, "Vgetclass:vg1");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
+    VERIFY_CHAR(vgclass, VG_LONGCLASS, "Vgetclass");
 
     if (strcmp(vgclass, VG_LONGCLASS)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
+    free(vgname);
     free(vgclass);
+    vgname  = NULL;
     vgclass = NULL;
 
     status = Vdetach(vg1);
@@ -202,14 +206,13 @@ done:
 static void
 test_undefined(void)
 {
-    int32  status;         /* Status values from routines */
-    int32  file_id = FAIL; /* File ID */
-    int32  vg1     = FAIL; /* Vdata ID */
-    int32  ref;            /* Vdata ref */
-    int    is_internal;    /* to test Vgisinternal */
-    uint16 name_len;       /* Length of a vgroup's name or class name */
-    /* to simulate calls to Vgetclass/Vgetname in older applications */
-    char vgname[VGNAMELENMAX + 1], vgclass[VGNAMELENMAX + 1];
+    int32   status;         /* Status values from routines */
+    int32   file_id = FAIL; /* File ID */
+    int32   vg1     = FAIL; /* Vdata ID */
+    int32   ref;            /* Vdata ref */
+    int     is_internal;    /* to test Vgisinternal */
+    ssize_t name_len;       /* Length of a vgroup's name or class name */
+    char   *vgname = NULL, *vgclass = NULL;
 
     /* Open the HDF file. */
     file_id = Hopen(NONAMECLASS, DFACC_CREATE, 0);
@@ -268,16 +271,10 @@ test_undefined(void)
     CHECK(is_internal, FAIL, "Vgisinternal");
     VERIFY(is_internal, FALSE, "Vgisinternal");
 
-    /* Try getting the vgroup's class without calling first Vgetclassnamelen.
-       This shows that bug HDFFR-1288 is fixed. */
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "Vgetclass");
-    VERIFY(strlen(vgclass), 0, "VSgetclass");
-
-    /* The length of the class name should be 0 */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetclassnamelen");
-    VERIFY(name_len, 0, "VSgetclassnamelen");
+    /* Test Vgetclass on vgroup with no class */
+    name_len = Vgetclass(vg1, 0, NULL);
+    CHECK(name_len, FAIL, "Vgetclass");
+    VERIFY(name_len, 0, "VSgetclass");
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -290,16 +287,10 @@ test_undefined(void)
     vg1 = Vattach(file_id, ref, "r");
     CHECK(vg1, FAIL, "VSattach");
 
-    /* Try getting the vgroup's name without calling first Vgetclassnamelen.
-       Similar to class name in bug HDFFR-1288. */
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "Vgetname");
-    VERIFY(strlen(vgname), 0, "VSgetname");
-
-    /* The length of the name should be 0 */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
-    VERIFY(name_len, 0, "VSgetnamelen");
+    /* Test Vgetname on vgroup with no name */
+    name_len = Vgetname(vg1, 0, NULL);
+    CHECK(name_len, FAIL, "Vgetname");
+    VERIFY(name_len, 0, "Vgetname");
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -327,7 +318,6 @@ done:
  *   - Use an existing GR file created during the period when GR vgroup had no
  *	class name, and had name set to GR_NAME
  *   - Get each vgroup, verify that it is internal or not
- * Jan 6, 2012 -BMR
  ****************************************************************************/
 
 #define GR_FILE "test_files/grtdfui83.hdf"

--- a/hdf/test/tvset.c
+++ b/hdf/test/tvset.c
@@ -13,12 +13,7 @@
 
 /*
  *
- * Vset tests
- *
- *
- * This file needs another pass at making sure all the return
- * values from function calls are checked in addition to
- * verifying that the proper tests are performed on all Vxx fcns - GV 9/5/97
+ * Vset tests - Tests VS functions
  *
  */
 #include "hdf.h"
@@ -50,6 +45,8 @@
 #define MX               "STATION_NAME,VALUES,FLOATS"
 #define EMPTY_VDATA      "Empty"
 #define VGROUP1          "VGROUP1"
+#define VGROUP2          "Test object"
+#define SECONDVG         "Second Vgroup"
 #define VG_LONGNAME      "Vgroup with more than 64 characters in length, 74 characters to be exact!"
 #define VG_LONGCLASS     "Very long class name to classify all Vgroups with more than 64 characters in name"
 #define APPENDABLE_VDATA "Appendable"
@@ -67,7 +64,9 @@ static void  test_blockinfo_oneLB(void);
 static void  test_blockinfo_multLBs(void);
 static void  test_VSofclass(void);
 
-/* write some stuff to the file */
+/*
+   Testing writing vgroup and vdata metadata and data.
+*/
 static int32
 write_vset_stuff(void)
 {
@@ -85,6 +84,7 @@ write_vset_stuff(void)
     char       *p;
     char8       c;
     float32     f;
+    int32       ret_value = SUCCEED;
 
     ibuf  = (int32 *)malloc(sizeof(float32) * 2000);
     fbuf  = (float32 *)malloc(sizeof(float32) * 2000);
@@ -98,18 +98,12 @@ write_vset_stuff(void)
     CHECK_ALLOC(gbuf2, "gbuf2", "write_vset_stuff");
 
     fid = Hopen(FNAME0, DFACC_CREATE, 100);
-    if (fid == FAIL) {
-        num_errs++;
-        goto done;
-    }
+    CHECK(fid, FAIL, "Hopen");
 
-    if (Vstart(fid) == FAIL) {
-        num_errs++;
-        goto done;
-    }
+    status = Vstart(fid);
+    CHECK(status, FAIL, "Vstart");
 
     /*
-
      * Vgroup Generation routines
      *
      */
@@ -118,15 +112,12 @@ write_vset_stuff(void)
      *  start simple --- create a simple Vgroup
      */
     vg1 = Vattach(fid, -1, "w");
-    if (vg1 == FAIL) {
-        num_errs++;
-        printf(">>> Failed creating initial Vgroup\n");
-    }
+    CHECK(vg1, FAIL, "Failed creating initial Vgroup");
 
     status = Vsetname(vg1, "Simple Vgroup");
     CHECK(status, FAIL, "Vsetname:vg1");
 
-    status = Vsetclass(vg1, "Test object");
+    status = Vsetclass(vg1, VGROUP2);
     CHECK(status, FAIL, "Vsetclass:vg1");
 
     MESSAGE(5, printf("created Vgroup %s (empty)\n", "Simple Vgroup"););
@@ -135,38 +126,24 @@ write_vset_stuff(void)
      * Lets do some more complex ones now
      */
     vg2 = Vattach(fid, -1, "w");
-    if (vg2 == FAIL) {
-        num_errs++;
-        printf(">>> Failed creating second Vgroup\n");
-    }
+    CHECK(vg2, FAIL, "Failed creating second Vgroup");
 
     /* keep track of how many in Vgroup */
     num = 0;
 
     /* add first group into the other */
     status = Vinsert(vg2, vg1);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vinsert failed\n");
-    }
-    else
-        num++;
+    CHECK(status, FAIL, "Vinsert failed");
+    num++;
 
     /* add a bogus element */
     status = Vaddtagref(vg2, (int32)1000, (int32)12345);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vaddtagref failed for bogus element\n");
-    }
-    else
-        num++;
+    CHECK(status, FAIL, "Vaddtagref failed for bogus element");
+    num++;
 
     /* create an element and insert that */
     aid = Hstartwrite(fid, (uint16)123, (uint16)1234, 10);
-    if (aid == FAIL) {
-        num_errs++;
-        printf(">>> Hstartwrite failed\n");
-    }
+    CHECK(aid, FAIL, "Hstartwrite failed");
 
     status = Hendaccess(aid);
     CHECK(status, FAIL, "Hendaccess:aid");
@@ -174,12 +151,8 @@ write_vset_stuff(void)
 
     /* add an existing HDF element */
     status = Vaddtagref(vg2, (int32)123, (int32)1234);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vaddtagref failed for legit element\n");
-    }
-    else
-        num++;
+    CHECK(status, FAIL, "Vaddtagref failed for legit element");
+    num++;
 
 #ifdef NO_DUPLICATES
     /* attempt to add an element already in the Vgroup */
@@ -209,10 +182,10 @@ write_vset_stuff(void)
         printf(">>> Vinqtagref found a bogus element\n");
     }
 
-    status = Vsetname(vg2, "Second Vgroup");
+    status = Vsetname(vg2, SECONDVG);
     CHECK(status, FAIL, "Vsetname:for vg2");
 
-    Vsetclass(vg2, "Test object");
+    Vsetclass(vg2, VGROUP2);
     CHECK(status, FAIL, "Vsetclass: for vg2");
 
     status = Vdetach(vg1);
@@ -223,12 +196,10 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "Vdetach:vg2");
     vg2 = FAIL;
 
-    MESSAGE(5, printf("created Vgroup %s with %d elements\n", "Second Vgroup", (int)num););
+    MESSAGE(5, printf("created Vgroup %s with %d elements\n", SECONDVG, (int)num););
 
     /*
-
      * Vdata Generation routines
-     *
      */
 
     /* Float32 Vdata */
@@ -239,22 +210,19 @@ write_vset_stuff(void)
     status = VSsetname(vs1, name);
     CHECK(status, FAIL, "VSsetname");
 
-    status = VSsetclass(vs1, "Test object");
+    status = VSsetclass(vs1, VGROUP2);
     CHECK(status, FAIL, "VSsetclass");
 
     status = VSfdefine(vs1, FIELD1, DFNT_FLOAT32, 1);
     CHECK(status, FAIL, "VSfdefine");
 
     /* Verify that VSsetfields will return FAIL when passing in a NULL
-       for field name list (bug #554) - BMR 5/17/01 */
+       for field name list (bug #554) */
     status = VSsetfields(vs1, NULL);
     VERIFY(status, FAIL, "VSsetfields");
 
     status = VSsetfields(vs1, FIELD1);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     for (i = 0, count = 100; i < count; i++)
@@ -263,11 +231,6 @@ write_vset_stuff(void)
     /* store it */
     status = VSwrite(vs1, (unsigned char *)fbuf, count, FULL_INTERLACE);
     CHECK(status, FAIL, "VSwrite:vs1");
-
-    /* Test VSgetexternalfile on a vdata without external element */
-    /*  status = VSgetexternalfile(vs1, 0, NULL, NULL);
-    VERIFY(status, FAIL, "VSgetexternalfile");
- */
 
     /* Test VSgetexternalinfo on a vdata without external element */
     status = VSgetexternalinfo(vs1, 0, NULL, NULL, NULL);
@@ -287,23 +250,17 @@ write_vset_stuff(void)
     status = VSsetname(vs1, name);
     CHECK(status, FAIL, "VSsetname:vs1");
 
-    status = VSsetclass(vs1, "Test object");
+    status = VSsetclass(vs1, VGROUP2);
     CHECK(status, FAIL, "VSsetclass:vs1");
 
     status = VSfdefine(vs1, FIELD2, DFNT_INT32, 2);
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, FIELD2);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
     /* change this vdata to store in an external file */
     status = VSsetexternalfile(vs1, EXTFNM, (int32)0);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSsetexternalfile failed\n");
-    }
+    CHECK(status, FAIL, "VSsetexternalfile failed");
 
     /* create some bogus data */
     for (i = 0, count = 100; i < 2 * count; i++)
@@ -337,10 +294,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, "A, B");
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     p = gbuf;
@@ -383,10 +337,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, MX);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     p = gbuf;
@@ -436,10 +387,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, "max_order");
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     for (i = 0; i < MAX_ORDER; i++)
@@ -466,10 +414,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, "max_fldsize");
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     for (i = 0; i < max_order; i++)
@@ -494,16 +439,10 @@ write_vset_stuff(void)
 
     max_order = MAX_FIELD_SIZE / SIZE_FLOAT32 + 1;
     status    = VSfdefine(vs1, "bad_fldsize", DFNT_FLOAT32, max_order);
-    if (status != FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    VERIFY(status, FAIL, "VSfdefine");
 
     status = VSsetfields(vs1, "bad_fldsize");
-    if (status != FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    VERIFY(status, FAIL, "VSsetfields");
 
     status = VSdetach(vs1);
     CHECK(status, FAIL, "VSdetach:vs1");
@@ -571,7 +510,9 @@ done:
     return SUCCEED;
 }
 
-/* read everything back in and check it */
+/*
+   Testing reading vgroup and vdata metadata and data.
+*/
 static int32
 read_vset_stuff(void)
 {
@@ -590,7 +531,7 @@ read_vset_stuff(void)
     float32  fl_expected;
     int32    in_expected;
     char8    c_expected;
-    uint16   name_len;
+    size_t   buf_size = 0;
 
     ibuf = (int32 *)malloc(sizeof(float32) * 2000);
     fbuf = (float32 *)malloc(sizeof(float32) * 2000);
@@ -600,10 +541,7 @@ read_vset_stuff(void)
     CHECK_ALLOC(gbuf, "gbuf", "write_vset_stuff");
 
     fid = Hopen(FNAME0, DFACC_RDONLY, 0);
-    if (fid == FAIL) {
-        num_errs++;
-        goto done;
-    }
+    CHECK(fid, FAIL, "Hopen");
 
     status = Vstart(fid);
     CHECK(status, FAIL, "Vstart:fid");
@@ -627,39 +565,39 @@ read_vset_stuff(void)
         printf(">>> Was not able to attach (r) Vgroup %d\n", (int)list[0]);
     }
 
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen:vg1");
+    /* Get the vgroup's name */
+    buf_size = Vgetname(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "read_vset_stuff");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "Vgetname:vg1");
+    buf_size = Vgetname(vg1, buf_size + 1, vgname);
+    CHECK(buf_size, FAIL, "Vgetname:vg1");
 
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetclassnamelen:vg1");
+    /* Get the vgroup's class */
+    buf_size = Vgetclass(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "read_vset_stuff");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "Vgetclass:vg1");
+    buf_size = Vgetclass(vg1, buf_size + 1, vgclass);
+    CHECK(buf_size, FAIL, "Vgetclass:vg1");
 
-    if (strcmp(vgname, "Second Vgroup")) {
+    if (strcmp(vgname, SECONDVG)) {
         num_errs++;
         printf(">>> Got bogus Vgroup name : %s\n", vgname);
     }
 
-    free(vgname);
-    vgname = NULL;
+    HDfreenclear(vgname);
 
-    if (strcmp(vgclass, "Test object")) {
+    if (strcmp(vgclass, VGROUP2)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
-    free(vgclass);
-    vgclass = NULL;
+    HDfreenclear(vgclass);
 
     num    = 3;
     status = Vgettagrefs(vg1, tags, refs, 100);
@@ -692,10 +630,7 @@ read_vset_stuff(void)
 
     /* test Vgetid */
     ref = Vgetid(fid, -1);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> Vgetid was unable to find first Vgroup\n");
-    }
+    CHECK(ref, FAIL, "Vgetid was unable to find first Vgroup");
 
     ref = Vgetid(fid, ref);
     if (ref != list[0]) {
@@ -704,17 +639,12 @@ read_vset_stuff(void)
     }
 
     /*
-
      *   Verify the Vdatas
-     *
      */
 
     /* test VSgetid */
     ref = VSgetid(fid, -1);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find first Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find first Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -731,16 +661,13 @@ read_vset_stuff(void)
         printf(">>> Got bogus Vdata name (VSgetname) : %s\n", vsname);
     }
 
-    if (strcmp(vsclass, "Test object")) {
+    if (strcmp(vsclass, VGROUP2)) {
         num_errs++;
         printf(">>> Got bogus Vdata class : %s\n", vsclass);
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on float Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on float Vdata");
 
     if (strcmp(vsname, "Float Vdata")) {
         num_errs++;
@@ -793,10 +720,7 @@ read_vset_stuff(void)
 
     /* Move to the next one (integers) */
     ref = VSgetid(fid, ref);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find second Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find second Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -813,16 +737,13 @@ read_vset_stuff(void)
         printf(">>> Got bogus Vdata name (VSgetname) : %s\n", vsname);
     }
 
-    if (strcmp(vsclass, "Test object")) {
+    if (strcmp(vsclass, VGROUP2)) {
         num_errs++;
         printf(">>> Got bogus Vdata class : %s\n", vsclass);
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on float Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on float Vdata");
 
     if (strcmp(vsname, "Integer Vdata")) {
         num_errs++;
@@ -906,10 +827,7 @@ read_vset_stuff(void)
 
     /* Move to the next one (integers + floats) */
     ref = VSgetid(fid, ref);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find third Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find third Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -932,10 +850,7 @@ read_vset_stuff(void)
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on float Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on float Vdata");
 
     if (strcmp(vsname, "Mixed Vdata")) {
         num_errs++;
@@ -995,10 +910,7 @@ read_vset_stuff(void)
 
     /* Move to the next one (multi-order) */
     ref = VSgetid(fid, ref);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find multi-order Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find multi-order Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -1021,10 +933,7 @@ read_vset_stuff(void)
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on multi-order Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on multi-order Vdata");
 
     if (count != 10) {
         num_errs++;
@@ -1245,16 +1154,14 @@ done:
 }
 
 /*
-   Testing VSdelete for vdatas.
-   Modification:
-        2011/12/22: added a test for VSgetexternalinfo on non-external vdata.
- */
-static void
-test_vsdelete(void)
-{
+   Testing VSdelete for vdatas and VSgetexternalinfo on non-external vdata.
+*/
 #define FIELD_NAME     "Field Entries"
 #define NUMBER_OF_ROWS 10
 #define ORDER          3
+static void
+test_vsdelete(void)
+{
     int32 fid      = FAIL;
     int32 vdata_id = FAIL;
     int32 status;
@@ -1391,7 +1298,9 @@ done:
     return;
 }
 
-/* Testing Vdelete for vgroups. */
+/*
+   Testing Vdelete for vgroups.
+*/
 static void
 test_vdelete(void)
 {
@@ -1502,7 +1411,9 @@ done:
     return;
 }
 
-/* Testing Vdeletetagref() for vgroups. */
+/*
+   Testing Vdeletetagref() for vgroups.
+*/
 static void
 test_vdeletetagref(void)
 {
@@ -1692,6 +1603,9 @@ done:
     return;
 }
 
+/*
+   Testing behavior of empty vdata.
+*/
 static void
 test_emptyvdata(void)
 {
@@ -1763,7 +1677,7 @@ test_emptyvdata(void)
 
     /* Verify that VSgetfields will return FAIL when passing in a NULL
        for field name list (from bug #554), although this might never
-       happen - BMR 5/17/01 */
+       happen */
     status = VSgetfields(vs1, NULL);
     VERIFY(status, FAIL, "VSgetfields");
 
@@ -1811,10 +1725,7 @@ test_emptyvdata(void)
     CHECK(status, FAIL, "VSfdefine");
 
     status = VSsetfields(vs1, FIELD1 "," FIELD2);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", vsname);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     status = VSdetach(vs1);
     CHECK(status, FAIL, "Vdetach");
@@ -1879,14 +1790,17 @@ done:
     return;
 }
 
+/*
+   Testing vgroups with long name and class.
+*/
 static void
 test_vglongnames(void)
 {
-    int32  status;     /* Status values from routines */
-    int32  fid = FAIL; /* File ID */
-    int32  vg1 = FAIL; /* Vdata ID */
-    int32  ref;        /* Vdata ref */
-    uint16 name_len;   /* Length of a vgroup's name or class name */
+    int32  status;       /* Status values from routines */
+    int32  fid = FAIL;   /* File ID */
+    int32  vg1 = FAIL;   /* Vdata ID */
+    int32  ref;          /* Vdata ref */
+    size_t buf_size = 0; /* Size for name or class buffer */
     char  *vgname = NULL, *vgclass = NULL;
 
     /* Open the HDF file. */
@@ -1948,40 +1862,38 @@ test_vglongnames(void)
     CHECK(vg1, FAIL, "VSattach");
 
     /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    buf_size = Vgetname(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size = Vgetname(vg1, buf_size + 1, vgname);
+    CHECK(buf_size, FAIL, "Vgetname");
 
     if (strcmp(vgname, VG_LONGNAME)) {
         num_errs++;
         printf(">>> Got bogus Vgroup name : %s\n", vgname);
     }
 
-    free(vgname);
-    vgname = NULL;
+    HDfreenclear(vgname);
 
     /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    buf_size = Vgetclass(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size = Vgetclass(vg1, buf_size + 1, vgclass);
+    CHECK(buf_size, FAIL, "Vgetclass");
 
     if (strcmp(vgclass, VG_LONGCLASS)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
-    free(vgclass);
-    vgclass = NULL;
+    HDfreenclear(vgclass);
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -1995,40 +1907,38 @@ test_vglongnames(void)
     CHECK(vg1, FAIL, "VSattach");
 
     /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    buf_size = Vgetname(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size = Vgetname(vg1, buf_size + 1, vgname);
+    CHECK(buf_size, FAIL, "Vgetname");
 
     if (strcmp(vgname, VGROUP1)) {
         num_errs++;
         printf(">>> Got bogus Vgroup name : %s\n", vgname);
     }
 
-    free(vgname);
-    vgname = NULL;
+    HDfreenclear(vgname);
 
     /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    buf_size = Vgetclass(vg1, 0, NULL);
+    CHECK(buf_size, FAIL, "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size = Vgetclass(vg1, buf_size + 1, vgclass);
+    CHECK(buf_size, FAIL, "Vgetclass");
 
     if (strcmp(vgclass, VG_LONGCLASS)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
-    free(vgclass);
-    vgclass = NULL;
+    HDfreenclear(vgclass);
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -2054,6 +1964,9 @@ done:
     return;
 }
 
+/*
+   Testing Vgetvgroups.
+*/
 #define USERVGROUPS "tuservgs.hdf"
 #define NUM_VGROUPS 10
 static void
@@ -2393,19 +2306,30 @@ done:
     return;
 }
 
-int
-check_vgs(int32 id, unsigned start_vg, unsigned n_vgs,
-          const char *ident_text,  /* just for debugging, remove when done */
-          int         resultcount, /* expected number of vgroups */
-          uint16     *resultarray)     /* array containing expected values */
-{
-    uint16 *refarray = NULL;
-    int     count    = 0, ii;
-    char    message[30];
-    int     ret_value = SUCCEED;
+/*******************************************************************************
+NAME
+   check_vgs
 
-    strcpy(message, "Vgetvgroups: ");
-    strcat(message, ident_text);
+DESCRIPTION
+   Retrieves the refs of vgroups contained in the vgroup/file identified by
+   'id', starting at index 'start_vg' and retrieving up to 'n_vgs' of them
+   (or all of them, if 'n_vgs' is 0), and verifies the retrieved refs against
+   the expected values in 'resultarray'.
+
+RETURNS
+   SUCCEED/FAIL
+
+*******************************************************************************/
+static int
+check_vgs(int32    id,          /* IN: vgroup or file key */
+          unsigned start_vg,    /* IN: index of first vgroup to retrieve */
+          unsigned n_vgs,       /* IN: number of vgroups to retrieve, or 0 for all */
+          int      resultcount, /* IN: expected number of vgroups */
+          uint16  *resultarray /* IN: array containing expected ref values */)
+{
+    uint16 *refarray  = NULL;
+    int     count     = 0, ii;
+    int     ret_value = SUCCEED;
 
     /* Get and verify the number of vgroups in the file */
     count = Vgetvgroups(id, start_vg, n_vgs, NULL);
@@ -2414,10 +2338,7 @@ check_vgs(int32 id, unsigned start_vg, unsigned n_vgs,
 
     /* Allocate space to retrieve the reference numbers of 'count' vgroups */
     refarray = (uint16 *)malloc(sizeof(uint16) * (size_t)count);
-    if (refarray == NULL) {
-        fprintf(stderr, "check_vgs: Allocation refarray failed\n");
-        return -1;
-    }
+    CHECK_ALLOC(refarray, "refarray", "check_vgs");
 
     /* Get all the vgroups in the file */
     count = Vgetvgroups(id, start_vg, (unsigned)count, refarray);
@@ -2425,9 +2346,11 @@ check_vgs(int32 id, unsigned start_vg, unsigned n_vgs,
     VERIFY(count, resultcount, "Vgetvgroups");
 
     for (ii = 0; ii < count; ii++)
-        if (refarray[ii] != resultarray[ii])
-            fprintf(stderr, "%s: at index %d - read value=%d, should be %d\n", ident_text, ii, refarray[ii],
+        if (refarray[ii] != resultarray[ii]) {
+            num_errs++;
+            fprintf(stderr, "check_vgs: at index %d - read value=%d, should be %d\n", ii, refarray[ii],
                     resultarray[ii]);
+        }
 
     free(refarray);
     refarray = NULL;
@@ -2438,41 +2361,51 @@ done:
     return ret_value;
 }
 
-static int
-check_vds(int32 id, unsigned start_vd, unsigned n_vds,
-          const char *ident_text,  /* just for debugging, remove when done */
-          int         resultcount, /* expected number of vdatas */
-          uint16     *resultarray)     /* array containing expected values */
-{
-    uint16 *refarray = NULL;
-    int     count    = 0, ii;
-    char    message[30];
-    int     ret_value = SUCCEED;
+/*******************************************************************************
+NAME
+   check_vds
 
-    strcpy(message, "VSgetvdatas: ");
-    strcat(message, ident_text);
+DESCRIPTION
+   Retrieves the refs of vdatas contained in the vgroup/file identified by
+   'id', starting at index 'start_vd' and retrieving up to 'n_vds' of them
+   (or all of them, if 'n_vds' is 0), and verifies the retrieved refs against
+   the expected values in 'resultarray'.
+
+RETURNS
+   SUCCEED/FAIL
+
+*******************************************************************************/
+static int
+check_vds(int32    id,          /* IN: vgroup or file key */
+          unsigned start_vd,    /* IN: index of first vdata to retrieve */
+          unsigned n_vds,       /* IN: number of vdatas to retrieve, or 0 for all */
+          int      resultcount, /* IN: expected number of vdatas */
+          uint16  *resultarray /* IN: array containing expected ref values */)
+{
+    uint16 *refarray  = NULL;
+    int     count     = 0, ii;
+    int     ret_value = SUCCEED;
 
     /* Get and verify the number of vdatas in the file */
     count = VSgetvdatas(id, start_vd, n_vds, NULL);
-    CHECK(count, FAIL, message);
-    VERIFY(count, resultcount, message);
+    CHECK(count, FAIL, "VSgetvdatas");
+    VERIFY(count, resultcount, "VSgetvdatas");
 
     /* Allocate space to retrieve the reference numbers of 'count' vdatas */
     refarray = (uint16 *)malloc(sizeof(uint16) * (size_t)count);
-    if (refarray == NULL) {
-        fprintf(stderr, "check_vds: Allocation refarray failed\n");
-        return -1;
-    }
+    CHECK_ALLOC(refarray, "refarray", "check_vds");
 
     /* Get all the vdatas in the file */
     count = VSgetvdatas(id, start_vd, (unsigned)count, refarray);
-    CHECK(count, FAIL, message);
-    VERIFY(count, resultcount, message);
+    CHECK(count, FAIL, "VSgetvdatas");
+    VERIFY(count, resultcount, "VSgetvdatas");
 
     for (ii = 0; ii < count; ii++)
-        if (refarray[ii] != resultarray[ii])
-            fprintf(stderr, "%s: at index %d - read value=%d, should be %d\n", ident_text, ii, refarray[ii],
+        if (refarray[ii] != resultarray[ii]) {
+            num_errs++;
+            fprintf(stderr, "check_vds: at index %d - read value=%d, should be %d\n", ii, refarray[ii],
                     resultarray[ii]);
+        }
 
     free(refarray);
     refarray = NULL;
@@ -2714,14 +2647,14 @@ test_getvdatas(void)
     /* Test getting all vgroups in the file: fid, start_vg=0, n_vgs=0 */
     {
         uint16 result[] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-        status          = check_vgs(fid, 0, 0, "file, 0, 0", NUM_VGROUPS, result);
+        status          = check_vgs(fid, 0, 0, NUM_VGROUPS, result);
         CHECK(status, FAIL, "Vgetvgroups fid");
     }
 
     /* Test getting all vdatas in the file: fid, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {12, 13, 14, 15, 16, 17, 18, 19};
-        status          = check_vds(fid, 0, 0, "file, 0, 0", NUM_VDATAS, result);
+        status          = check_vds(fid, 0, 0, NUM_VDATAS, result);
         CHECK(status, FAIL, "VSgetvdatas fid");
     }
 
@@ -2731,14 +2664,14 @@ test_getvdatas(void)
     /* Test getting vgroups in vg0: vgroup0_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {9, 11};
-        status          = check_vgs(vgroup0_id, 0, 0, "vgroup0_id, 0, 0", 2, result);
+        status          = check_vgs(vgroup0_id, 0, 0, 2, result);
         CHECK(status, FAIL, "VSgetvgroups vgroup0_id");
     }
 
     /* Test getting vdatas in vg0: vgroup0_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {13, 14};
-        status          = check_vds(vgroup0_id, 0, 0, "vgroup0_id, 0, 0", 2, result);
+        status          = check_vds(vgroup0_id, 0, 0, 2, result);
         CHECK(status, FAIL, "VSgetvdatas fid");
     }
 
@@ -2748,14 +2681,14 @@ test_getvdatas(void)
     /* Test getting vgroups in vg1: vgroup1_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {6, 8}; /* vg4 and vg6 */
-        status          = check_vgs(vgroup1_id, 0, 0, "vgroup1_id, 0, 0", 2, result);
+        status          = check_vgs(vgroup1_id, 0, 0, 2, result);
         CHECK(status, FAIL, "Vgetvgroups vgroup1_id");
     }
 
     /* Test getting vdatas in vg1: vgroup1_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {19}; /* vd7 */
-        status          = check_vds(vgroup1_id, 0, 0, "vgroup1_id, 0, 0", 1, result);
+        status          = check_vds(vgroup1_id, 0, 0, 1, result);
         CHECK(status, FAIL, "VSgetvdata vgroup1_id");
     }
 
@@ -2765,14 +2698,14 @@ test_getvdatas(void)
     /* Test getting vgroups in vg6: vgroup6_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {4}; /* vg2 */
-        status          = check_vgs(vgroup6_id, 0, 0, "vgroup6_id, 0, 0", 1, result);
+        status          = check_vgs(vgroup6_id, 0, 0, 1, result);
         CHECK(status, FAIL, "Vgetvgroups vgroup6_id");
     }
 
     /* Test getting vdatas in vg6: vgroup6_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {18}; /* vd6 */
-        status          = check_vds(vgroup6_id, 0, 0, "vgroup6_id, 0, 0", 1, result);
+        status          = check_vds(vgroup6_id, 0, 0, 1, result);
         CHECK(status, FAIL, "VSgetvdata vgroup6_id");
     }
 
@@ -2797,14 +2730,14 @@ test_getvdatas(void)
     /* Test getting vdatas in vg9: vgroup9_id, start_vd=2, n_vds=2 */
     {
         uint16 result[] = {17}; /* vd5 */
-        status          = check_vds(vgroup9_id, 2, 2, "vgroup9_id, 2, 2", 1, result);
+        status          = check_vds(vgroup9_id, 2, 2, 1, result);
         CHECK(status, FAIL, "VSgetvdata vgroup9_id");
     }
 
     /* Test getting vgroups in vg1: vgroup1_id, start_vd=1, n_vds=3 */
     {
         uint16 result[] = {8}; /* vg6 */
-        status          = check_vgs(vgroup1_id, 1, 3, "vgroup1_id, 1, 3", 1, result);
+        status          = check_vgs(vgroup1_id, 1, 3, 1, result);
         CHECK(status, FAIL, "Vgetvgroups vgroup1_id");
     }
 
@@ -3002,24 +2935,6 @@ test_extfile(void)
     /* Create the first vdata */
     vdata1_id = VSattach(fid, vdata1_ref, "r");
     CHECK(vdata1_id, FAIL, "VSattach");
-
-    { /* This is an old test, will be removed when VSgetexternalfile is */
-        /* Get the length of the external file name first - VSgetexternalfile
-           is deprecated as of 4.2.7 */
-        name_len = VSgetexternalfile(vdata1_id, 0, NULL, NULL);
-        VERIFY(name_len, (int)strlen(EXTERNAL_FILE), "VSgetexternalfile");
-
-        extfile_name = (char *)malloc(sizeof(char) * (size_t)(name_len + 1));
-        CHECK_ALLOC(extfile_name, "extfile_name", "test_extfile");
-
-        /* Old function: Get the external file name - VSgetexternalfile
-           is deprecated as of 4.2.7 */
-        name_len = VSgetexternalfile(vdata1_id, (unsigned)name_len + 1, extfile_name, &offset);
-        VERIFY(name_len, (int)strlen(EXTERNAL_FILE), "VSgetexternalfile");
-        VERIFY_CHAR(extfile_name, EXTERNAL_FILE, "VSgetexternalfile");
-        free(extfile_name);
-        extfile_name = NULL;
-    } /* old test */
 
     /* Get the length of the external file name first */
     name_len = VSgetexternalinfo(vdata1_id, 0, NULL, NULL, NULL);

--- a/hdf/util/vshow.c
+++ b/hdf/util/vshow.c
@@ -63,13 +63,13 @@ main(int ac, char **av)
     int32   vsno = 0;
     int32   vstag;
 
-    int32  i, t, nvg, n, ne, nv, interlace, vsize;
+    int32  i, t, nvg, nentries, ne, nv, interlace, vsize;
     int32 *lonevs;   /* array to store refs of all lone vdatas */
     int32  nlone;    /* total number of lone vdatas */
     uint16 name_len; /* length of vgroup's name or classname */
 
     char  fields[VSFIELDMAX * FIELDNAMELENMAX];
-    char *vgname, *vgclass;
+    char *vgname = NULL, *vgclass = NULL;
     char  vsname[VSNAMELENMAX];
     char  vsclass[VSNAMELENMAX];
     char *name;
@@ -114,33 +114,33 @@ main(int ac, char **av)
         if (vg == FAIL) {
             printf("cannot open vg id=%d\n", (int)vgid);
         }
-        /* get the length of the vgname to allocate enough space */
-        Vgetnamelen(vg, &name_len);
-        vgname = (char *)malloc(sizeof(char *) * (name_len + 1));
-        if (vgname == NULL) {
-            printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-            return (0);
+
+        /* get the vgname */
+        vgname = vgetvgname(vg);
+        if (vgname == NULL || strlen(vgname) == 0) {
+            free(vgname); // Safe
+            vgname = strdup("NoName");
         }
-        Vinquire(vg, &n, vgname);
-        if (strlen(vgname) == 0)
-            strcat(vgname, "NoName");
+
+        /* get the vgclass */
+        vgclass = vgetvgclass(vg);
+        if (vgclass == NULL || strlen(vgclass) == 0) {
+            free(vgclass); // Safe
+            vgclass = strdup("NoClass");
+        }
+
+        if (Vinquire(vg, &nentries, 0, NULL) == FAIL)
+            printf("cannot retrieve number of entries for vg id=%d\n", (int)vgid);
 
         vgotag = VQuerytag(vg);
         vgoref = VQueryref(vg);
 
-        /* get the length of the vgname to allocate enough space */
-        Vgetclassnamelen(vg, &name_len);
-        vgclass = (char *)malloc(sizeof(char *) * (name_len + 1));
-        if (vgclass == NULL) {
-            printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-            return (0);
-        }
-        Vgetclass(vg, vgclass);
-        if (strlen(vgclass) == 0)
-            strcat(vgclass, "NoClass");
-
         printf("\nvg:%d <%d/%d> (%s {%s}) has %d entries:\n", (int)nvg, (int)vgotag, (int)vgoref, vgname,
-               vgclass, (int)n);
+               vgclass, (int)nentries);
+        free(vgname);
+        free(vgclass);
+
+        /* Dump the attribute */
         dumpattr(vg, fulldump, 0);
         for (t = 0; t < Vntagrefs(vg); t++) {
             Vgettagref(vg, t, &vstag, &vsid);
@@ -182,34 +182,35 @@ main(int ac, char **av)
                     continue;
                 }
 
-                /* get length of the vgclass to allocate enough space */
-                Vgetclassnamelen(vgt, &name_len);
-                vgclass = (char *)malloc(sizeof(char *) * (name_len + 1));
-                if (vgclass == NULL) {
-                    printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-                    return (0);
-                }
-                Vgetclass(vg, vgclass);
-                if (strlen(vgclass) == 0)
-                    strcat(vgclass, "NoClass");
+                /* get the vgname */
+                vgname = vgetvgname(vgt);
+                if (!vgname)
+                    if (strlen(vgname) == 0)
+                        strcpy(vgname, "NoName");
 
-                /* get length of the vgname to allocate enough space */
-                Vgetnamelen(vgt, &name_len);
-                vgname = (char *)malloc(sizeof(char *) * (name_len + 1));
-                if (vgname == NULL) {
-                    printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-                    return (0);
-                }
-                Vinquire(vgt, &ne, vgname);
-                if (strlen(vgname) == 0)
-                    strcat(vgname, "NoName");
+                /* get the vgclass */
+                vgclass = vgetvgclass(vgt);
+                if (!vgclass)
+                    if (strlen(vgclass) == 0)
+                        strcpy(vgclass, "NoClass");
+
+                if (Vinquire(vg, &nentries, 0, NULL) == FAIL)
+                    printf("cannot retrieve number of entries for vg id=%d\n", (int)vgid);
+
                 vgotag = VQuerytag(vgt);
                 vgoref = VQueryref(vgt);
-                Vgetclass(vgt, vgclass);
+
                 printf("  vg:%d <%d/%d> ne=%d (%s {%s})\n", (int)t, (int)vgotag, (int)vgoref, (int)ne, vgname,
                        vgclass);
+
+                /* Dump the attribute */
                 dumpattr(vg, fulldump, 0);
-                Vdetach(vgt);
+
+                /* Release resources */
+                if (Vdetach(vgt) == FAIL)
+                    printf("cannot end access to vgroup\n");
+                free(vgname);
+                free(vgclass);
             }
             else {
                 name = HDgettagsname((uint16)vstag);

--- a/java/src/jni/hdfvgroupImp.c
+++ b/java/src/jni/hdfvgroupImp.c
@@ -117,15 +117,12 @@ done:
 JNIEXPORT void JNICALL
 Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, jobjectArray hdfclassname)
 {
-    int32   rval     = FAIL;
-    char   *data     = NULL;
-    ssize_t buf_size = 0;
-    jstring rstring;
+    int32     rval     = FAIL;
+    char     *data     = NULL;
+    ptrdiff_t buf_size = 0;
+    jstring   rstring;
 
     UNUSED(clss);
-
-    if ((data = (char *)malloc(H4_MAX_NC_CLASS + 1)) == NULL)
-        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetclass: failed to allocate data buffer");
 
     if (hdfclassname == NULL)
         H4_NULL_ARGUMENT_ERROR(ENVONLY, "Vgetclass: hdfclassname is NULL");
@@ -161,10 +158,10 @@ done:
 JNIEXPORT void JNICALL
 Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, jobjectArray hdfname)
 {
-    int32   rval     = FAIL;
-    char   *data     = NULL;
-    ssize_t buf_size = 0;
-    jstring rstring;
+    int32     rval     = FAIL;
+    char     *data     = NULL;
+    ptrdiff_t buf_size = 0; /* portable substitute for POSIX ssize_t */
+    jstring   rstring;
 
     UNUSED(clss);
 

--- a/java/src/jni/hdfvgroupImp.c
+++ b/java/src/jni/hdfvgroupImp.c
@@ -117,8 +117,9 @@ done:
 JNIEXPORT void JNICALL
 Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, jobjectArray hdfclassname)
 {
-    int32   rval = FAIL;
-    char   *data = NULL;
+    int32   rval     = FAIL;
+    char   *data     = NULL;
+    ssize_t buf_size = 0;
     jstring rstring;
 
     UNUSED(clss);
@@ -132,11 +133,16 @@ Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, 
     if (ENVPTR->GetArrayLength(ENVONLY, hdfclassname) < 1)
         H4_BAD_ARGUMENT_ERROR(ENVONLY, "Vgetclass: output array hdfclassname < order 1");
 
-    /* get the class name of the vgroup */
-    if ((rval = Vgetclass((int32)vgroup_id, data)) < 0)
+    if ((buf_size = Vgetclass((int32)vgroup_id, 0, NULL)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
-    data[H4_MAX_NC_CLASS] = '\0';
+    if ((data = (char *)malloc(buf_size + 1)) == NULL)
+        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetclass: failed to allocate data buffer");
+
+    /* get the null-terminated class name of the vgroup */
+    if ((rval = Vgetclass((int32)vgroup_id, (size_t)buf_size + 1, data)) == FAIL)
+        H4_LIBRARY_ERROR(ENVONLY);
+
     /* convert it to java string */
     if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -155,14 +161,12 @@ done:
 JNIEXPORT void JNICALL
 Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, jobjectArray hdfname)
 {
-    int32   rval = FAIL;
-    char   *data = NULL;
+    int32   rval     = FAIL;
+    char   *data     = NULL;
+    ssize_t buf_size = 0;
     jstring rstring;
 
     UNUSED(clss);
-
-    if ((data = (char *)malloc(H4_MAX_GR_NAME + 1)) == NULL)
-        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetname: failed to allocate data buffer");
 
     if (hdfname == NULL)
         H4_NULL_ARGUMENT_ERROR(ENVONLY, "Vgetname: hdfname is NULL");
@@ -170,10 +174,16 @@ Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, j
     if (ENVPTR->GetArrayLength(ENVONLY, hdfname) < 1)
         H4_BAD_ARGUMENT_ERROR(ENVONLY, "Vgetname: array hdfname < order 1");
 
-    if ((rval = Vgetname((int32)vgroup_id, data)) == FAIL)
+    if ((buf_size = Vgetname((int32)vgroup_id, 0, NULL)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
-    data[H4_MAX_GR_NAME] = '\0';
+    if ((data = (char *)malloc(buf_size + 1)) == NULL)
+        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetname: failed to allocate data buffer");
+
+    /* get the null-terminated name of the vgroup */
+    if ((rval = Vgetname((int32)vgroup_id, (size_t)buf_size + 1, data)) == FAIL)
+        H4_LIBRARY_ERROR(ENVONLY);
+
     /* convert it to java string */
     if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -494,10 +504,9 @@ Java_hdf_hdflib_HDFLibrary_Vinquire(JNIEnv *env, jclass clss, jlong vgroup_id, j
 
     PIN_INT_ARRAY(ENVONLY, n_entries, theArg, &isCopy, "Vinquire:  n_entries not pinned");
 
-    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), data)) == FAIL)
+    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), H4_MAX_NC_NAME + 1, data)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
-    data[H4_MAX_NC_NAME] = '\0';
     /* convert it to java string */
     if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);

--- a/mfhdf/hdiff/hdiff_list.c
+++ b/mfhdf/hdiff/hdiff_list.c
@@ -17,6 +17,7 @@
 
 #include "hdf.h"
 #include "mfhdf.h"
+#include "vg_priv.h"
 #include "hdiff_list.h"
 
 static int   is_reserved(char *vg_class);
@@ -145,7 +146,7 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
     int32  ref_vg;
     char  *vg_name  = NULL;
     char  *vg_class = NULL;
-    uint16 name_len;
+    size_t name_len;
     int32  i;
 
     /* initialize the V interface */
@@ -190,29 +191,17 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
                 goto out;
             }
 
-            if (Vgetnamelen(vg_id, &name_len) == FAIL) {
+            /* Get vgroup's name */
+            vg_name = vgetvgname(vg_id);
+            if (!vg_name) {
                 printf("Error: Could not get name length for group with ref <%d>\n", ref);
                 goto out;
             }
 
-            free(vg_name);
-            vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetname(vg_id, vg_name) == FAIL) {
-                printf("Error: Could not get name for group with ref <%d>\n", ref);
-                goto out;
-            }
-
-            if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                printf("Error: Could not get classname length for group with ref <%d>\n", ref);
-                goto out;
-            }
-
-            free(vg_class);
-            vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetclass(vg_id, vg_class) == FAIL) {
-                printf("Error: Could not get class for group with ref <%d>\n", ref);
+            /* Get vgroup's class */
+            vg_class = vgetvgclass(vg_id);
+            if (!vg_class) {
+                printf("Error: Could not get class length for group with ref <%d>\n", ref);
                 goto out;
             }
 
@@ -270,17 +259,15 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
                 goto out;
             }
 
-            free(vg_name);
+            HDfreenclear(vg_name);
             vg_name = NULL;
-            free(vg_class);
+            HDfreenclear(vg_class);
             vg_class = NULL;
         } /* for */
 
         /* free the space allocated */
         free(ref_array);
     } /* if */
-    free(vg_name);
-    free(vg_class);
 
     /* terminate access to the V interface */
     if (Vend(file_id) == FAIL) {
@@ -329,7 +316,7 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
     char  *vg_class = NULL;
     char  *path     = NULL;
     int    i;
-    uint16 name_len;
+    size_t name_len;
 
     for (i = 0; i < npairs; i++) {
         tag = in_tags[i];
@@ -348,25 +335,24 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
                 }
 
                 vg_id = Vattach(file_id, ref, "r");
-                if (Vgetnamelen(vg_id, &name_len) == FAIL) {
-                    printf("Error: Could not get name length for group with ref <%d>\n", ref);
+                if (vg_id == FAIL) {
+                    printf("Error: Could not attach group with ref <%d>\n", ref);
                     break;
                 }
 
-                free(vg_name);
-                vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-
-                Vgetname(vg_id, vg_name);
-
-                if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                    printf("Error: Could not get classname length for group with ref <%d>\n", ref);
+                /* Get vgroup's name */
+                vg_name = vgetvgname(vg_id);
+                if (!vg_name) {
+                    printf("Error: Could not get name for group with ref <%d>\n", ref);
                     break;
                 }
 
-                free(vg_class);
-                vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-
-                Vgetclass(vg_id, vg_class);
+                /* Get vgroup's class */
+                vg_class = vgetvgclass(vg_id);
+                if (!vg_class) {
+                    printf("Error: Could not get class length for group with ref <%d>\n", ref);
+                    break;
+                }
 
                 /* ignore reserved HDF groups/vdatas */
                 if (is_reserved(vg_class)) {

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -226,11 +226,11 @@ int32
 Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
          int is_name, int32 *find_ref, int32 *index) /* index of the vgroup w/ref# *find_ref */
 {
-    int32   vg_id     = FAIL;
-    char   *name      = NULL;
-    ssize_t name_len  = 0;
-    int32   status_32 = FAIL;
-    int32   ret_value = FAIL;
+    int32     vg_id     = FAIL;
+    char     *name      = NULL;
+    ptrdiff_t name_len  = 0; /* portable substitute for POSIX ssize_t */
+    int32     status_32 = FAIL;
+    int32     ret_value = FAIL;
 
     /* starting from the ref# *find_ref, search for the vgroup having a
        name or class the same as the given string searched_name; when no
@@ -409,9 +409,9 @@ int
 get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, int32 *n_entries,
               char **vgname, char **vgclass)
 {
-    int     status, ret_value = SUCCEED;
-    int32   status_32;
-    ssize_t name_len = 0;
+    int       status, ret_value = SUCCEED;
+    int32     status_32;
+    ptrdiff_t name_len = 0;
 
     /* detach the current vgroup if it's attached to cover the case
       where a library routine fails and must continue to the next vgroup

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -13,6 +13,7 @@
 
 #include <math.h>
 
+#include "vg_priv.h"
 #include "vg.h"
 #include "hdp.h"
 
@@ -225,67 +226,60 @@ int32
 Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
          int is_name, int32 *find_ref, int32 *index) /* index of the vgroup w/ref# *find_ref */
 {
-    int32  vg_id     = FAIL;
-    char  *name      = NULL;
-    uint16 name_len  = 0;
-    int32  status_32 = FAIL;
-    int32  ret_value = FAIL;
+    int32   vg_id     = FAIL;
+    char   *name      = NULL;
+    ssize_t name_len  = 0;
+    int32   status_32 = FAIL;
+    int32   ret_value = FAIL;
 
     /* starting from the ref# *find_ref, search for the vgroup having a
        name or class the same as the given string searched_name; when no
        more vgroups to search, return FAIL */
     while ((*find_ref = Vgetid(file_id, *find_ref)) != FAIL) {
         vg_id = Vattach(file_id, *find_ref, "r");
-        if (FAIL == vg_id)
+        if (vg_id == FAIL)
             ERROR_GOTO_2("in %s: Vattach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
 
-        /* get the length of the vgname to allocate enough space */
-        if (is_name)
-            status_32 = Vgetnamelen(vg_id, &name_len);
-        else
-            status_32 = Vgetclassnamelen(vg_id, &name_len);
-        if (FAIL == status_32) /* go to done and return a FAIL */
-        {
-            ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "Vstr_ref", (int)*find_ref);
+        /* get the vg name/class */
+        if (is_name) {
+            name = vgetvgname(vg_id);
+            if (!name) {
+                ERROR_GOTO_2("in %s: Failed to get name for vgroup with ref#(%d)", "Vstr_ref",
+                             (int)*find_ref);
+            }
         }
-        name = (char *)malloc(sizeof(char) * (name_len + 1));
-        /* If allocation fails, Vstr_ref simply terminates hdp. */
-        CHECK_ALLOC(name, "vgroup classname", "Vstr_ref");
-
-        if (name_len > 0) {
-            if (is_name) {
-                if (FAIL == Vgetname(vg_id, name))
-                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
-                                 (int)*find_ref);
+        else {
+            name = vgetvgclass(vg_id);
+            if (!name) {
+                ERROR_GOTO_2("in %s: Failed to get class name for vgroup with ref#(%d)", "Vstr_ref",
+                             (int)*find_ref);
             }
-            else {
-                if (FAIL == Vgetclass(vg_id, name))
-                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
-                                 (int)*find_ref);
-            }
+        }
 
-            if (FAIL == Vdetach(vg_id))
-                ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
+        if (FAIL == Vdetach(vg_id))
+            ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
+        vg_id = FAIL;
 
-            /* if the vg's name or vg's class is the given string, return the
-            index of the vgroup found */
-            if (strcmp(name, searched_str) == 0) {
-                /* return the current ref# */
-                ret_value = *find_ref;
-                /* increment index for next vgroup - same class vgroups*/
-                (*index)++;
-                goto done;
-            }
+        /* if the vg's name or vg's class is the given string, return the
+        index of the vgroup found */
+        if (strcmp(name, searched_str) == 0) {
+            /* return the current ref# */
+            ret_value = *find_ref;
+            /* increment index for next vgroup - same class vgroups*/
             (*index)++;
-        } /* name_len > 0 */
+            goto done;
+        }
+        (*index)++;
 
         SAFE_FREE(name); /* free name and set it to NULL */
     }                    /* end while getting vgroups */
 
-    /* when VSgetid returned FAIL in while above, search should stop */
+    /* when Vgetid returned FAIL in while above, search should stop */
     ret_value = FAIL;
 
 done:
+    if (vg_id != FAIL)
+        Vdetach(vg_id);
     SAFE_FREE(name); /* free name and set it to NULL */
 
     return ret_value;
@@ -415,9 +409,9 @@ int
 get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, int32 *n_entries,
               char **vgname, char **vgclass)
 {
-    int    status, ret_value = SUCCEED;
-    int32  status_32;
-    uint16 name_len = 0;
+    int     status, ret_value = SUCCEED;
+    int32   status_32;
+    ssize_t name_len = 0;
 
     /* detach the current vgroup if it's attached to cover the case
       where a library routine fails and must continue to the next vgroup
@@ -429,10 +423,10 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         ERROR_GOTO_2("in %s: Vattach failed for vgroup ref=%d", "get_VGandInfo", (int)vg_ref);
 
     /* get the length of the vgname to allocate enough space */
-    status_32 = Vgetnamelen(*vg_id, &name_len);
-    if (FAIL == status_32) /* go to done and return a FAIL */
+    name_len = Vgetname(*vg_id, 0, NULL);
+    if (name_len == FAIL) /* go to done and return a FAIL */
     {
-        ERROR_GOTO_2("in %s: Vgetnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
+        ERROR_GOTO_2("in %s: Vgetname failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
     if (name_len > 0) {
         *vgname = (char *)malloc(sizeof(char) * (name_len + 1));
@@ -440,7 +434,7 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
         CHECK_ALLOC(*vgname, "*vgname", "get_VGandInfo");
 
-        status = Vinquire(*vg_id, n_entries, *vgname);
+        status = Vinquire(*vg_id, n_entries, name_len + 1, *vgname);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -450,7 +444,7 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     else {
         *vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
         strcpy(*vgname, "<Undefined>");
-        status = Vinquire(*vg_id, n_entries, NULL);
+        status = Vinquire(*vg_id, n_entries, 0, NULL);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -459,10 +453,10 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     }
 
     /* get the length of the vgclass to allocate enough space */
-    status_32 = Vgetclassnamelen(*vg_id, &name_len);
-    if (FAIL == status_32) /* go to done and return a FAIL */
+    name_len = Vgetclass(*vg_id, 0, NULL);
+    if (name_len == FAIL) /* go to done and return a FAIL */
     {
-        ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
+        ERROR_GOTO_2("in %s: Vgetclass failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
     if (name_len > 0) {
         *vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
@@ -470,8 +464,8 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
         CHECK_ALLOC(*vgclass, "*vgclass", "get_VGandInfo");
 
-        status_32 = Vgetclass(*vg_id, *vgclass);
-        if (FAIL == status_32) /* go to done and return a FAIL */
+        name_len = Vgetclass(*vg_id, name_len + 1, *vgclass);
+        if (name_len == FAIL) /* go to done and return a FAIL */
         {
             ERROR_GOTO_2("in %s: Vgetclass failed for vgroup ref#=%d", "get_VGandInfo", (int)vg_ref);
         }
@@ -533,9 +527,6 @@ alloc_list_of_strings(int32 num_entries)
 {
     char **ptr = NULL;
 
-    /* I don't know why +1 here and only i<num_entries at for loop - BMR*/
-    /* probably, +1 so that malloc won't fail when num_entries = 0, was */
-    /* added in r1842.  But, that means possible memory leak! */
     ptr = (char **)malloc(sizeof(char *) * (size_t)num_entries);
 
     /* If allocation fails, alloc_list_of_string simply terminates hdp. */
@@ -584,7 +575,7 @@ print_fields(const char *fields, const char *field_title, FILE *fp)
     CHECK_ALLOC(tempflds, "tempflds", "print_fields");
 
     /* if fields are not defined by VSsetfields and VSfdefine */
-    if (fields[0] == '\0' || fields == NULL)
+    if (fields == NULL || fields[0] == '\0')
         fprintf(fp, "%s <Undefined>;\n", field_title);
 
     else { /* there are fields to print */
@@ -858,22 +849,27 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 /* get the current vgroup and its information */
                 status =
                     get_VGandInfo(&vgt, file_id, elem_ref, file_name, &elem_n_entries, &vgname, &vgclass);
-                if (status == FAIL)
+                if (status == FAIL) {
                     ERROR_NOTIFY_3("in %s: %s failed in getting vgroup with ref#=%d", "vgBuildGraph",
                                    "get_VGandInfo", (int)vg_ref);
 
-                /* although get_VGandInfo failed to get a valid id for this vgroup,
-                   the node for the vgroup is not affected, so build it anyway */
-                if (vgt == FAIL) {
-                    *skipfile = TRUE; /* severe failure, skip this file */
-                    ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
-                                   "vgBuildGraph", "get_VGandInfo", (int)entry_num);
+                    /* attach itself failed - nothing usable for this entry, skip it */
+                    if (vgt == FAIL) {
+                        *skipfile = TRUE; /* severe failure, skip this file */
+                        ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
+                                       "vgBuildGraph", "get_VGandInfo", (int)entry_num);
+                        continue;
+                    }
+                    /* attach succeeded but if name/class fetch failed, get_VGandInfo
+                       already freed and NULL'd vgname/vgclass on this path */
                 }
 
                 /* vgroup has no name */
-                if (strlen(vgname) == 0 || vgname == NULL) {
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgname);
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    strcat(vgname, "<Undefined>");
+                    CHECK_ALLOC(vgname, "vgname", "vgBuildGraph");
+                    strcpy(vgname, "<Undefined>");
                 }
 
                 resetVG(&vgt, file_name);
@@ -933,6 +929,7 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 aNode->children[entry_num] = alloc_string_of_chars("***");
 
                 if (!strcmp(name, "Unknown Tag")) {
+                    free(name);
                     aNode->type[entry_num] = alloc_string_of_chars("Unknown Object");
                 }
                 else
@@ -942,8 +939,8 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
         }     /* for */
     }
 done:
-    SAFE_FREE(vgname);  /* free vg name and set it to NULL */
-    SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
+    free(vgname);
+    free(vgclass);
 
     return ret_value;
 } /* vgBuildGraph */
@@ -1008,24 +1005,26 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 /* get the current vgroup and its information */
                 status =
                     get_VGandInfo(&vgt, file_id, elem_ref, file_name, &elem_n_entries, &vgname, &vgclass);
-                if (status == FAIL)
-                    ERROR_GOTO_3("in %s: %s failed in getting vgroup with ref#=%d", "vgdumpfull",
-                                 "get_VGandInfo", (int)vg_ref);
+                if (status == FAIL) {
+                    ERROR_NOTIFY_3("in %s: %s failed in getting vgroup with ref#=%d", "vgdumpfull",
+                                   "get_VGandInfo", (int)vg_ref);
 
-                /* since the succeeding processing depends on this vg id, we
-                   decided to just skip the current file.  Note that elem_n_entries
-                   is not checked here since it does not effect the following
-                   processing as in the case of the parent's vgroup */
-                if (vgt == FAIL) {
-                    /* return to caller to go to next file */
-                    *skipfile = TRUE;
-                    ERROR_GOTO_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
-                                 "vgdumpfull", "get_VGandInfo", (int)entry_num);
+                    /* attach itself failed - nothing usable for this entry, skip it */
+                    if (vgt == FAIL) {
+                        *skipfile = TRUE; /* severe failure, skip this file */
+                        ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
+                                       "vgdumpfull", "get_VGandInfo", (int)entry_num);
+                        continue;
+                    }
+                    /* attach succeeded but if name/class fetch failed, get_VGandInfo
+                       already freed and NULL'd vgname/vgclass on this path */
                 }
                 /* vgroup has no name */
-                if (strlen(vgname) == 0 || vgname == NULL) {
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgname);
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    strcat(vgname, "<Undefined>");
+                    CHECK_ALLOC(vgname, "vgname", "vgdumpfull");
+                    strcpy(vgname, "<Undefined>");
                 }
 
                 /* add the name and type of this element to the current graph */
@@ -1059,11 +1058,16 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
 
             }                                 /* if current element is vgroup */
             else if (elem_tag == VSDESCTAG) { /* vdata */
+                                              /* add type of this element to the current graph */
+                aNode->type[entry_num] = alloc_string_of_chars("vd");
 
                 vs = VSattach(file_id, elem_ref, "r");
-                if (vs == FAIL)
+                if (vs == FAIL) {
                     ERROR_NOTIFY_2("in %s: VSattach failed for vdata with ref#=%d", "vgdumpfull",
                                    (int)elem_ref);
+                    aNode->children[entry_num] = alloc_string_of_chars("<Invalid>");
+                    continue;
+                }
 
                 /* get and print vdata's information */
                 status = VSinquire(vs, &nv, &interlace, fields, &vsize, vsname);
@@ -1126,9 +1130,8 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 if (strlen(vsname) == 0)
                     strcat(vsname, "<Undefined>");
 
-                /* add the name and type of this element to the list node */
+                /* add the name of this element to the list node */
                 aNode->children[entry_num] = alloc_string_of_chars(vsname);
-                aNode->type[entry_num]     = alloc_string_of_chars("vd");
 
             }    /* if current element is a vdata */
             else /* else something else */
@@ -1308,8 +1311,8 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
             /* attaches the current vgroup and gets its tag, name, and class */
             status = get_VGandInfo(&vg_id, file_id, vg_ref, file_name, &n_entries, &vgname, &vgclass);
             if (status == FAIL)
-                ERROR_CONT_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
-                             (int)vg_ref);
+                ERROR_NOTIFY_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
+                               (int)vg_ref);
 
             /* since the succeeding processing depends heavily on these
                we decided to just skip the current file */
@@ -1331,7 +1334,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
                 CHECK_ALLOC(list, "list", "dvg");
             }
 
-            list[curr_vg] = (vg_info_t *)malloc(sizeof(vg_info_t));
+            list[curr_vg] = (vg_info_t *)calloc(1, sizeof(vg_info_t));
             CHECK_ALLOC(list[curr_vg], "list[curr_vg]", "dvg");
             list[curr_vg]->children = NULL;
             list[curr_vg]->type     = NULL;
@@ -1451,8 +1454,8 @@ done:
         resetVG(&vg_id, file_name);
         list = free_vginfo_list(list, curr_vg);
         closeVG(&file_id, &vg_chosen, file_name);
-        SAFE_FREE(vgname);  /* free vg name and set it to NULL */
-        SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
+        free(vgname);
+        free(vgclass);
     }
 
     return ret_value;

--- a/mfhdf/hrepack/hrepack_list.c
+++ b/mfhdf/hrepack/hrepack_list.c
@@ -26,6 +26,7 @@
 #include "hrepack_an.h"
 #include "hrepack_vg.h"
 #include "hrepack_dim.h"
+#include "vg_priv.h"
 
 int list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_id, int32 gr_out,
             list_table_t *list_tbl, dim_table_t *td1, dim_table_t *td2, options_t *options);
@@ -235,6 +236,7 @@ list_main(const char *infname, const char *outfname, options_t *options)
         printf("Failed to close file <%s>\n", infname);
     if (Hclose(infile_id) == FAIL)
         printf("Failed to close file <%s>\n", infname);
+    infile_id = FAIL;
 
     if (options->trip == 1) {
         if (has_GRelems)
@@ -244,6 +246,7 @@ list_main(const char *infname, const char *outfname, options_t *options)
             printf("Failed to close file <%s>\n", outfname);
         if (Hclose(outfile_id) == FAIL)
             printf("Failed to close file <%s>\n", outfname);
+        infile_id = FAIL;
     }
 
     /*-------------------------------------------------------------------------
@@ -360,9 +363,8 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
          * iterate through each lone vgroup.
          */
         for (i = 0; i < nlones; i++) {
-
             int32  ref = ref_array[i];
-            uint16 name_len;
+            size_t name_len;
 
             /*
              * attach to the current vgroup then get its
@@ -375,30 +377,16 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
             }
 
             /* Get vgroup's name */
-            if (Vgetnamelen(vg_id, &name_len) == FAIL) {
+            vg_name = vgetvgname(vg_id);
+            if (!vg_name) {
                 printf("Error: Could not get name length for group with ref <%d>\n", ref);
                 goto out;
             }
 
-            free(vg_name);
-            vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetname(vg_id, vg_name) == FAIL) {
-                printf("Could not get name for group\n");
-                goto out;
-            }
-
-            /* Get vgroup's class name */
-            if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                printf("Error: Could not get name length for group with ref <%d>\n", ref);
-                goto out;
-            }
-
-            free(vg_class);
-            vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetclass(vg_id, vg_class) == FAIL) {
-                printf("Could not get class for group\n");
+            /* Get vgroup's class */
+            vg_class = vgetvgclass(vg_id);
+            if (!vg_class) {
+                printf("Error: Could not get class length for group with ref <%d>\n", ref);
                 goto out;
             }
 
@@ -472,10 +460,8 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
                     goto out;
                 }
 
-                free(tags);
-                tags = NULL;
-                free(refs);
-                refs = NULL;
+                HDfreenclear(tags);
+                HDfreenclear(refs);
             }
 
             if (Vdetach(vg_id) == FAIL) {
@@ -489,14 +475,12 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
                 }
             }
 
-            free(vg_class);
-            vg_class = NULL;
-            free(vg_name);
-            vg_name = NULL;
+            HDfreenclear(vg_class);
+            HDfreenclear(vg_name);
         } /* for nlones */
 
         /* free the space allocated */
-        free(ref_array);
+        HDfreenclear(ref_array);
 
     } /* if  nlones */
 
@@ -509,6 +493,7 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
         printf("Error: Could not end infile group interface\n");
         return FAIL;
     }
+    infile_id = FAIL;
     if (options->trip == 1) {
         if (Vend(outfile_id) == FAIL) {
             printf("Error: Could not end outfile group interface\n");
@@ -516,8 +501,8 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
         }
     }
 
-    free(vg_class);
-    free(vg_name);
+    HDfreenclear(vg_class);
+    HDfreenclear(vg_name);
 
     return SUCCEED;
 
@@ -565,7 +550,7 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
     char  *vg_name       = NULL;
     char  *vg_class      = NULL;
     char  *path          = NULL;
-    uint16 name_len;
+    size_t name_len;
     int    visited;
     int32  tag;
     int32  ref;
@@ -592,27 +577,16 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                 vg_id = Vattach(infile_id, ref, "r");
 
                 /* Get vgroup's name */
-                if (Vgetnamelen(vg_id, &name_len) == FAIL) {
+                vg_name = vgetvgname(vg_id);
+                if (!vg_name) {
                     printf("Error: Could not get name length for group with ref <%d>\n", ref);
-                    goto out;
-                }
-                free(vg_name);
-                vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-                if (Vgetname(vg_id, vg_name) == FAIL) {
-                    printf("Could not get name for group\n");
                     goto out;
                 }
 
                 /* Get vgroup's class name */
-                if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                    printf("Error: Could not get name length for group with ref <%d>\n", ref);
-                    goto out;
-                }
-
-                free(vg_class);
-                vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-                if (Vgetclass(vg_id, vg_class) == FAIL) {
-                    printf("Could not get class for group\n");
+                vg_class = vgetvgclass(vg_id);
+                if (!vg_class) {
+                    printf("Error: Could not get class length for group with ref <%d>\n", ref);
                     goto out;
                 }
 
@@ -629,6 +603,7 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                         printf("Could not detach group\n");
                         goto out;
                     }
+                    vg_id = FAIL;
                     continue;
                 }
 
@@ -774,11 +749,9 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                 }
                 break;
         } /* switch */
-        free(vg_name);
-        vg_name = NULL;
+        HDfreenclear(vg_name);
+        HDfreenclear(vg_class);
     } /* i */
-    free(vg_class);
-    free(vg_name);
 
     return SUCCEED;
 

--- a/mfhdf/src/cdf.c
+++ b/mfhdf/src/cdf.c
@@ -15,11 +15,12 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "nc_priv.h"
+#include "vg_priv.h"
 #include "herr_priv.h"
 
 #include "hfile_priv.h"
 
-int32 hdf_get_magicnum(const char *filename);
+static int32 hdf_get_magicnum(const char *filename);
 
 static int hdf_num_attrs(NC   *handle, /* IN: handle to SDS */
                          int32 vg /* IN: ref of top Vgroup */);
@@ -79,6 +80,13 @@ NC_free_cdf(NC *handle)
     }
 
 done:
+    if (ret_value == FAIL) {
+        if (handle->file_type == HDF_FILE) {
+            Vend(handle->hdf_file);
+            Hclose(handle->hdf_file);
+        }
+    }
+
     return ret_value;
 }
 
@@ -88,7 +96,7 @@ done:
   can be used to determine the format type of a file, such as HDF, CDF, or
   netCDF/64-bit.
 */
-int32
+static int32
 hdf_get_magicnum(const char *filename)
 {
     hdf_file_t fp;
@@ -1153,15 +1161,17 @@ done:
 int
 hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
 {
-    char     vgname[H4_MAX_NC_NAME]   = "";
-    char     vsclass[H4_MAX_NC_CLASS] = "";
-    char     vgclass[H4_MAX_NC_CLASS] = "";
     int      id, count, i, found;
     int      sub_id;
+    char    *vgname                   = NULL; /* name of a vgroup, used by new Vgetname */
+    char    *vgclass                  = NULL; /* class of a vgroup, used by new Vgetclass */
+    size_t   buf_size                 = 0;    /* length of the name or class of a vgroup */
+    char     vsclass[H4_MAX_NC_CLASS] = "";   /* name of vdata */
     int32    dim_size;
     NC_dim **dimension = NULL;
-    int32    dim, entries;
-    int32    vs;
+    int32    dimvg     = -1;
+    int32    vs        = -1;
+    int32    entries;
     int      ret_value = SUCCEED;
 
     (void)xdrs;
@@ -1181,34 +1191,40 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
     }
 
     /*
-     * Look through for a Vgroup of class _HDF_DIMENSION
+     * Look through cdf vg for a Vgroup of class _HDF_[U]DIMENSION, then in that dim
+     * Vgroup, look for the Vdata of class DIM_VALS01 or DIM_VALS to get the size
      */
     while ((id = Vgetnext(vg, id)) != FAIL) {
         if (Visvg(vg, id)) {
-            dim = Vattach(handle->hdf_file, id, "r");
-            if (dim == FAIL)
-                continue; /* why do we continue? does this failure here
-                                not matter? -GV */
-            if (Vgetclass(dim, vgclass) == FAIL)
+            dimvg = Vattach(handle->hdf_file, id, "r");
+            if (dimvg == FAIL)
+                continue; /* to the next vg */
+
+            /* Get the class of the vgroup, should be a dimension */
+            vgclass = vgetvgclass(dimvg);
+            if (!vgclass)
                 HGOTO_FAIL(FAIL);
 
+            /* Process if the dimension vgroup */
             if (!strcmp(vgclass, _HDF_DIMENSION) || !strcmp(vgclass, _HDF_UDIMENSION)) {
                 int is_dimval, is_dimval01;
 
-                /* init both flags to FALSE  */
+                /* Init both flags to FALSE  */
                 is_dimval   = FALSE;
                 is_dimval01 = FALSE;
 
-                if (Vinquire(dim, &entries, vgname) == FAIL)
+                /* Get the vgroup name */
+                vgname = vgetvgname(dimvg);
+                if (!vgname)
                     HGOTO_FAIL(FAIL);
 
                 /*
-                 * look through for a Vdata of class DIM_VALS01 and/or DIM_VALS
+                 * Look through for a Vdata of class DIM_VALS01 and/or DIM_VALS
                  * to get size
                  */
                 sub_id = -1;
-                while (((sub_id = Vgetnext(dim, sub_id)) != FAIL)) {
-                    if (Visvs(dim, sub_id)) {
+                while (((sub_id = Vgetnext(dimvg, sub_id)) != FAIL)) {
+                    if (Visvs(dimvg, sub_id)) {
                         vs = VSattach(handle->hdf_file, sub_id, "r");
                         if (vs == FAIL)
                             HGOTO_FAIL(FAIL);
@@ -1285,7 +1301,7 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
                                 dimension[count]->dim00_compat = 0;
 
                             /* record vgroup id here so we can use later */
-                            /* Note: this is only for later file -BMR */
+                            /* Note: this is only for later file */
                             dimension[count]->vgid = id;
 
                             count++;
@@ -1294,8 +1310,13 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
                 }         /* while in dimension vg  */
             }             /* is vg  */
 
-            if (Vdetach(dim) == FAIL)
+            if (Vdetach(dimvg) == FAIL)
                 HGOTO_FAIL(FAIL);
+            dimvg = FAIL;
+            free(vgclass);
+            vgclass = NULL;
+            free(vgname);
+            vgname = NULL;
         } /* while */
     }
 
@@ -1309,6 +1330,8 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
 
 done:
     if (ret_value == FAIL) {
+        if (dimvg != -1)
+            Vdetach(dimvg);
         if (handle->dims != NULL) {
             NC_free_array(handle->dims);
             handle->dims = NULL;
@@ -1316,6 +1339,8 @@ done:
     }
 
     free(dimension);
+    free(vgname);
+    free(vgclass);
 
     return ret_value;
 } /* hdf_read_dims */
@@ -1505,11 +1530,8 @@ done:
 int
 hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
 {
-    char vgname[H4_MAX_NC_NAME]  = "";
-    char subname[H4_MAX_NC_NAME] = "";
-    char class[H4_MAX_NC_CLASS]  = "";
-    NC_var      **variables      = NULL;
-    NC_var       *vp             = NULL;
+    NC_var      **variables = NULL;
+    NC_var       *vp        = NULL;
     int           ndims, *dims = NULL;
     uint8         ntstring[4];
     int           data_ref, is_rec_var, vg_size, count;
@@ -1517,7 +1539,6 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
     int32         HDFtype = FAIL;
     int32         tag;
     int32         id;
-    int32         n;
     int32         sub_id;
     int32         entries;
     int32         ndg_ref = 0;
@@ -1526,8 +1547,13 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
     hdf_vartype_t var_type = UNKNOWN;
     int           t, i;
     nc_type       type;
-    int32         var, sub;
-    int           ret_value = SUCCEED;
+    int32         varvg, subvg;
+    char         *vgname     = NULL;
+    char         *vgclass    = NULL;
+    char         *dimvgname  = NULL;
+    char         *dimvgclass = NULL;
+    size_t        buf_size   = 0; /* Length of buffer for name or class */
+    int           ret_value  = SUCCEED;
 
     count = 0;
     id    = -1;
@@ -1561,17 +1587,18 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
         }
 
         if (tag == DFTAG_VG) {
-            var = Vattach(handle->hdf_file, id, "r");
-            if (var == FAIL)
-                continue; /* isn't this bad? -GV */
+            varvg = Vattach(handle->hdf_file, id, "r");
+            if (varvg == FAIL)
+                continue; /* skip a bad var */
 
-            if (Vgetclass(var, class) == FAIL) {
+            /* Get the class of the variable vgroup */
+            vgclass = vgetvgclass(varvg);
+            if (!vgclass)
                 HGOTO_FAIL(FAIL);
-            }
 
             /* Process as below if this VGroup represents a Variable or
             a Coordinate Variable */
-            if (!strcmp(class, _HDF_VARIABLE)) {
+            if (!strcmp(vgclass, _HDF_VARIABLE)) {
 
                 /*
                  * We have found a VGroup representing a Variable or a
@@ -1584,59 +1611,62 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                 rag_ref    = 0;
                 is_rec_var = FALSE;
 
-                if (Vinquire(var, &n, vgname) == FAIL) {
+                /* Get the number of entries in the variable vgroup */
+                if (Vinquire(varvg, &entries, 0, NULL) == FAIL)
                     HGOTO_FAIL(FAIL);
-                }
 
                 /*
                  * Loop through contents looking for dimensions
                  */
-                for (t = 0; t < n; t++) {
-                    char dimclass[H4_MAX_NC_CLASS] = "";
-                    char vsclass[H4_MAX_NC_CLASS]  = "";
-                    if (Vgettagref(var, t, &tag, &sub_id) == FAIL) {
+                for (t = 0; t < entries; t++) {
+                    char vsclass[H4_MAX_NC_CLASS] = "";
+                    if (Vgettagref(varvg, t, &tag, &sub_id) == FAIL) {
                         HGOTO_FAIL(FAIL);
                     }
 
                     switch (tag) {
                         case DFTAG_VG: /* ------ V G R O U P ---------- */
-                            sub = Vattach(handle->hdf_file, sub_id, "r");
-                            if (FAIL == sub) {
+                            subvg = Vattach(handle->hdf_file, sub_id, "r");
+                            if (FAIL == subvg) {
                                 HGOTO_FAIL(FAIL);
                             }
-
-                            if (FAIL == Vgetclass(sub, dimclass)) {
+                            /* Get the class of the dimension vgroup */
+                            dimvgclass = vgetvgclass(subvg);
+                            if (!dimvgclass)
                                 HGOTO_FAIL(FAIL);
-                            }
 
-                            if (!strcmp(dimclass, _HDF_DIMENSION) || !strcmp(dimclass, _HDF_UDIMENSION)) {
+                            if (!strcmp(dimvgclass, _HDF_DIMENSION) || !strcmp(dimvgclass, _HDF_UDIMENSION)) {
 
-                                if (!strcmp(dimclass, _HDF_UDIMENSION))
+                                /* Mark if the dimension is an unlimited dimension */
+                                if (!strcmp(dimvgclass, _HDF_UDIMENSION))
                                     is_rec_var = TRUE;
 
-                                if (FAIL == Vinquire(sub, &entries, subname)) {
+                                /* Get the name of the dimension vg */
+                                dimvgname = vgetvgname(subvg);
+                                if (!dimvgname)
                                     HGOTO_FAIL(FAIL);
-                                }
 
-                                dims[ndims] = (int)NC_dimid(handle, subname);
-                                if (-1 == dims[ndims]) /* should change to FAIL */
-                                {
+                                dims[ndims] = NC_dimid(handle, dimvgname);
+                                free(dimvgname);
+                                if (dims[ndims] == -1)
                                     HGOTO_FAIL(FAIL);
-                                }
 
+                                /* Increment the number of dimensions in varvg */
                                 ndims++;
                             }
-                            if (FAIL == Vdetach(sub)) {
+                            if (FAIL == Vdetach(subvg)) {
                                 HGOTO_FAIL(FAIL);
                             }
+                            subvg = FAIL;
+                            HDfreenclear(dimvgclass);
 
                             break;
                         case DFTAG_VH: /* ----- V D A T A ----- */
-                            sub = VSattach(handle->hdf_file, sub_id, "r");
-                            if (FAIL == sub)
+                            subvg = VSattach(handle->hdf_file, sub_id, "r");
+                            if (FAIL == subvg)
                                 HGOTO_FAIL(FAIL);
 
-                            if (FAIL == VSgetclass(sub, vsclass))
+                            if (FAIL == VSgetclass(subvg, vsclass))
                                 HGOTO_FAIL(FAIL);
 
                             if (!strcmp(vsclass, _HDF_SDSVAR))
@@ -1646,7 +1676,7 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                             else
                                 var_type = UNKNOWN;
 
-                            if (FAIL == VSdetach(sub))
+                            if (FAIL == VSdetach(subvg))
                                 HGOTO_FAIL(FAIL);
                             break;
                         case DFTAG_NDG: /* ----- NDG Tag for HDF 3.2 ----- */
@@ -1709,6 +1739,11 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                     }
                 }
 
+                /* Get the name of the variable vgroup */
+                vgname = vgetvgname(varvg);
+                if (!vgname)
+                    HGOTO_FAIL(FAIL);
+
                 variables[count] = NC_new_var(vgname, type, ndims, dims);
                 /* BMR: put back hdf type that was set wrong by
                 NC_new_var; please refer to the cvs history of
@@ -1722,8 +1757,8 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                 }
 
                 /* Read in the attributes if any */
-                if ((nattrs = hdf_num_attrs(handle, var)) > 0)
-                    vp->attrs = hdf_read_attrs(xdrs, handle, var);
+                if ((nattrs = hdf_num_attrs(handle, varvg)) > 0)
+                    vp->attrs = hdf_read_attrs(xdrs, handle, varvg);
                 else
                     vp->attrs = NULL;
 
@@ -1772,12 +1807,8 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                          * Deallocate the shape info as it will be recomputed
                          *  at a higher level later
                          */
-                        free(vp->shape);
-                        free(vp->dsizes);
-                        /* Reset these two pointers to NULL after
-                            freeing.  BMR 4/11/01 */
-                        vp->shape  = NULL;
-                        vp->dsizes = NULL;
+                        HDfreenclear(vp->shape);
+                        HDfreenclear(vp->dsizes);
                     }
                     else {
                         /* Not a rec var, don't worry about it */
@@ -1789,8 +1820,12 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
 
 bad_number_type: /* ? */
 
-            if (FAIL == Vdetach(var))
+            if (FAIL == Vdetach(varvg))
                 HGOTO_FAIL(FAIL);
+            varvg = FAIL;
+
+            HDfreenclear(vgclass);
+            HDfreenclear(vgname);
 
         } /* end if DTAG_VG */
     }     /* end for vg_size */
@@ -1812,6 +1847,9 @@ done:
 
     free(variables);
     free(dims);
+    free(vgname);
+    free(vgclass);
+    free(dimvgclass);
 
     return ret_value;
 } /* hdf_read_vars */
@@ -1996,7 +2034,7 @@ done:
 int
 hdf_cdf_clobber(NC *handle)
 {
-    int32 vg, tag, ref;
+    int32 vg = FAIL, tag, ref;
     int   n, t, status;
     int   ret_value = SUCCEED;
 
@@ -2073,6 +2111,8 @@ hdf_cdf_clobber(NC *handle)
     handle->vgid = 0; /* reset ref of SDS vgroup to invalid ref */
 
 done:
+    if (vg != FAIL)
+        Vdetach(vg);
     return ret_value;
 } /* hdf_cdf_clobber */
 
@@ -2097,10 +2137,10 @@ hdf_close(NC *handle)
     uint8_t  *vars = NULL;
     int       i;
     int       id, sub_id;
-    int32     vg, dim;
-    int32     vs;
-    char class[H4_MAX_NC_CLASS] = "";
-    int ret_value               = SUCCEED;
+    int32     vg = FAIL, dim = FAIL, vs = FAIL;
+    char     *vgclass                  = NULL;
+    char      vsclass[H4_MAX_NC_CLASS] = "";
+    int       ret_value                = SUCCEED;
 
     /* loop through and detach from variable data VDatas */
     if (handle->vars) {
@@ -2138,12 +2178,12 @@ hdf_close(NC *handle)
                     HGOTO_FAIL(FAIL);
                 }
 
-                if (FAIL == Vgetclass(dim, class)) {
+                vgclass = vgetvgclass(dim);
+                if (!vgclass)
                     HGOTO_FAIL(FAIL);
-                }
 
                 /* look for proper vgroup */
-                if (!strcmp(class, _HDF_UDIMENSION)) {
+                if (!strcmp(vgclass, _HDF_UDIMENSION)) {
                     sub_id = -1;
                     /* look for vdata in vgroup */
                     while ((sub_id = Vgetnext(dim, sub_id)) != FAIL) {
@@ -2154,12 +2194,12 @@ hdf_close(NC *handle)
                                 /* HEprint(stdout, 0); */
                             }
                             /* get class of vdata */
-                            if (FAIL == VSgetclass(vs, class)) {
+                            if (FAIL == VSgetclass(vs, vsclass)) {
                                 HGOTO_FAIL(FAIL);
                             }
 
                             /* are these dimension vdatas? */
-                            if (!strcmp(class, DIM_VALS) || !strcmp(class, DIM_VALS01)) { /* yes */
+                            if (!strcmp(vsclass, DIM_VALS) || !strcmp(vsclass, DIM_VALS01)) { /* yes */
                                 int32 val = handle->numrecs;
 
                                 if (FAIL == VSsetfields(vs, "Values")) {
@@ -2177,9 +2217,9 @@ hdf_close(NC *handle)
                             }
 
                             /* detach from vdata */
-                            if (FAIL == VSdetach(vs)) {
+                            if (FAIL == VSdetach(vs))
                                 HGOTO_FAIL(FAIL);
-                            }
+                            vs = FAIL;
 
                         } /* end if vdata */
                     }     /* end while looking for vdata in vgroup */
@@ -2189,17 +2229,29 @@ hdf_close(NC *handle)
                     fprintf(stderr, "hdf_close: Vdetach failed for vgroup ref %d\n", id);
                     HGOTO_FAIL(FAIL);
                 }
+                dim = FAIL;
+                HDfreenclear(vgclass);
 
             } /* end if vgroup */
         }     /* end if looking through toplevel vgroup hierarchy */
 
-        if (FAIL == Vdetach(vg)) {
+        if (FAIL == Vdetach(vg))
             HGOTO_FAIL(FAIL);
-        }
+        vg = FAIL;
 
     } /* end if we need to flush out unlimited dimensions? */
 
 done:
+    if (ret_value == FAIL) {
+        if (dim != FAIL)
+            Vdetach(dim);
+        if (vs != FAIL)
+            VSdetach(vs);
+        if (vg != FAIL)
+            Vdetach(vg);
+        free(vgclass);
+    }
+
     return ret_value;
 } /* hdf_close */
 

--- a/mfhdf/test/tdatainfo.c
+++ b/mfhdf/test/tdatainfo.c
@@ -44,7 +44,6 @@
 
 #if defined H4_HAVE_WIN32_API
 #define snprintf sprintf_s
-#define ssize_t  int32
 #endif
 
 #ifdef H4_HAVE_LIBSZ
@@ -353,9 +352,9 @@ test_nonspecial_SDSs()
 
     /* Open file and read in data without using SD API */
     {
-        int32   ret32;       /* for DFKconvert */
-        ssize_t readlen = 0; /* for read */
-        int     kk;
+        int32     ret32;       /* for DFKconvert */
+        ptrdiff_t readlen = 0; /* for read, portable ssize_t substitute */
+        int       kk;
 
         /* Open the file for reading without SD API */
         fd = open(SIMPLE_FILE, O_RDONLY);
@@ -1093,8 +1092,8 @@ test_chunked_partial()
 
     /* Read each chunk and compare values */
     for (chk_num = 0; chk_num < info_count; chk_num++) {
-        int32   ret32;       /* for DFKconvert */
-        ssize_t readlen = 0; /* for read */
+        int32     ret32;       /* for DFKconvert */
+        ptrdiff_t readlen = 0; /* for read, portable ssize_t substitute */
 
         /* Forward to the position of the data of the SDS */
         if (lseek(fd, (off_t)sds_info.offsets[chk_num], SEEK_SET) == -1) {

--- a/mfhdf/test/tmixed_apis.c
+++ b/mfhdf/test/tmixed_apis.c
@@ -29,6 +29,7 @@
 #include <string.h>
 
 #include "mfhdf.h"
+#include "vg_priv.h"
 #include "hdftest.h"
 
 #define IDTYPE_FILE "idtypes.hdf" /* data file to test ID types */
@@ -265,8 +266,8 @@ test_vdatavgroups()
     float32     att1_values[2] = {2., 10.};
     char8       att2_values[]  = "Seconds";
     uint16     *refarray       = NULL;
-    uint16      name_len       = 0;
     int         ii, status;
+    size_t      buf_size          = 0;
     char       *vg_name           = NULL, vd_name[10];
     const char *check_vg_names[3] = {"Vgroup_1", "Vgroup_2", "Vgroup_3"};
     const char *check_vd_names[1] = {"Vdata_1"};
@@ -395,24 +396,16 @@ test_vdatavgroups()
         vgroup_id = Vattach(fid, refarray[ii], "r");
         CHECK(vgroup_id, FAIL, "Vattach");
 
-        status = Vgetnamelen(vgroup_id, &name_len);
-        CHECK(status, FAIL, "Vgetnamelen");
+        vg_name = vgetvgname(vgroup_id);
+        CHECK(vg_name, NULL, "vgetvgname");
 
-        vg_name = (char *)malloc((sizeof(char) * name_len) + 1);
-        CHECK_ALLOC(vg_name, "vg_name", "test_vdatavgroups");
-
-        status = Vgetname(vgroup_id, vg_name);
-        CHECK(status, FAIL, "Vgetname");
-        VERIFY_CHAR(vg_name, check_vg_names[ii], "");
-
-        if (strncmp(vg_name, check_vg_names[ii], name_len) != 0)
+        if (strcmp(vg_name, check_vg_names[ii]) != 0)
             fprintf(stderr, "vg %d: name is %s, should be %s\n", ii, vg_name, check_vg_names[ii]);
 
         /* Release resource */
-        free(vg_name);
-        vg_name = NULL;
-        status  = Vdetach(vgroup_id);
+        status = Vdetach(vgroup_id);
         CHECK(status, FAIL, "Vdetach");
+        HDfreenclear(vg_name);
     }
     /* Release resource */
     free(refarray);
@@ -442,7 +435,7 @@ test_vdatavgroups()
 
         VERIFY_CHAR(vd_name, check_vd_names[ii], "");
 
-        if (strncmp(vd_name, check_vd_names[ii], name_len) != 0)
+        if (strcmp(vd_name, check_vd_names[ii]) != 0)
             fprintf(stderr, "vd %d: name is %s, should be %s\n", ii, vd_name, check_vd_names[ii]);
         status = VSdetach(vdata_id);
         CHECK(status, FAIL, "VSdetach");


### PR DESCRIPTION
Vgetname, Vgetclass, and Vinquire performed unbounded strcpy into caller-supplied buffers with no length parameter, allowing stack buffer overflows on names/classes longer than the caller anticipated.

Each function now takes a buf_size parameter and returns the actual name/class length on success or FAIL on error, using ptrdiff_t (instead of ssize_t) as the return type for Windows portability without a POSIX-type workaround. This makes Vgetnamelen and Vgetclassnamelen redundant, so they're removed.

Two utility functions were added, vgetvgname/vgetvgclass.  They return the name/class of a vgroup, allocating the buffer internally so the caller does not need to know the length of the name/class in advance.  Strictly intended for use within the library and tools only by including the private header file vg_priv.h; the caller is responsible for freeing the returned buffer.

BREAKING: callers must update call sites to pass buf_size to any of these three functions and replace the calls to Vgetnamelen/Vgetclassnamelen by the appropriate Vgetname/Vgetclass calls, passing in 0 and NULL for buffer size and buffer.

Fixes #872