### PR TITLE
Fix stack buffer overflow in Vgetname/Vgetclass/Vinquire

### DIFF
--- a/HDF4Examples/C/VG/h4ex_VG_get_vgroup_info.c
+++ b/HDF4Examples/C/VG/h4ex_VG_get_vgroup_info.c
@@ -65,25 +65,27 @@ main()
              * moving to the next.
              */
             vgroup_id = Vattach(file_id, ref_array[lone_vg_number], "r");
-            if (Vgetnamelen(vgroup_id, &name_len) == FAIL)
-                printf("*** ERROR from Vgetnamelen\n");
+            if ((name_len = Vgetname(vgroup_id, NULL, 0)) == FAIL)
+                printf("*** ERROR from Vgetname to get length of vgroup name\n");
             vgroup_name = (char *)malloc(sizeof(char *) * (name_len + 1));
             if (vgroup_name == NULL) {
                 fprintf(stderr, "Not enough memory for vgroup_name!\n");
                 exit(1);
             }
-            if (Vgetname(vgroup_id, vgroup_name) == FAIL)
-                printf("*** ERROR from Vgetname\n");
+            name_len++;
+            if (Vgetname(vgroup_id, vgroup_name, &name_len) == FAIL)
+                printf("*** ERROR from Vgetname to get vgroup name\n");
 
-            if (Vgetclassnamelen(vgroup_id, &name_len) == FAIL)
-                printf("*** ERROR from Vgetclassnamelen\n");
+            if ((name_len = Vgetclass(vgroup_id, NULL, 0)) == FAIL)
+                printf("*** ERROR from Vgetclass to get length of vgroup class\n");
             vgroup_class = (char *)malloc(sizeof(char *) * (name_len + 1));
             if (vgroup_class == NULL) {
                 fprintf(stderr, "Not enough memory for vgroup_class!\n");
                 exit(1);
             }
-            if (Vgetclass(vgroup_id, vgroup_class) == FAIL)
-                printf("*** ERROR from Vgetclass\n");
+            name_len++;
+            if (Vgetclass(vgroup_id, vgroup_class, name_len + 1) == FAIL)
+                printf("*** ERROR from Vgetclass to get vgroup class\n");
             fprintf(stderr, "   Vgroup name %s and class %s\n", vgroup_name, vgroup_class);
             if (Vdetach(vgroup_id) == FAIL)
                 printf("*** ERROR from Vdetach\n");

--- a/HDF4Examples/C/VG/h4ex_VG_get_vgroup_info.c
+++ b/HDF4Examples/C/VG/h4ex_VG_get_vgroup_info.c
@@ -14,8 +14,8 @@ main()
     int32  lone_vg_number;      /* current lone vgroup number */
     int32  num_of_lones = 0;    /* number of lone vgroups */
     int32 *ref_array    = NULL; /* buffer to hold the ref numbers of lone vgroups   */
-    char  *vgroup_name, *vgroup_class;
-    uint16 name_len;
+    char  *vgroup_name = NULL, *vgroup_class = NULL;
+    size_t name_len;
 
     /********************** End of variable declaration **********************/
 
@@ -65,7 +65,9 @@ main()
              * moving to the next.
              */
             vgroup_id = Vattach(file_id, ref_array[lone_vg_number], "r");
-            if ((name_len = Vgetname(vgroup_id, NULL, 0)) == FAIL)
+
+            /* Get the vgroup name */
+            if (Vgetname(vgroup_id, NULL, &name_len) == FAIL)
                 printf("*** ERROR from Vgetname to get length of vgroup name\n");
             vgroup_name = (char *)malloc(sizeof(char *) * (name_len + 1));
             if (vgroup_name == NULL) {
@@ -76,7 +78,8 @@ main()
             if (Vgetname(vgroup_id, vgroup_name, &name_len) == FAIL)
                 printf("*** ERROR from Vgetname to get vgroup name\n");
 
-            if ((name_len = Vgetclass(vgroup_id, NULL, 0)) == FAIL)
+            /* Get the vgroup class */
+            if (Vgetclass(vgroup_id, NULL, &name_len) == FAIL)
                 printf("*** ERROR from Vgetclass to get length of vgroup class\n");
             vgroup_class = (char *)malloc(sizeof(char *) * (name_len + 1));
             if (vgroup_class == NULL) {
@@ -84,9 +87,12 @@ main()
                 exit(1);
             }
             name_len++;
-            if (Vgetclass(vgroup_id, vgroup_class, name_len + 1) == FAIL)
+            if (Vgetclass(vgroup_id, vgroup_class, &name_len) == FAIL)
                 printf("*** ERROR from Vgetclass to get vgroup class\n");
+
             fprintf(stderr, "   Vgroup name %s and class %s\n", vgroup_name, vgroup_class);
+
+            /* Release resources */
             if (Vdetach(vgroup_id) == FAIL)
                 printf("*** ERROR from Vdetach\n");
             free(vgroup_name);

--- a/hdf/src/hproto.h
+++ b/hdf/src/hproto.h
@@ -1402,15 +1402,11 @@ HDFLIBAPI int32 Vgetid(HFILEID f, int32 vgid);
 
 HDFLIBAPI int32 Vgetnext(int32 vkey, int32 id);
 
-HDFLIBAPI int32 Vgetname(int32 vkey, char *vgname);
+HDFLIBAPI int Vgetname(int32 vkey, char *vgname, size_t *buf_size);
 
-HDFLIBAPI int32 Vgetnamelen(int32 vkey, uint16 *name_len);
+HDFLIBAPI int Vgetclass(int32 vkey, char *vgclass, size_t *buf_size);
 
-HDFLIBAPI int32 Vgetclassnamelen(int32 vkey, uint16 *classname_len);
-
-HDFLIBAPI int32 Vgetclass(int32 vkey, char *vgclass);
-
-HDFLIBAPI int Vinquire(int32 vkey, int32 *nentries, char *vgname);
+HDFLIBAPI int Vinquire(int32 vkey, int32 *nentries, char *vgname, size_t *buf_size);
 
 HDFLIBAPI int32 Vdelete(int32 f, int32 ref);
 

--- a/hdf/src/hproto_fortran.h
+++ b/hdf/src/hproto_fortran.h
@@ -944,11 +944,11 @@ HDFFCLIBAPI intf nvatchc(intf *f, intf *vgid, _fcd accesstype);
 
 HDFFCLIBAPI intf nvdtchc(intf *vkey);
 
-HDFFCLIBAPI intf nvgnamc(intf *vkey, _fcd vgname);
+HDFFCLIBAPI intf nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen);
 
-HDFFCLIBAPI intf nvgclsc(intf *vkey, _fcd vgclass);
+HDFFCLIBAPI intf nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen);
 
-HDFFCLIBAPI intf nvinqc(intf *vkey, intf *nentries, _fcd vgname);
+HDFFCLIBAPI intf nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen);
 
 HDFFCLIBAPI intf nvdeletec(intf *f, intf *vkey);
 

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -611,9 +611,9 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
         gr_ptr->gr_ref = gr_ref; /* squirrel this away for later use */
         if ((gr_key = Vattach(file_id, (int32)gr_ref, "r")) != FAIL) {
             int32 nobjs = Vntagrefs(gr_key); /* The number of objects in the Vgroup */
-            int32  grp_tag, grp_ref;          /* a tag/ref in the Vgroup */
-            int32  img_tag, img_ref;          /* image tag/ref in the Vgroup */
-            char   textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
+            int32 grp_tag, grp_ref;          /* a tag/ref in the Vgroup */
+            int32 img_tag, img_ref;          /* image tag/ref in the Vgroup */
+            char  textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
 
             for (i = 0; i < nobjs; i++) {
                 if (Vgettagref(gr_key, i, &grp_tag, &grp_ref) == FAIL)
@@ -622,7 +622,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 switch (grp_tag) {
                     case DFTAG_VG: /* should be an image */
                         if ((img_key = Vattach(file_id, grp_ref, "r")) != FAIL) {
-                            char  *class    = NULL;
+                            char *class     = NULL;
                             size_t buf_size = 0;
 
                             /* If unable to get class len, release vg, move on to next vg */

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -628,10 +628,12 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                             /* If unable to get class len, release vg, move on to next vg */
                             if (Vgetclass(img_key, NULL, &buf_size) == FAIL) {
                                 Vdetach(img_key);
+                                img_key = FAIL;
                                 continue;
                             }
                             if ((class = (char *)malloc(sizeof(char) * (buf_size + 1))) == NULL) {
                                 Vdetach(img_key);
+                                img_key = FAIL;
                                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
                             }
                             buf_size++; /* for null-terminator */
@@ -658,6 +660,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                 }         /* end if */
                             }             /* end if */
                             Vdetach(img_key);
+                            img_key = FAIL;
                             free(class);
                         }      /* end if */
                         break; /* case DFTAG_VG, an image */
@@ -714,6 +717,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                             VSdetach(at_key);
                         } /* end if */
+                        else
+                            free(new_attr);
 
                         /* increment the number of GR global attributes */
                         gr_ptr->gattr_count++;
@@ -750,6 +755,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 } /* end if */
             }     /* end if */
         }         /* end while */
+        DFdifree(group_id);
     }             /* end while */
 
     /* go through the RI8s */
@@ -850,7 +856,9 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                     if ((img_key = Vattach(file_id, (int32)img_info[i].grp_ref, "r")) != FAIL) {
                         if ((new_image = (ri_info_t *)malloc(sizeof(ri_info_t))) == NULL) {
-                            free(img_info); /* free offsets */
+                            Vdetach(img_key);
+                            img_key = FAIL;
+                            HDfreenclear(img_info); /* free offsets */
                             Hclose(file_id);
                             HGOTO_ERROR(DFE_NOSPACE, FAIL);
                         }
@@ -860,16 +868,25 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                         /* Get the name of the image */
                         if ((new_image->name = vgetvgname(img_key)) == NULL) {
-                            if ((new_image->name = (char *)malloc(20)) == NULL)
+                            if ((new_image->name = (char *)malloc(20)) == NULL) {
+                                free(new_image);
+                                Vdetach(img_key);
+                                img_key = FAIL;
                                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                            }
                             sprintf(new_image->name, "Raster Image #%d", (int)i);
                         }
 
                         /* Initialize the local attribute tree */
                         new_image->lattr_count = 0;
                         new_image->lattree = tbbtdmake(rigcompare, sizeof(int32), TBBT_FAST_INT32_COMPARE);
-                        if (new_image->lattree == NULL)
+                        if (new_image->lattree == NULL) {
+                            free(new_image->name);
+                            free(new_image);
+                            Vdetach(img_key);
+                            img_key = FAIL;
                             HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                        }
                         new_image->ri_ref = img_info[i].grp_ref;
                         if (img_info[i].aux_ref != 0)
                             new_image->rig_ref = img_info[i].aux_ref;
@@ -982,8 +999,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                                 case DFTAG_VH: /* Attribute information */
                                 {
-                                    at_info_t *new_attr; /* attr to add to the local attr set */
-                                    int32      at_key;   /* VData key for the attribute */
+                                    at_info_t *new_attr = NULL; /* attr to add to the local attr set */
+                                    int32      at_key   = FAIL; /* VData key for the attribute */
 
                                     if ((new_attr = (at_info_t *)malloc(sizeof(at_info_t))) == NULL)
                                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
@@ -998,7 +1015,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                         /* Make certain the attribute only has one field */
                                         if (VFnfields(at_key) != 1) {
                                             VSdetach(at_key);
-                                            free(new_attr);
+                                            HDfreenclear(new_attr);
                                             break;
                                         }
                                         new_attr->nt  = VFfieldtype(at_key, 0);
@@ -1012,7 +1029,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                             if ((new_attr->name = (char *)malloc(strlen(textbuf) + 1)) ==
                                                 NULL) {
                                                 VSdetach(at_key);
-                                                free(new_attr);
+                                                HDfreenclear(new_attr);
                                                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
                                             }
                                             strcpy(new_attr->name, textbuf);
@@ -1021,7 +1038,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                             if ((new_attr->name = (char *)malloc(strlen(fname) + 1)) ==
                                                 NULL) {
                                                 VSdetach(at_key);
-                                                free(new_attr);
+                                                HDfreenclear(new_attr);
                                                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
                                             }
                                             strcpy(new_attr->name, fname);
@@ -1033,6 +1050,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                         VSdetach(at_key);
                                     } /* end if */
 
+                                    else
+                                        HDfreenclear(new_attr);
                                     new_image->lattr_count++;
 
                                     break;
@@ -1068,7 +1087,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                         HGOTO_ERROR(DFE_READERROR, FAIL);
 
                     if ((new_image = (ri_info_t *)malloc(sizeof(ri_info_t))) == NULL) {
-                        free(img_info); /* free offsets */
+                        DFdifree(GroupID);
+                        HDfreenclear(img_info); /* free offsets */
                         Hclose(file_id);
                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
                     }
@@ -1078,15 +1098,22 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                     /* Get the name of the image */
                     sprintf(textbuf, "Raster Image #%d", (int)i);
-                    if ((new_image->name = (char *)malloc(strlen(textbuf) + 1)) == NULL)
+                    if ((new_image->name = (char *)malloc(strlen(textbuf) + 1)) == NULL) {
+                        free(new_image);
+                        DFdifree(GroupID);
                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                    }
                     strcpy(new_image->name, textbuf);
                     new_image->name_generated = TRUE;
 
                     /* Initialize the local attribute tree */
                     new_image->lattree = tbbtdmake(rigcompare, sizeof(int32), TBBT_FAST_INT32_COMPARE);
-                    if (new_image->lattree == NULL)
+                    if (new_image->lattree == NULL) {
+                        free(new_image->name);
+                        free(new_image);
+                        DFdifree(GroupID);
                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                    }
                     new_image->ri_ref  = DFREF_WILDCARD;
                     new_image->rig_ref = img_info[i].grp_ref;
 
@@ -1200,6 +1227,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                 break;
                         } /* end switch */
                     }     /* end while */
+                    DFdifree(GroupID);
                     new_image->index  = gr_ptr->gr_count;
                     new_image->gr_ptr = gr_ptr;                /* point up the tree */
                     tbbtdins(gr_ptr->grtree, new_image, NULL); /* insert the new image into B-tree */
@@ -1214,7 +1242,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                     uint8      GRtbuf[64];                /* local buffer for reading RIG info */
 
                     if ((new_image = (ri_info_t *)malloc(sizeof(ri_info_t))) == NULL) {
-                        free(img_info); /* free offsets */
+                        HDfreenclear(img_info); /* free offsets */
                         Hclose(file_id);
                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
                     }
@@ -1224,15 +1252,20 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                     /* Get the name of the image */
                     sprintf(textbuf, "Raster Image #%d", (int)i);
-                    if ((new_image->name = (char *)malloc(strlen(textbuf) + 1)) == NULL)
+                    if ((new_image->name = (char *)malloc(strlen(textbuf) + 1)) == NULL) {
+                        free(new_image);
                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                    }
                     strcpy(new_image->name, textbuf);
                     new_image->name_generated = TRUE;
 
                     /* Initialize the local attribute tree */
                     new_image->lattree = tbbtdmake(rigcompare, sizeof(int32), TBBT_FAST_INT32_COMPARE);
-                    if (new_image->lattree == NULL)
+                    if (new_image->lattree == NULL) {
+                        free(new_image->name);
+                        free(new_image);
                         HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                    }
                     new_image->ri_ref  = DFREF_WILDCARD;
                     new_image->rig_ref = DFREF_WILDCARD;
 
@@ -1257,8 +1290,11 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                         new_image->img_dim.ydim   = (int32)u;
                         new_image->img_dim.ncomps = 1;
                     } /* end if */
-                    else
+                    else {
+                        free(new_image->name);
+                        free(new_image);
                         HGOTO_ERROR(DFE_GETELEM, FAIL);
+                    }
 
                     /* Get palette information */
                     if (Hexist(file_id, DFTAG_IP8, new_image->img_ref) == SUCCEED) {

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -868,13 +868,14 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                         /* Get the name of the image */
                         if ((new_image->name = vgetvgname(img_key)) == NULL) {
-                            if ((new_image->name = (char *)malloc(20)) == NULL) {
+                            sprintf(textbuf, "Raster Image #%d", (int)i);
+                            if ((new_image->name = (char *)malloc(strlen(textbuf) + 1)) == NULL) {
                                 free(new_image);
                                 Vdetach(img_key);
                                 img_key = FAIL;
                                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
                             }
-                            sprintf(new_image->name, "Raster Image #%d", (int)i);
+                            strcpy(new_image->name, textbuf);
                         }
 
                         /* Initialize the local attribute tree */

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -756,7 +756,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
             }     /* end if */
         }         /* end while */
         DFdifree(group_id);
-    }             /* end while */
+    } /* end while */
 
     /* go through the RI8s */
     noldimages = Get_oldimgs(file_id, &img_info[curr_image], DFTAG_RI8);

--- a/hdf/src/mfgr.c
+++ b/hdf/src/mfgr.c
@@ -155,6 +155,7 @@ int GRIil_convert(const void * inbuf,gr_interlace_t inil,void * outbuf,
  */
 
 #include "hdf_priv.h"
+#include "vg_priv.h"
 #include "mfgr_priv.h"
 
 #ifdef H4_HAVE_LIBSZ /* we have the library */
@@ -561,7 +562,8 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
     int32      nri, nci, nri8, nci8, nii8, nvg; /* number of RIs, CIs, RI8s, CI8s & II8s & Vgroups */
     uint16     find_tag, find_ref;              /* storage for tag/ref pairs found */
     int32      find_off, find_len;              /* storage for offset/lengths of tag/refs found */
-    imginfo_t *img_info;                        /* image info list */
+    int32      img_key  = FAIL;                 /* Vgroup key of an image */
+    imginfo_t *img_info = NULL;                 /* image info list */
     int        i, j;                            /* local counting variable */
     int        ret_value = SUCCEED;
 
@@ -609,10 +611,9 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
         gr_ptr->gr_ref = gr_ref; /* squirrel this away for later use */
         if ((gr_key = Vattach(file_id, (int32)gr_ref, "r")) != FAIL) {
             int32 nobjs = Vntagrefs(gr_key); /* The number of objects in the Vgroup */
-            int32 img_key;                   /* Vgroup key of an image */
-            int32 grp_tag, grp_ref;          /* a tag/ref in the Vgroup */
-            int32 img_tag, img_ref;          /* image tag/ref in the Vgroup */
-            char  textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
+            int32  grp_tag, grp_ref;          /* a tag/ref in the Vgroup */
+            int32  img_tag, img_ref;          /* image tag/ref in the Vgroup */
+            char   textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
 
             for (i = 0; i < nobjs; i++) {
                 if (Vgettagref(gr_key, i, &grp_tag, &grp_ref) == FAIL)
@@ -621,11 +622,25 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 switch (grp_tag) {
                     case DFTAG_VG: /* should be an image */
                         if ((img_key = Vattach(file_id, grp_ref, "r")) != FAIL) {
-                            if (Vgetclass(img_key, textbuf) != FAIL) {
-                                if (!strcmp(textbuf, RI_NAME)) { /* it is an image, get the image's tag/ref */
+                            char  *class    = NULL;
+                            size_t buf_size = 0;
+
+                            /* If unable to get class len, release vg, move on to next vg */
+                            if (Vgetclass(img_key, NULL, &buf_size) == FAIL) {
+                                Vdetach(img_key);
+                                continue;
+                            }
+                            if ((class = (char *)malloc(sizeof(char) * (buf_size + 1))) == NULL) {
+                                Vdetach(img_key);
+                                HGOTO_ERROR(DFE_NOSPACE, FAIL);
+                            }
+                            buf_size++; /* for null-terminator */
+                            if (Vgetclass(img_key, class, &buf_size) != FAIL) {
+                                if (!strcmp(class, RI_NAME)) { /* it is an image, get the image's tag/ref */
                                     for (j = 0; j < Vntagrefs(img_key); j++) {
-                                        if (Vgettagref(img_key, j, &img_tag, &img_ref) == FAIL)
+                                        if (Vgettagref(img_key, j, &img_tag, &img_ref) == FAIL) {
                                             continue;
+                                        }
                                         /* Make sure the tag is correct, then
                                            store the image's info and the
                                            tag/ref of the vgroup that represents
@@ -643,6 +658,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                                 }         /* end if */
                             }             /* end if */
                             Vdetach(img_key);
+                            free(class);
                         }      /* end if */
                         break; /* case DFTAG_VG, an image */
 
@@ -701,6 +717,7 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
 
                         /* increment the number of GR global attributes */
                         gr_ptr->gattr_count++;
+
                     } /* end case DFTAG_VH, a global attribute */
                     break;
 
@@ -826,14 +843,12 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                 case DFTAG_VG: /* New style raster image, found in a Vgroup */
                 {
                     ri_info_t *new_image;                 /* ptr to the image to read in */
-                    int32      img_key;                   /* Vgroup key of an image */
                     int32      img_tag, img_ref;          /* image tag/ref in the Vgroup */
                     char       textbuf[VGNAMELENMAX + 1]; /* buffer to store the name in */
                     uint8      ntstring[4];               /* buffer to store NT info */
                     uint8      GRtbuf[64];                /* local buffer for reading RIG info */
 
                     if ((img_key = Vattach(file_id, (int32)img_info[i].grp_ref, "r")) != FAIL) {
-                        uint16 name_len;
                         if ((new_image = (ri_info_t *)malloc(sizeof(ri_info_t))) == NULL) {
                             free(img_info); /* free offsets */
                             Hclose(file_id);
@@ -844,12 +859,11 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                         memset(new_image, 0, sizeof(ri_info_t));
 
                         /* Get the name of the image */
-                        if (Vgetnamelen(img_key, &name_len) == FAIL)
-                            name_len = 20; /* for "Raster Image #%d" */
-                        if ((new_image->name = (char *)malloc(name_len + 1)) == NULL)
-                            HGOTO_ERROR(DFE_NOSPACE, FAIL);
-                        if (Vgetname(img_key, new_image->name) == FAIL)
+                        if ((new_image->name = vgetvgname(img_key)) == NULL) {
+                            if ((new_image->name = (char *)malloc(20)) == NULL)
+                                HGOTO_ERROR(DFE_NOSPACE, FAIL);
                             sprintf(new_image->name, "Raster Image #%d", (int)i);
+                        }
 
                         /* Initialize the local attribute tree */
                         new_image->lattr_count = 0;
@@ -1033,7 +1047,9 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
                         new_image->gr_ptr = gr_ptr;                /* point up the tree */
                         tbbtdins(gr_ptr->grtree, new_image, NULL); /* insert the new image into B-tree */
                         gr_ptr->gr_count++;
-                        Vdetach(img_key);
+                        if (Vdetach(img_key) == FAIL)
+                            HGOTO_ERROR(DFE_CANTDETACH, FAIL);
+                        img_key = FAIL;
                     } /* end if */
                 }     /* end case DFTAG_VG */
                 break;
@@ -1271,6 +1287,11 @@ GRIget_image_list(int32 file_id, gr_info_t *gr_ptr)
     free(img_info); /* free image info structures */
 
 done:
+    if (ret_value == FAIL) {
+        Vdetach(img_key);
+        free(img_info); /* free image info structures */
+    }
+
     return ret_value;
 } /* end GRIget_image_list() */
 
@@ -1780,8 +1801,6 @@ GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr)
 {
     int32 GroupID; /* RI vgroup id */
     int   ret_value = SUCCEED;
-    int32 temp_ref; /* used to hold the returned value from a function
-                            that may return a ref or a FAIL - BMR */
 
     HEclear();
     if (!HDvalidfid(hdf_file_id) || img_ptr == NULL)
@@ -1799,7 +1818,9 @@ GRIupdateRI(int32 hdf_file_id, ri_info_t *img_ptr)
     /* grab the ref. # of the new Vgroup */
     if (img_ptr->ri_ref == DFREF_WILDCARD) {
         /* due to uint16 type of ref, check return value of VQueryref
-             and assign it to ri_ref only when it's not FAIL - BMR */
+             and assign it to ri_ref only when it's not FAIL */
+        int32 temp_ref;
+
         temp_ref = VQueryref(GroupID);
         if (temp_ref == FAIL)
             HGOTO_ERROR(DFE_BADREF, FAIL);
@@ -1947,8 +1968,6 @@ GRend(int32 grid)
     filerec_t *file_rec;    /* File record */
     void     **t1;
     int        ret_value = SUCCEED;
-    int32      temp_ref; /* used to hold the returned value from a function
-                                 that may return a ref or a FAIL - BMR */
 
     /* clear error stack and check validity of file id */
     HEclear();
@@ -1970,6 +1989,8 @@ GRend(int32 grid)
     if (((file_rec->access) & DFACC_WRITE) != 0) {
         /* Check if the GR group exists, and create it if not */
         if (gr_ptr->gr_ref == DFREF_WILDCARD) {
+            int32 temp_ref;
+
             if ((GroupID = Vattach(gr_ptr->hdf_file_id, -1, "w")) == FAIL)
                 HGOTO_ERROR(DFE_CANTATTACH, FAIL);
 
@@ -2232,8 +2253,7 @@ GRcreate(int32 grid, const char *name, int32 ncomp, int32 nt, int32 il, int32 di
     gr_info_t *gr_ptr;  /* ptr to the GR information for this grid */
     ri_info_t *ri_ptr;  /* ptr to the image to work with */
     int32      ret_value = SUCCEED;
-    int32      temp_ref; /* used to hold the returned value from a function
-                                 that may return a ref or a FAIL - BMR */
+    int32      temp_ref;
 
     /* clear error stack */
     HEclear();

--- a/hdf/src/vg_priv.h
+++ b/hdf/src/vg_priv.h
@@ -255,6 +255,10 @@ HDFLIBAPI vginstance_t *vginst(HFILEID f, uint16 vgid);
 
 HDFLIBAPI DYN_VWRITELIST *vswritelist(int32 vskey);
 
+HDFLIBAPI char *vgetvgname(int32 vkey);
+
+HDFLIBAPI char *vgetvgclass(int32 vkey);
+
 HDFLIBAPI int vpackvg(VGROUP *vg, uint8 buf[], int32 *size);
 
 HDFLIBAPI int32 vinsertpair(VGROUP *vg, uint16 tag, uint16 ref);

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -158,7 +158,7 @@ nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
     if (!tvgname)
         HRETURN_ERROR(DFE_NOSPACE, FAIL);
 
-    buf_size++; /* the fetch call needs the actual buffer capacity, not the name length */
+    buf_size++; /* for null-terminator */
     ret = Vgetname((int32)*vkey, tvgname, &buf_size);
     if (ret != FAIL)
         HDpackFstring(tvgname, _fcdtocp(vgname), (int)*vgnamelen);
@@ -189,7 +189,7 @@ nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
     if (!tvgclass)
         HRETURN_ERROR(DFE_NOSPACE, FAIL);
 
-    buf_size++; /* the fetch call needs the actual buffer capacity, not the class length */
+    buf_size++; /* for null-terminator */
     ret = Vgetclass((int32)*vkey, tvgclass, &buf_size);
     if (ret != FAIL)
         HDpackFstring(tvgclass, _fcdtocp(vgclass), (int)*vgclasslen);
@@ -221,7 +221,7 @@ nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen)
     if (!tvgname)
         HRETURN_ERROR(DFE_NOSPACE, FAIL);
 
-    buf_size++; /* the fetch call needs the actual buffer capacity, not the name length */
+    buf_size++; /* for null-terminator */
     ret = Vinquire((int32)*vkey, &tnentries, tvgname, &buf_size);
     if (ret != FAIL) {
         *nentries = (intf)tnentries;

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -143,9 +143,28 @@ nvdtchc(intf *vkey)
  */
 
 intf
-nvgnamc(intf *vkey, _fcd vgname)
+nvgnamc(intf *vkey, _fcd vgname, intf *vgnamelen)
 {
-    return Vgetname(*vkey, _fcdtocp(vgname));
+    char  *tvgname;
+    size_t buf_size = 0;
+    int    ret;
+
+    /* Query the actual name length first */
+    ret = Vgetname((int32)*vkey, NULL, &buf_size);
+    if (ret == FAIL)
+        return FAIL;
+
+    tvgname = (char *)malloc(buf_size + 1);
+    if (!tvgname)
+        HRETURN_ERROR(DFE_NOSPACE, FAIL);
+
+    buf_size++; /* the fetch call needs the actual buffer capacity, not the name length */
+    ret = Vgetname((int32)*vkey, tvgname, &buf_size);
+    if (ret != FAIL)
+        HDpackFstring(tvgname, _fcdtocp(vgname), (int)*vgnamelen);
+
+    free(tvgname);
+    return (intf)ret;
 } /* VGNAMC */
 
 /* ------------------------------------------------------------------ */
@@ -155,9 +174,28 @@ nvgnamc(intf *vkey, _fcd vgname)
  */
 
 intf
-nvgclsc(intf *vkey, _fcd vgclass)
+nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 {
-    return Vgetclass(*vkey, _fcdtocp(vgclass));
+    char  *tvgclass;
+    size_t buf_size = 0;
+    int    ret;
+
+    /* Query the actual class length first */
+    ret = Vgetclass((int32)*vkey, NULL, &buf_size);
+    if (ret == FAIL)
+        return FAIL;
+
+    tvgclass = (char *)malloc(buf_size + 1);
+    if (!tvgclass)
+        HRETURN_ERROR(DFE_NOSPACE, FAIL);
+
+    buf_size++; /* the fetch call needs the actual buffer capacity, not the class length */
+    ret = Vgetclass((int32)*vkey, tvgclass, &buf_size);
+    if (ret != FAIL)
+        HDpackFstring(tvgclass, _fcdtocp(vgclass), (int)*vgclasslen);
+
+    free(tvgclass);
+    return (intf)ret;
 } /* VGCLSC */
 
 /* ------------------------------------------------------------------ */
@@ -167,9 +205,31 @@ nvgclsc(intf *vkey, _fcd vgclass)
  */
 
 intf
-nvinqc(intf *vkey, intf *nentries, _fcd vgname)
+nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen)
 {
-    return (intf)Vinquire(*vkey, (int32 *)nentries, _fcdtocp(vgname));
+    char   *tvgname;
+    int32   tnentries;
+    size_t  buf_size = 0;
+    int     ret;
+
+    /* Query the actual name length first */
+    ret = Vinquire((int32)*vkey, &tnentries, NULL, &buf_size);
+    if (ret == FAIL)
+        return FAIL;
+
+    tvgname = (char *)malloc(buf_size + 1);
+    if (!tvgname)
+        HRETURN_ERROR(DFE_NOSPACE, FAIL);
+
+    buf_size++; /* the fetch call needs the actual buffer capacity, not the name length */
+    ret = Vinquire((int32)*vkey, &tnentries, tvgname, &buf_size);
+    if (ret != FAIL) {
+        *nentries = (intf)tnentries;
+        HDpackFstring(tvgname, _fcdtocp(vgname), (int)*vgnamelen);
+    }
+
+    free(tvgname);
+    return (intf)ret;
 } /* VINQC */
 
 /* ------------------------------------------------------------------ */
@@ -1349,12 +1409,10 @@ nvsfccpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
         return FAIL;
     }
     if (*flds_in_buf == '\0') {
-        free(flds_in_buf);
-        flds_in_buf = NULL;
+        HDfreenclear(flds_in_buf);
     }
     if (*afield == '\0') {
-        free(afield);
-        afield = NULL;
+        HDfreenclear(afield);
     }
     fldbufpt[0] = _fcdtocp(fldbuf);
     ret = VSfpack((int32)*vs, (int)*packtype, flds_in_buf, (void *)buf, (int)*bufsz, (int)*nrecs, afield,
@@ -1386,12 +1444,10 @@ nvsfncpk(intf *vs, intf *packtype, _fcd buflds, intf *buf, intf *bufsz, intf *nr
         return FAIL;
     }
     if (*flds_in_buf == '\0') {
-        free(flds_in_buf);
-        flds_in_buf = NULL;
+        HDfreenclear(flds_in_buf);
     }
     if (*afield == '\0') {
-        free(afield);
-        afield = NULL;
+        HDfreenclear(afield);
     }
     fldbufpt[0] = fldbuf;
     ret = VSfpack((int32)*vs, (int)*packtype, flds_in_buf, (void *)buf, (int)*bufsz, (int)*nrecs, afield,
@@ -1472,11 +1528,8 @@ intf
 nvscsetnmbl(intf *id, intf *num_blocks)
 {
     intf ret;
-    int  c_ret;
 
-    c_ret = VSsetnumblocks(*id, *num_blocks);
-    if (c_ret == 0)
-        ret = 0;
+    ret = VSsetnumblocks(*id, *num_blocks);
     return ret;
 }
 /*------------------------------------------------------------------------

--- a/hdf/src/vgf.c
+++ b/hdf/src/vgf.c
@@ -207,10 +207,10 @@ nvgclsc(intf *vkey, _fcd vgclass, intf *vgclasslen)
 intf
 nvinqc(intf *vkey, intf *nentries, _fcd vgname, intf *vgnamelen)
 {
-    char   *tvgname;
-    int32   tnentries;
-    size_t  buf_size = 0;
-    int     ret;
+    char  *tvgname;
+    int32  tnentries;
+    size_t buf_size = 0;
+    int    ret;
 
     /* Query the actual name length first */
     ret = Vinquire((int32)*vkey, &tnentries, NULL, &buf_size);

--- a/hdf/src/vgff.f
+++ b/hdf/src/vgff.f
@@ -57,7 +57,7 @@ c	related: Vgetname--vgnamc--VFGNAM
       character*(*)   vgname
       integer         vgnamc
 
-      vfgnam = vgnamc (vg, vgname)
+      vfgnam = vgnamc (vg, vgname, len(vgname))
       end
 c	------------------------------------------------------------
 c	get the class name of a vgroup
@@ -69,7 +69,7 @@ c	related: Vgetclass--vgclsc--VFGCLS
       character*(*)   vgclass
       integer       vgclsc
 
-      vfgcls = vgclsc  (vg, vgclass)
+      vfgcls = vgclsc  (vg, vgclass, len(vgclass))
       end
 c   ------------------------------------------------------------
 c	general inquiry on a vgroup
@@ -80,7 +80,7 @@ c	related: Vinquire--vinqc--VFINQ
       character*(*)   vgname
       integer   vinqc
 
-      vfinq = vinqc (vg, nentries, vgname)
+      vfinq = vinqc (vg, nentries, vgname, len(vgname))
       end
 
 c   ------------------------------------------------------------

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -246,7 +246,7 @@ done:
     VGROUP record pointer or NULL if failed.
 
 *******************************************************************************/
-VGROUP *
+static VGROUP *
 VIGet_vgdesc(int32 vkey /* IN: vgroup key */)
 {
 
@@ -803,11 +803,14 @@ NAME
    vgetvgclass
 
 DESCRIPTION
-   Is a utility function for common code that get the class of a vgroup.
+   A utility function that returns the glass of a vgroup, allocating the buffer
+   internally so the caller does not need to know the length of the glass in
+   advance.  Intended for use within the library and tools only; the caller is
+   responsible for freeing the returned buffer.
 
 RETURNS
-   returns FAIL if not found,
-   returns TRUE if found.
+   Returns the vgroup's glass, which can be an empty string if there is no glass,
+   if successful, otherwise, returns NULL.
 
 *******************************************************************************/
 char *

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -803,13 +803,13 @@ NAME
    vgetvgclass
 
 DESCRIPTION
-   A utility function that returns the glass of a vgroup, allocating the buffer
-   internally so the caller does not need to know the length of the glass in
+   A utility function that returns the class of a vgroup, allocating the buffer
+   internally so the caller does not need to know the length of the class in
    advance.  Intended for use within the library and tools only; the caller is
    responsible for freeing the returned buffer.
 
 RETURNS
-   Returns the vgroup's glass, which can be an empty string if there is no glass,
+   Returns the vgroup's class, which can be an empty string if there is no class,
    if successful, otherwise, returns NULL.
 
 *******************************************************************************/

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -2560,8 +2560,8 @@ RETURNS
 
 *******************************************************************************/
 int
-Vgetname(int32   vkey,     /* IN: vgroup key */
-         char   *vgname,   /* OUT: vgroup name */
+Vgetname(int32   vkey,   /* IN: vgroup key */
+         char   *vgname, /* OUT: vgroup name */
          size_t *buf_size /* IN/OUT: name buffer size */)
 {
     VGROUP *vg        = NULL;
@@ -2622,8 +2622,8 @@ RETURNS
 
 *******************************************************************************/
 int
-Vgetclass(int32   vkey,     /* IN: vgroup key */
-          char   *vgclass,  /* OUT: vgroup class buffer */
+Vgetclass(int32   vkey,    /* IN: vgroup key */
+          char   *vgclass, /* OUT: vgroup class buffer */
           size_t *buf_size /* IN/OUT: class buffer size */)
 {
     VGROUP *vg        = NULL;
@@ -3249,4 +3249,3 @@ Vgetvgroups(int32    id,       /* IN: file id or vgroup id */
 done:
     return ret_value;
 } /* Vgetvgroups */
-

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -29,6 +29,7 @@ LOCAL ROUTINES
  New_vfile    -- create new vgroup file record
  Load_vfile   -- loads vgtab table with info of all vgroups in file.
  Remove_vfile -- removes the file ptr from the vfile[] table.
+ VIGet_vgdesc -- get and verify the vgroup
 
  VPgetinfo  --  Read in the "header" information about the Vgroup.
  VIstart    --  V-level initialization routine
@@ -36,7 +37,7 @@ LOCAL ROUTINES
 
 EXPORTED ROUTINES
 =================
- Following 4 routines are solely for B-tree routines.
+ Following 5 routines are solely for B-tree routines.
  vcompare     -- Compares two TBBT-tree keys for equality.  Similar to memcmp.
  vprint       -- Prints out the key and reference number of VDatas and Vgroups
  vdestroynode -- destroy vgroup node in TBBT
@@ -49,6 +50,8 @@ EXPORTED ROUTINES
  vginstance   -- Looks thru vgtab for vgid and return the addr of the vg
                   instance where vgid is found.
  vexistvg     -- Tests if a vgroup with id "vgid" is in the file's vgtab.
+ vgetvgname   -- Returns the name of a vgroup
+ vgetvgclass  -- Returns the class of a vgroup
  vpackvg      -- Extracts fields from a VGROUP struct "vg" and packs the
                   fields into array buf in preparation for storage in the
                   HDF file.
@@ -73,19 +76,17 @@ EXPORTED ROUTINES
  Vaddtagref   -- Inserts a tag/ref pair into the attached vgroup vg.
  vinsertpair  -- Inserts a tag/ref pair into the attached vgroup vg.
  Ventries     -- Returns the num of entries (+ve integer) in the vgroup vgid.
- Vsetname     -- Gives a name to the VGROUP vg.
- Vsetclass    -- Assigns a class name to the VGROUP vg.
+ Vsetname     -- Gives a name to the Vgroup vg.
+ Vsetclass    -- Assigns a class name to the Vgroup vg.
  Visvg        -- Tests if the given entry in the vgroup vg is a VGROUP.
  Visvs        -- Checks if an id in a vgroup refers to a VDATA.
  Vgetid       -- Given a vgroup's id, returns the next vgroup's id in the file.
  Vgetnext     -- Given the id of an entry from a vgroup vg, looks in vg
                   for the next entry after it, and returns its id.
- Vgetnamelen  -- Retrieves the length of the vgroup's name.
- Vgetclassnamelen  -- Retrieves the length of the vgroup's classname.
  Vgetname     -- Returns the vgroup's name.
- Vgetclass    -- Returns the vgroup's class name .
+ Vgetclass    -- Returns the vgroup's class.
  Vgetvgroups  -- Gets user-created vgroups in a file or in a vgroup
- Vinquire     -- General inquiry routine for VGROUP.
+ Vinquire     -- General inquiry routine for Vgroup.
  Vopen        -- This routine opens the HDF file and initializes it for
                   Vset operations.(i.e." Hopen(); Vinitialize(f)").
  Vclose       -- This routine closes the HDF file, after it has freed
@@ -95,9 +96,6 @@ EXPORTED ROUTINES
                   remove the Vgoup from the internal Vset data structures
                   as well as from the file.
  Vdeletetagref - delete tag/ref pair in Vgroup
-
- NOTE: Another pass needs to made through this file to update some of
-       the comments about certain sections of the code. -GV 9/8/97
 
 *************************************************************************/
 
@@ -237,6 +235,39 @@ done:
     return ret_value;
 } /* VIget_vginstance_node */
 
+/*******************************************************************************
+ NAME
+    VIget_vgdesc -- get and verify the vgroup
+
+ DESCRIPTION
+    Return a pointer to a VGROUP for subsequent accesses of the vgroup.
+
+ RETURNS
+    VGROUP record pointer or NULL if failed.
+
+*******************************************************************************/
+VGROUP *
+VIGet_vgdesc(int32 vkey /* IN: vgroup key */)
+{
+
+    vginstance_t *v         = NULL;
+    VGROUP       *vg        = NULL;
+    VGROUP       *ret_value = NULL;
+
+    /* get and verify the vgroup */
+    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
+        HGOTO_ERROR(DFE_NOVS, NULL);
+    vg = v->vg;
+    if (vg == NULL)
+        HGOTO_ERROR(DFE_BADPTR, NULL);
+    if (vg->otag != DFTAG_VG)
+        HGOTO_ERROR(DFE_ARGS, NULL);
+
+    ret_value = vg;
+done:
+    return ret_value;
+}
+
 /******************************************************************************
  NAME
     VIrelease_vginstance_node -- Releases a vginstance node
@@ -372,7 +403,7 @@ Load_vfile(HFILEID f /* IN: file handle */)
 
     ret = aid = Hstartread(f, DFTAG_VG, DFREF_WILDCARD);
     while (ret != FAIL) {
-        /* get tag/ref for this vgroup */
+        /* get tag/ref for this Vgroup */
         HQuerytagref(aid, &tag, &ref);
 
         /* get a vgroup struct to fill */
@@ -398,8 +429,10 @@ Load_vfile(HFILEID f /* IN: file handle */)
         ret = Hnextread(aid, DFTAG_VG, DFREF_WILDCARD, DF_CURRENT);
     }
 
-    if (aid != FAIL)
+    if (aid != FAIL) {
         Hendaccess(aid);
+        aid = FAIL;
+    }
 
     /* clear error stack - this is to remove the faux errors about DD not
        found from when Hstartread is called on a new file */
@@ -445,8 +478,10 @@ Load_vfile(HFILEID f /* IN: file handle */)
         ret = Hnextread(aid, VSDESCTAG, DFREF_WILDCARD, DF_CURRENT);
     }
 
-    if (aid != FAIL)
+    if (aid != FAIL) {
         Hendaccess(aid);
+        aid = FAIL;
+    }
 
     /* clear error stack - this is to remove the faux errors about DD not
        found from when Hstartread is called on a new file */
@@ -462,6 +497,10 @@ Load_vfile(HFILEID f /* IN: file handle */)
     }
 
 done:
+    if (ret_value == FAIL) {
+        if (aid != FAIL)
+            Hendaccess(aid);
+    }
     return ret_value;
 } /* Load_vfile */
 
@@ -585,8 +624,7 @@ vdestroynode(void *n /* IN: node to free */)
 
             /* Free the old-style attr list and reset associated fields */
             if (vg->old_alist != NULL) {
-                free(vg->old_alist);
-                vg->old_alist = NULL;
+                HDfreenclear(vg->old_alist);
                 vg->noldattrs = 0;
             }
 
@@ -759,6 +797,107 @@ vexistvg(HFILEID f, /* IN: file handle */
 
     return ret_value;
 } /* vexistvg */
+
+/*******************************************************************************
+NAME
+   vgetvgclass
+
+DESCRIPTION
+   Is a utility function for common code that get the class of a vgroup.
+
+RETURNS
+   returns FAIL if not found,
+   returns TRUE if found.
+
+*******************************************************************************/
+char *
+vgetvgclass(int32 vkey)
+{
+    VGROUP *vg        = NULL;
+    size_t  class_len = 0;
+    char   *vgclass   = NULL;
+    char   *ret_value = NULL;
+
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP)
+        HGOTO_ERROR(DFE_ARGS, NULL);
+
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
+        HGOTO_ERROR(DFE_BADPTR, NULL);
+
+    /* Get the length of the vgroup class */
+    class_len = (vg->vgclass != NULL) ? strlen(vg->vgclass) : 0;
+
+    vgclass = (char *)malloc(class_len + 1);
+    if (!vgclass)
+        HGOTO_ERROR(DFE_NOSPACE, NULL);
+
+    /* Copy vgroup class or set it null-terminated */
+    if (class_len > 0)
+        strcpy(vgclass, vg->vgclass);
+    else
+        vgclass[0] = '\0';
+
+    ret_value = vgclass;
+
+done:
+    if (ret_value == NULL)
+        free(vgclass);
+    return ret_value;
+}
+
+/*******************************************************************************
+NAME
+   vgetvgname
+
+DESCRIPTION
+   A utility function that returns the name of a vgroup, allocating the buffer
+   internally so the caller does not need to know the length of the name in
+   advance.  Intended for use within the library and tools only; the caller is
+   responsible for freeing the returned buffer.
+
+RETURNS
+   Returns the vgroup's name, which can be an empty string if there is no name,
+   if successful, otherwise, returns NULL.
+
+*******************************************************************************/
+char *
+vgetvgname(int32 vkey)
+{
+    VGROUP *vg        = NULL;
+    size_t  name_len  = 0;
+    char   *vgname    = NULL;
+    char   *ret_value = NULL;
+
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP)
+        HGOTO_ERROR(DFE_ARGS, NULL);
+
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
+        HGOTO_ERROR(DFE_BADPTR, NULL);
+
+    /* Get the length of the vgroup name */
+    name_len = (vg->vgname != NULL) ? strlen(vg->vgname) : 0;
+
+    vgname = (char *)malloc(name_len + 1);
+    if (!vgname)
+        HGOTO_ERROR(DFE_NOSPACE, NULL);
+
+    /* Copy vgroup name or set it null-terminated */
+    if (name_len > 0)
+        strcpy(vgname, vg->vgname);
+    else
+        vgname[0] = '\0';
+
+    ret_value = vgname;
+
+done:
+    if (ret_value == NULL)
+        free(vgname);
+    return ret_value;
+}
 
 /* ==================================================================== */
 /*
@@ -1289,8 +1428,7 @@ Vdetach(int32 vkey /* IN: vgroup key */)
 
     /* Free the old-style attribute list and reset associated fields */
     if (vg->old_alist != NULL) {
-        free(vg->old_alist);
-        vg->old_alist = NULL;
+        HDfreenclear(vg->old_alist);
         vg->noldattrs = 0;
     }
 
@@ -2034,13 +2172,13 @@ NAME
    Vsetname
 
 DESCRIPTION
-   gives a name to the VGROUP vg.
+   Assigns a name to the vgroup vkey.
 
 RETURNS
     RETURN VALUES: SUCCEED/FAIL
 
 *******************************************************************************/
-int32
+int
 Vsetname(int32       vkey, /* IN: vgroup key */
          const char *vgname /* IN: name to set for vgroup */)
 {
@@ -2093,16 +2231,16 @@ NAME
    Vsetclass
 
 DESCRIPTION
-    Assigns a class name to the VGROUP vg.
+    Assigns a class name to the vgroup vkey
 
 RETURNS
-    RETURN VALUES: SUCCEED for success, FAIL for failure
+    SUCCEED/FAIL
 
 MODIFICATION
     2010/01/26 No longer truncates classname to max length of VGNAMELENMAX.
 
 *******************************************************************************/
-int32
+int
 Vsetclass(int32       vkey, /* IN: vgroup key */
           const char *vgclass /* IN: class to set for vgroup */)
 {
@@ -2405,144 +2543,61 @@ done:
 
 /*******************************************************************************
 NAME
-   Vgetnamelen
+   Vgetname - Retrieves the vgroup's name
 
 DESCRIPTION
-   Retrieves the length of the vgroup's name.
-
-RETURNS
-   Returns SUCCEED/FAIL
-   BMR - 2006/09/10
-
-*******************************************************************************/
-int32
-Vgetnamelen(int32   vkey, /* IN: vgroup key */
-            uint16 *name_len /* OUT: length of vgroup's name */)
-{
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
-
-    /* clear error stack */
-    HEclear();
-
-    /* check if vgroup is valid and the vgname */
-    if (HAatom_group(vkey) != VGIDGROUP)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
-        HGOTO_ERROR(DFE_BADPTR, FAIL);
-
-    /*
-     * Obtain the name length
-     */
-
-    if (vg->vgname == NULL)
-        /* if there is no name... */
-        *name_len = 0;
-    else
-        /* if name had been set... */
-        *name_len = (uint16)strlen(vg->vgname);
-
-done:
-    return ret_value;
-} /* Vgetnamelen */
-
-/*******************************************************************************
-NAME
-   Vgetclassnamelen
-
-DESCRIPTION
-   Retrieves the length of the vgroup's name.
-
-RETURNS
-   Returns SUCCEED/FAIL
-   BMR - 2006/09/10
-
-*******************************************************************************/
-int32
-Vgetclassnamelen(int32   vkey, /* IN: vgroup key */
-                 uint16 *classname_len /* OUT: length of vgroup's classname */)
-{
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
-
-    /* clear error stack */
-    HEclear();
-
-    /* check if vgroup is valid and the vgname */
-    if (HAatom_group(vkey) != VGIDGROUP)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
-        HGOTO_ERROR(DFE_BADPTR, FAIL);
-
-    /* obtain the class name length */
-    if (vg->vgclass == NULL)
-        *classname_len = 0;
-    else
-        /* if name had been set... */
-        *classname_len = (uint16)strlen(vg->vgclass);
-
-done:
-    return ret_value;
-} /* Vgetclassnamelen */
-
-/*******************************************************************************
-NAME
-   Vgetname
-
-DESCRIPTION
-   returns the vgroup's name
-   ASSUME that vgname has been allocated large enough to hold
-   the name
+    This function retrieves the name of a vgroup.  buf_size is an IN/OUT
+    parameter.  When vgname is NULL or *buf_size is 0, the function returns
+    the length of the vgroup name in *buf_size without copying.  Otherwise,
+    up to *buf_size-1 characters are stored in vgname followed by a null
+    terminator, and the actual name length is returned in *buf_size.  If the
+    name of the vgroup is longer than *buf_size-1, the string will be truncated
+    and the null terminator is stored in the last position of the buffer.
+    buf_size must not be NULL.
 
 RETURNS
    SUCCEED / FAIL
 
 *******************************************************************************/
-int32
-Vgetname(int32 vkey, /* IN: vgroup key */
-         char *vgname /* IN/OUT: vgroup name */)
+int
+Vgetname(int32   vkey,     /* IN: vgroup key */
+         char   *vgname,   /* OUT: vgroup name */
+         size_t *buf_size /* IN/OUT: name buffer size */)
 {
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
+    VGROUP *vg        = NULL;
+    size_t  name_len  = 0;
+    int     ret_value = SUCCEED;
 
-    /* clear error stack */
+    /* Clear error stack */
     HEclear();
 
-    /* check if vgroup is valid and the vgname */
-    if (HAatom_group(vkey) != VGIDGROUP || vgname == NULL)
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP || buf_size == NULL)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
-    /* copy vgroup name over if it had been set */
-    if (vg->vgname != NULL)
-        strcpy(vgname, vg->vgname);
+    /* Get the length of the vgroup name */
+    name_len = (vg->vgname != NULL) ? strlen(vg->vgname) : 0;
+
+    /* If vgname is NULL or *buf_size is 0, return the length of the name */
+    if (vgname == NULL || *buf_size == 0) {
+        *buf_size = name_len;
+        HGOTO_DONE(ret_value);
+    }
+
+    /* Copy vgroup name, truncating if necessary */
+    if (vg->vgname != NULL) {
+        strncpy(vgname, vg->vgname, *buf_size - 1);
+        vgname[*buf_size - 1] = '\0';
+    }
     else
         vgname[0] = '\0';
+
+    /* Return the actual name length */
+    *buf_size = name_len;
 
 done:
     return ret_value;
@@ -2550,46 +2605,61 @@ done:
 
 /*******************************************************************************
 NAME
-   Vgetclass
+   Vgetclass - Retrieves the vgroup's class
 
 DESCRIPTION
-   returns the vgroup's class name
-   ASSUME that vgclass has been allocated large enough to hold
-   the name
+    This function retrieves the class of a vgroup.  buf_size is an IN/OUT
+    parameter.  When vgclass is NULL or *buf_size is 0, the function returns
+    the length of the vgroup class in *buf_size without copying.  Otherwise,
+    up to *buf_size-1 characters are stored in vgclass followed by a null
+    terminator, and the actual class length is returned in *buf_size.  If the
+    class of the vgroup is longer than *buf_size-1, the string will be truncated
+    and the null terminator is stored in the last position of the buffer.
+    buf_size must not be NULL.
 
 RETURNS
-   SUCCEED/FAIL
+   SUCCEED / FAIL
 
 *******************************************************************************/
-int32
-Vgetclass(int32 vkey, /* IN: vgroup key */
-          char *vgclass /* IN/OUT: vgroup class */)
+int
+Vgetclass(int32   vkey,     /* IN: vgroup key */
+          char   *vgclass,  /* OUT: vgroup class buffer */
+          size_t *buf_size /* IN/OUT: class buffer size */)
 {
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int32         ret_value = SUCCEED;
+    VGROUP *vg        = NULL;
+    size_t  class_len = 0;
+    int     ret_value = SUCCEED;
 
-    /* clear error stack */
+    /* Clear error stack */
     HEclear();
 
-    /* check if vgroup is valid and also vgroup class */
-    if (HAatom_group(vkey) != VGIDGROUP || vgclass == NULL)
+    /* Check arguments */
+    if (HAatom_group(vkey) != VGIDGROUP || buf_size == NULL)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
-    /* copy class over if it had been set */
-    if (vg->vgclass != NULL)
-        strcpy(vgclass, vg->vgclass);
+    /* Get the length of the vgroup class */
+    class_len = (vg->vgclass != NULL) ? strlen(vg->vgclass) : 0;
+
+    /* If vgclass is NULL or *buf_size is 0, return the length of the class */
+    if (vgclass == NULL || *buf_size == 0) {
+        *buf_size = class_len;
+        HGOTO_DONE(ret_value);
+    }
+
+    /* Copy vgroup class, truncating if necessary */
+    if (vg->vgclass != NULL) {
+        strncpy(vgclass, vg->vgclass, *buf_size - 1);
+        vgclass[*buf_size - 1] = '\0';
+    }
     else
         vgclass[0] = '\0';
+
+    /* Return the actual class length */
+    *buf_size = class_len;
 
 done:
     return ret_value;
@@ -2600,52 +2670,63 @@ NAME
    Vinquire
 
 DESCRIPTION
-   General inquiry routine for VGROUP.
-   output parameters:
-         nentries - no of entries in the vgroup
-         vgname  - the vgroup's name
+   General inquiry routine for VGROUP.  buf_size is an IN/OUT parameter.
+   When vgname is NULL or *buf_size is 0, the function returns the length
+   of the vgroup name in *buf_size without copying.  Otherwise, up to
+   *buf_size-1 characters are stored in vgname followed by a null
+   terminator, and the actual name length is returned in *buf_size.  If the
+   name of the vgroup is longer than *buf_size-1, the string will be truncated
+   and the null terminator is stored in the last position of the buffer.
+   buf_size must not be NULL.
 
 RETURNS
-   RETURNS FAIL if error
-   RETURNS SUCCEED if ok
+   SUCCEED / FAIL
 
 *******************************************************************************/
 int
-Vinquire(int32  vkey,     /* IN: vgroup key */
-         int32 *nentries, /* IN/OUT: number of entries in vgroup */
-         char  *vgname /* IN/OUT: vgroup name */)
+Vinquire(int32   vkey,     /* IN: vgroup key */
+         int32  *nentries, /* OUT: number of entries in vgroup */
+         char   *vgname,   /* OUT: vgroup name */
+         size_t *buf_size /* IN/OUT: vgname buffer size */)
 {
-    vginstance_t *v         = NULL;
-    VGROUP       *vg        = NULL;
-    int           ret_value = SUCCEED;
+    VGROUP *vg        = NULL;
+    size_t  name_len  = 0;
+    int     ret_value = SUCCEED;
 
-    /* clear error stack */
+    /* Clear error stack */
     HEclear();
 
-    /* check if vgroup is valid */
-    if (HAatom_group(vkey) != VGIDGROUP)
+    /* Check argument */
+    if (HAatom_group(vkey) != VGIDGROUP || buf_size == NULL)
         HGOTO_ERROR(DFE_ARGS, FAIL);
 
-    /* get instance of vgroup */
-    if (NULL == (v = (vginstance_t *)HAatom_object(vkey)))
-        HGOTO_ERROR(DFE_NOVS, FAIL);
-
-    /* get vgroup itself and check */
-    vg = v->vg;
-    if (vg == NULL)
+    /* Get the vgroup struct for access */
+    if ((vg = VIGet_vgdesc(vkey)) == NULL)
         HGOTO_ERROR(DFE_BADPTR, FAIL);
 
-    /* check tag of vgroup */
-    if (vg->otag != DFTAG_VG)
-        HGOTO_ERROR(DFE_ARGS, FAIL);
-
-    /* copy vgroup name if requested.  Assumes 'vgname' has sufficient space */
-    if (vgname != NULL)
-        strcpy(vgname, vg->vgname);
-
-    /* set number of entries in vgroup if requested */
+    /* Get the number of entries in vgroup, if requested */
     if (nentries != NULL)
         *nentries = (int32)vg->nvelt;
+
+    /* Get the length of the vgroup name */
+    name_len = (vg->vgname != NULL) ? strlen(vg->vgname) : 0;
+
+    /* If vgname is NULL or *buf_size is 0, return the length of the name */
+    if (vgname == NULL || *buf_size == 0) {
+        *buf_size = name_len;
+        HGOTO_DONE(ret_value);
+    }
+
+    /* Copy vgroup name, truncating if necessary */
+    if (vg->vgname != NULL) {
+        strncpy(vgname, vg->vgname, *buf_size - 1);
+        vgname[*buf_size - 1] = '\0';
+    }
+    else
+        vgname[0] = '\0';
+
+    /* Return the actual name length */
+    *buf_size = name_len;
 
 done:
     return ret_value;
@@ -2873,8 +2954,7 @@ VPshutdown(void)
     }
 
     if (Vgbuf != NULL) {
-        free(Vgbuf);
-        Vgbuf     = NULL;
+        HDfreenclear(Vgbuf);
         Vgbufsize = 0;
     }
 
@@ -3169,3 +3249,4 @@ Vgetvgroups(int32    id,       /* IN: file id or vgroup id */
 done:
     return ret_value;
 } /* Vgetvgroups */
+

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -359,10 +359,10 @@ RETURNS
 static int
 Load_vfile(HFILEID f /* IN: file handle */)
 {
-    vfile_t      *vf = NULL;
-    vginstance_t *v  = NULL;
-    vsinstance_t *w  = NULL;
-    int32         aid;
+    vfile_t      *vf  = NULL;
+    vginstance_t *v   = NULL;
+    vsinstance_t *w   = NULL;
+    int32         aid = FAIL;
     int32         ret;
     uint16        tag       = DFTAG_NULL;
     uint16        ref       = DFTAG_NULL;

--- a/hdf/src/vhi.c
+++ b/hdf/src/vhi.c
@@ -154,7 +154,7 @@ int32
 VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *vgname, const char *vgclass)
 {
     int32 ref, i;
-    int32 vg        = FAIL;
+    int32 vg;
     int32 ret_value = SUCCEED;
 
     if ((vg = Vattach(f, -1, "w")) == FAIL)
@@ -180,8 +180,9 @@ VHmakegroup(HFILEID f, int32 tagarray[], int32 refarray[], int32 n, const char *
     ret_value = (ref);
 
 done:
-    if (vg != FAIL)
+    if (ret_value == FAIL && vg != FAIL)
         Vdetach(vg);
+
     return ret_value;
 } /* VHmakegroup */
 

--- a/hdf/test/tvnameclass.c
+++ b/hdf/test/tvnameclass.c
@@ -25,8 +25,6 @@
 #define VG_LONGNAME  "Vgroup with more than 64 characters in length, 74 characters to be exact!"
 #define VG_LONGCLASS "Very long class name to classify all Vgroups with more than 64 characters in name"
 
-static void test_vglongnames(void);
-
 static void
 test_vglongnames(void)
 {
@@ -317,6 +315,271 @@ done:
 }
 
 /****************************************************************************
+ * test_vinquire_buf_size - tests Vinquire's buf_size handling
+ *   - buf_size == NULL, Vinquire should fail
+ *   - a non-NULL buffer with *buf_size == 0, Vinquire should behave as
+ *     a length-only query
+ *   - a too-small buffer, Vinquire should truncate the name while still
+ *     reporting the actual name length and correct entry count.
+ ****************************************************************************/
+
+#define INQUIRETEST "tvinquire.hdf"
+
+static void
+test_vinquire_buf_size(void)
+{
+    int32  file_id = FAIL; /* File ID */
+    int32  vg1     = FAIL; /* Vgroup ID */
+    int32  vs1     = FAIL; /* Vdata ID, used as vgroup's one entry */
+    int32  ref;            /* Vgroup ref */
+    int32  nentries;       /* Number of entries returned by Vinquire */
+    size_t buf_size;       /* Size for name buffer */
+    char   smallbuf[10];   /* deliberately too-small buffer, for truncation test */
+    int32  status;         /* Status values from routines */
+
+    /* Create the HDF file and a vgroup with one entry and a known,
+       long name for the truncation test. */
+    file_id = Hopen(INQUIRETEST, DFACC_CREATE, 0);
+    CHECK(file_id, FAIL, "Hopen");
+
+    status = Vstart(file_id);
+    CHECK(status, FAIL, "Vstart");
+
+    vg1 = Vattach(file_id, -1, "w");
+    CHECK(vg1, FAIL, "Vattach");
+
+    status = Vsetname(vg1, VG_LONGNAME);
+    CHECK(status, FAIL, "Vsetname");
+
+    vs1 = VSattach(file_id, -1, "w");
+    CHECK(vs1, FAIL, "VSattach");
+
+    status = Vinsert(vg1, vs1);
+    CHECK(status, FAIL, "Vinsert");
+
+    status = VSdetach(vs1);
+    CHECK(status, FAIL, "VSdetach");
+    vs1 = FAIL;
+
+    status = Vdetach(vg1);
+    CHECK(status, FAIL, "Vdetach");
+    vg1 = FAIL;
+
+    status = Vend(file_id);
+    CHECK(status, FAIL, "Vend");
+
+    status = Hclose(file_id);
+    CHECK(status, FAIL, "Hclose");
+    file_id = FAIL;
+
+    /* Re-open the file and attach the vgroup for read-only testing. */
+    file_id = Hopen(INQUIRETEST, DFACC_RDWR, 0);
+    CHECK(file_id, FAIL, "Hopen");
+
+    status = Vstart(file_id);
+    CHECK(status, FAIL, "Vstart");
+
+    ref = Vfind(file_id, VG_LONGNAME);
+    CHECK(ref, FAIL, "Vfind");
+
+    vg1 = Vattach(file_id, ref, "r");
+    CHECK(vg1, FAIL, "Vattach");
+
+    /* Tests buf_size == NULL should fail, regardless of the buffer
+       pointer. */
+    nentries = FAIL;
+    status   = Vinquire(vg1, &nentries, smallbuf, NULL);
+    VERIFY(status, FAIL, "Vinquire:NULL buf_size");
+
+    /* Tests a non-NULL buffer with *buf_size == 0 is a length-only
+       query verifies the real name length */
+    smallbuf[0] = 'X'; /* to confirm the buffer is untouched */
+    buf_size    = 0;
+    status      = Vinquire(vg1, &nentries, smallbuf, &buf_size);
+    CHECK(status, FAIL, "Vinquire:query");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vinquire:query");
+    VERIFY(nentries, 1, "Vinquire:query");
+    VERIFY(smallbuf[0], 'X', "Vinquire:query must not write to buffer");
+
+    /* Tests calling Vinquire with a buffer smaller than the actual
+       name. The vgroup name should be truncated, while
+       buf_size still reports the actual length. */
+    buf_size = sizeof(smallbuf);
+    nentries = FAIL;
+    status   = Vinquire(vg1, &nentries, smallbuf, &buf_size);
+    CHECK(status, FAIL, "Vinquire:truncate");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vinquire:truncate");
+    VERIFY(nentries, 1, "Vinquire:truncate");
+    if (strlen(smallbuf) != sizeof(smallbuf) - 1) {
+        num_errs++;
+        printf(">>> Vinquire:truncate - name not truncated to buffer size\n");
+    }
+    if (strncmp(smallbuf, VG_LONGNAME, sizeof(smallbuf) - 1)) {
+        num_errs++;
+        printf(">>> Vinquire:truncate - truncated name doesn't match\n");
+    }
+
+    status = Vdetach(vg1);
+    CHECK(status, FAIL, "Vdetach");
+    vg1 = FAIL;
+
+    status = Vend(file_id);
+    CHECK(status, FAIL, "Vend");
+
+    status = Hclose(file_id);
+    CHECK(status, FAIL, "Hclose");
+    file_id = FAIL;
+
+done:
+    /* Release resources */
+    if (vs1 != FAIL)
+        VSdetach(vs1);
+    if (vg1 != FAIL)
+        Vdetach(vg1);
+    if (file_id != FAIL) {
+        Vend(file_id);
+        Hclose(file_id);
+    }
+}
+
+/****************************************************************************
+ * test_vgetname_vgetclass_buf_size - tests Vgetname's and Vgetclass's
+ * buf_size handling
+ *   - buf_size == NULL, Vgetname/Vgetclass should fail
+ *   - a non-NULL buffer with *buf_size == 0, Vgetname/Vgetclass should
+ *     behave as a length-only query and must not write to the buffer
+ *   - a too-small buffer, Vgetname/Vgetclass should truncate the
+ *     name/class while still reporting the actual length
+ ****************************************************************************/
+
+#define GETNAMETEST "tgetname.hdf"
+
+static void
+test_vgetname_vgetclass_buf_size(void)
+{
+    int32  file_id = FAIL; /* File ID */
+    int32  vg1     = FAIL; /* Vgroup ID */
+    int32  ref;            /* Vgroup ref */
+    size_t buf_size;       /* Size for name or class buffer */
+    char   smallbuf[10];   /* deliberately too-small buffer, for truncation test */
+    int32  status;         /* Status values from routines */
+
+    /* Create the HDF file and a vgroup with known, long name and class
+       name for the truncation test. */
+    file_id = Hopen(GETNAMETEST, DFACC_CREATE, 0);
+    CHECK(file_id, FAIL, "Hopen");
+
+    status = Vstart(file_id);
+    CHECK(status, FAIL, "Vstart");
+
+    vg1 = Vattach(file_id, -1, "w");
+    CHECK(vg1, FAIL, "Vattach");
+
+    status = Vsetname(vg1, VG_LONGNAME);
+    CHECK(status, FAIL, "Vsetname");
+
+    status = Vsetclass(vg1, VG_LONGCLASS);
+    CHECK(status, FAIL, "Vsetclass");
+
+    status = Vdetach(vg1);
+    CHECK(status, FAIL, "Vdetach");
+    vg1 = FAIL;
+
+    status = Vend(file_id);
+    CHECK(status, FAIL, "Vend");
+
+    status = Hclose(file_id);
+    CHECK(status, FAIL, "Hclose");
+    file_id = FAIL;
+
+    /* Re-open the file and attach the vgroup for read-only testing. */
+    file_id = Hopen(GETNAMETEST, DFACC_RDWR, 0);
+    CHECK(file_id, FAIL, "Hopen");
+
+    status = Vstart(file_id);
+    CHECK(status, FAIL, "Vstart");
+
+    ref = Vfind(file_id, VG_LONGNAME);
+    CHECK(ref, FAIL, "Vfind");
+
+    vg1 = Vattach(file_id, ref, "r");
+    CHECK(vg1, FAIL, "Vattach");
+
+    /* Tests buf_size == NULL should fail, for both Vgetname and
+       Vgetclass, regardless of the buffer pointer. */
+    status = Vgetname(vg1, smallbuf, NULL);
+    VERIFY(status, FAIL, "Vgetname:NULL buf_size");
+
+    status = Vgetclass(vg1, smallbuf, NULL);
+    VERIFY(status, FAIL, "Vgetclass:NULL buf_size");
+
+    /* Tests a non-NULL buffer with *buf_size == 0 is a length-only
+       query verifies the real name/class length */
+    smallbuf[0] = 'X'; /* to confirm the buffer is untouched */
+    buf_size    = 0;
+    status      = Vgetname(vg1, smallbuf, &buf_size);
+    CHECK(status, FAIL, "Vgetname:query");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vgetname:query");
+    VERIFY(smallbuf[0], 'X', "Vgetname:query must not write to buffer");
+
+    smallbuf[0] = 'X';
+    buf_size    = 0;
+    status      = Vgetclass(vg1, smallbuf, &buf_size);
+    CHECK(status, FAIL, "Vgetclass:query");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass:query");
+    VERIFY(smallbuf[0], 'X', "Vgetclass:query must not write to buffer");
+
+    /* Tests calling the functions with a buffer smaller than the actual
+       name/class name. The name/class name should be truncated, while
+       buf_size still reports the actual length. */
+    buf_size = sizeof(smallbuf);
+    status   = Vgetname(vg1, smallbuf, &buf_size);
+    CHECK(status, FAIL, "Vgetname:truncate");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vgetname:truncate");
+    if (strlen(smallbuf) != sizeof(smallbuf) - 1) {
+        num_errs++;
+        printf(">>> Vgetname:truncate - name not truncated to buffer size\n");
+    }
+    if (strncmp(smallbuf, VG_LONGNAME, sizeof(smallbuf) - 1)) {
+        num_errs++;
+        printf(">>> Vgetname:truncate - truncated name doesn't match\n");
+    }
+
+    buf_size = sizeof(smallbuf);
+    status   = Vgetclass(vg1, smallbuf, &buf_size);
+    CHECK(status, FAIL, "Vgetclass:truncate");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass:truncate");
+    if (strlen(smallbuf) != sizeof(smallbuf) - 1) {
+        num_errs++;
+        printf(">>> Vgetclass:truncate - class not truncated to buffer size\n");
+    }
+    if (strncmp(smallbuf, VG_LONGCLASS, sizeof(smallbuf) - 1)) {
+        num_errs++;
+        printf(">>> Vgetclass:truncate - truncated class doesn't match\n");
+    }
+
+    status = Vdetach(vg1);
+    CHECK(status, FAIL, "Vdetach");
+    vg1 = FAIL;
+
+    status = Vend(file_id);
+    CHECK(status, FAIL, "Vend");
+
+    status = Hclose(file_id);
+    CHECK(status, FAIL, "Hclose");
+    file_id = FAIL;
+
+done:
+    /* Release resources */
+    if (vg1 != FAIL)
+        Vdetach(vg1);
+    if (file_id != FAIL) {
+        Vend(file_id);
+        Hclose(file_id);
+    }
+}
+
+/****************************************************************************
  * test_vgisinternal - tests the API function Vgisinternal
  *   - Use an existing GR file created during the period when GR vgroup had no
  *	class name, and had name set to GR_NAME
@@ -383,6 +646,12 @@ test_vnameclass(void)
 
     /* test Vgetname and Vgetclass when either name or class is not defined. */
     test_undefined();
+
+    /* test Vinquire post new argument buf_size */
+    test_vinquire_buf_size();
+
+    /* test Vgetname and Vgetclass post new argument buf_size */
+    test_vgetname_vgetclass_buf_size();
 
     /* test Vgisinternal when there is no class name */
     test_vgisinternal();

--- a/hdf/test/tvnameclass.c
+++ b/hdf/test/tvnameclass.c
@@ -33,7 +33,7 @@ test_vglongnames(void)
     int32  file_id = FAIL; /* File ID */
     int32  vg1     = FAIL; /* Vdata ID */
     int32  ref;            /* Vdata ref */
-    uint16 name_len;       /* Length of a vgroup's name or class name */
+    size_t buf_size = 0;   /* Size for name or class buffer */
     char  *vgname = NULL, *vgclass = NULL;
     int    is_internal;
     int32  status; /* Status values from routines */
@@ -101,29 +101,35 @@ test_vglongnames(void)
     CHECK(is_internal, FAIL, "Vgisinternal");
     VERIFY(is_internal, FALSE, "Vgisinternal");
 
-    /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    /* Get the vgroup's name */
+    status = Vgetname(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size++;
+    status = Vgetname(vg1, vgname, &buf_size);
+    CHECK(status, FAIL, "Vgetname:vg1");
+    VERIFY(buf_size, strlen(VG_LONGNAME), "Vgetname");
     VERIFY_CHAR(vgname, VG_LONGNAME, "Vgetname");
 
     free(vgname);
     vgname = NULL;
 
-    /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    /* Get the vgroup's class */
+    status = Vgetclass(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size++;
+    status = Vgetclass(vg1, vgclass, &buf_size);
+    CHECK(status, FAIL, "Vgetclass:vg1");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
     VERIFY_CHAR(vgclass, VG_LONGCLASS, "Vgetclass");
 
     free(vgclass);
@@ -140,40 +146,42 @@ test_vglongnames(void)
     vg1 = Vattach(file_id, ref, "r");
     CHECK(vg1, FAIL, "VSattach");
 
-    /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    /* Get the vgroup's name */
+    status = Vgetname(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
+    VERIFY(buf_size, strlen(VGROUP1), "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size++;
+    status = Vgetname(vg1, vgname, &buf_size);
+    CHECK(status, FAIL, "Vgetname:vg1");
+    VERIFY(buf_size, strlen(VGROUP1), "Vgetname");
+    VERIFY_CHAR(vgname, VGROUP1, "Vgetname");
 
-    if (strcmp(vgname, VGROUP1)) {
-        num_errs++;
-        printf(">>> Got bogus Vgroup name : %s\n", vgname);
-    }
+    /* Should have the same class */
+    status = Vgetclass(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
 
-    free(vgname);
-    vgname = NULL;
-
-    /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
-
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size++;
+    status = Vgetclass(vg1, vgclass, &buf_size);
+    CHECK(status, FAIL, "Vgetclass:vg1");
+    VERIFY(buf_size, strlen(VG_LONGCLASS), "Vgetclass");
+    VERIFY_CHAR(vgclass, VG_LONGCLASS, "Vgetclass");
 
     if (strcmp(vgclass, VG_LONGCLASS)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
+    free(vgname);
     free(vgclass);
+    vgname  = NULL;
     vgclass = NULL;
 
     status = Vdetach(vg1);
@@ -207,9 +215,7 @@ test_undefined(void)
     int32  vg1     = FAIL; /* Vdata ID */
     int32  ref;            /* Vdata ref */
     int    is_internal;    /* to test Vgisinternal */
-    uint16 name_len;       /* Length of a vgroup's name or class name */
-    /* to simulate calls to Vgetclass/Vgetname in older applications */
-    char vgname[VGNAMELENMAX + 1], vgclass[VGNAMELENMAX + 1];
+    size_t buf_size = 0;   /* Size for name or class buffer */
 
     /* Open the HDF file. */
     file_id = Hopen(NONAMECLASS, DFACC_CREATE, 0);
@@ -268,16 +274,10 @@ test_undefined(void)
     CHECK(is_internal, FAIL, "Vgisinternal");
     VERIFY(is_internal, FALSE, "Vgisinternal");
 
-    /* Try getting the vgroup's class without calling first Vgetclassnamelen.
-       This shows that bug HDFFR-1288 is fixed. */
-    status = Vgetclass(vg1, vgclass);
+    /* Test Vgetclass on vgroup with no class */
+    status = Vgetclass(vg1, NULL, &buf_size);
     CHECK(status, FAIL, "Vgetclass");
-    VERIFY(strlen(vgclass), 0, "VSgetclass");
-
-    /* The length of the class name should be 0 */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetclassnamelen");
-    VERIFY(name_len, 0, "VSgetclassnamelen");
+    VERIFY(buf_size, 0, "VSgetclass");
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -290,16 +290,10 @@ test_undefined(void)
     vg1 = Vattach(file_id, ref, "r");
     CHECK(vg1, FAIL, "VSattach");
 
-    /* Try getting the vgroup's name without calling first Vgetclassnamelen.
-       Similar to class name in bug HDFFR-1288. */
-    status = Vgetname(vg1, vgname);
+    /* Test Vgetname on vgroup with no name */
+    status = Vgetname(vg1, NULL, &buf_size);
     CHECK(status, FAIL, "Vgetname");
-    VERIFY(strlen(vgname), 0, "VSgetname");
-
-    /* The length of the name should be 0 */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
-    VERIFY(name_len, 0, "VSgetnamelen");
+    VERIFY(buf_size, 0, "Vgetname");
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -327,7 +321,6 @@ done:
  *   - Use an existing GR file created during the period when GR vgroup had no
  *	class name, and had name set to GR_NAME
  *   - Get each vgroup, verify that it is internal or not
- * Jan 6, 2012 -BMR
  ****************************************************************************/
 
 #define GR_FILE "test_files/grtdfui83.hdf"

--- a/hdf/test/tvset.c
+++ b/hdf/test/tvset.c
@@ -13,12 +13,7 @@
 
 /*
  *
- * Vset tests
- *
- *
- * This file needs another pass at making sure all the return
- * values from function calls are checked in addition to
- * verifying that the proper tests are performed on all Vxx fcns - GV 9/5/97
+ * Vset tests - Tests VS functions
  *
  */
 #include "hdf.h"
@@ -50,6 +45,8 @@
 #define MX               "STATION_NAME,VALUES,FLOATS"
 #define EMPTY_VDATA      "Empty"
 #define VGROUP1          "VGROUP1"
+#define VGROUP2          "Test object"
+#define SECONDVG         "Second Vgroup"
 #define VG_LONGNAME      "Vgroup with more than 64 characters in length, 74 characters to be exact!"
 #define VG_LONGCLASS     "Very long class name to classify all Vgroups with more than 64 characters in name"
 #define APPENDABLE_VDATA "Appendable"
@@ -67,7 +64,9 @@ static void  test_blockinfo_oneLB(void);
 static void  test_blockinfo_multLBs(void);
 static void  test_VSofclass(void);
 
-/* write some stuff to the file */
+/*
+   Testing writing vgroup and vdata metadata and data.
+*/
 static int32
 write_vset_stuff(void)
 {
@@ -85,6 +84,7 @@ write_vset_stuff(void)
     char       *p;
     char8       c;
     float32     f;
+    int32       ret_value = SUCCEED;
 
     ibuf  = (int32 *)malloc(sizeof(float32) * 2000);
     fbuf  = (float32 *)malloc(sizeof(float32) * 2000);
@@ -98,18 +98,12 @@ write_vset_stuff(void)
     CHECK_ALLOC(gbuf2, "gbuf2", "write_vset_stuff");
 
     fid = Hopen(FNAME0, DFACC_CREATE, 100);
-    if (fid == FAIL) {
-        num_errs++;
-        goto done;
-    }
+    CHECK(fid, FAIL, "Hopen");
 
-    if (Vstart(fid) == FAIL) {
-        num_errs++;
-        goto done;
-    }
+    status = Vstart(fid);
+    CHECK(status, FAIL, "Vstart");
 
     /*
-
      * Vgroup Generation routines
      *
      */
@@ -118,15 +112,12 @@ write_vset_stuff(void)
      *  start simple --- create a simple Vgroup
      */
     vg1 = Vattach(fid, -1, "w");
-    if (vg1 == FAIL) {
-        num_errs++;
-        printf(">>> Failed creating initial Vgroup\n");
-    }
+    CHECK(vg1, FAIL, "Failed creating initial Vgroup");
 
     status = Vsetname(vg1, "Simple Vgroup");
     CHECK(status, FAIL, "Vsetname:vg1");
 
-    status = Vsetclass(vg1, "Test object");
+    status = Vsetclass(vg1, VGROUP2);
     CHECK(status, FAIL, "Vsetclass:vg1");
 
     MESSAGE(5, printf("created Vgroup %s (empty)\n", "Simple Vgroup"););
@@ -135,38 +126,24 @@ write_vset_stuff(void)
      * Lets do some more complex ones now
      */
     vg2 = Vattach(fid, -1, "w");
-    if (vg2 == FAIL) {
-        num_errs++;
-        printf(">>> Failed creating second Vgroup\n");
-    }
+    CHECK(vg2, FAIL, "Failed creating second Vgroup");
 
     /* keep track of how many in Vgroup */
     num = 0;
 
     /* add first group into the other */
     status = Vinsert(vg2, vg1);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vinsert failed\n");
-    }
-    else
-        num++;
+    CHECK(status, FAIL, "Vinsert failed");
+    num++;
 
     /* add a bogus element */
     status = Vaddtagref(vg2, (int32)1000, (int32)12345);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vaddtagref failed for bogus element\n");
-    }
-    else
-        num++;
+    CHECK(status, FAIL, "Vaddtagref failed for bogus element");
+    num++;
 
     /* create an element and insert that */
     aid = Hstartwrite(fid, (uint16)123, (uint16)1234, 10);
-    if (aid == FAIL) {
-        num_errs++;
-        printf(">>> Hstartwrite failed\n");
-    }
+    CHECK(aid, FAIL, "Hstartwrite failed");
 
     status = Hendaccess(aid);
     CHECK(status, FAIL, "Hendaccess:aid");
@@ -174,12 +151,8 @@ write_vset_stuff(void)
 
     /* add an existing HDF element */
     status = Vaddtagref(vg2, (int32)123, (int32)1234);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vaddtagref failed for legit element\n");
-    }
-    else
-        num++;
+    CHECK(status, FAIL, "Vaddtagref failed for legit element");
+    num++;
 
 #ifdef NO_DUPLICATES
     /* attempt to add an element already in the Vgroup */
@@ -209,10 +182,10 @@ write_vset_stuff(void)
         printf(">>> Vinqtagref found a bogus element\n");
     }
 
-    status = Vsetname(vg2, "Second Vgroup");
+    status = Vsetname(vg2, SECONDVG);
     CHECK(status, FAIL, "Vsetname:for vg2");
 
-    Vsetclass(vg2, "Test object");
+    Vsetclass(vg2, VGROUP2);
     CHECK(status, FAIL, "Vsetclass: for vg2");
 
     status = Vdetach(vg1);
@@ -223,12 +196,10 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "Vdetach:vg2");
     vg2 = FAIL;
 
-    MESSAGE(5, printf("created Vgroup %s with %d elements\n", "Second Vgroup", (int)num););
+    MESSAGE(5, printf("created Vgroup %s with %d elements\n", SECONDVG, (int)num););
 
     /*
-
      * Vdata Generation routines
-     *
      */
 
     /* Float32 Vdata */
@@ -239,22 +210,19 @@ write_vset_stuff(void)
     status = VSsetname(vs1, name);
     CHECK(status, FAIL, "VSsetname");
 
-    status = VSsetclass(vs1, "Test object");
+    status = VSsetclass(vs1, VGROUP2);
     CHECK(status, FAIL, "VSsetclass");
 
     status = VSfdefine(vs1, FIELD1, DFNT_FLOAT32, 1);
     CHECK(status, FAIL, "VSfdefine");
 
     /* Verify that VSsetfields will return FAIL when passing in a NULL
-       for field name list (bug #554) - BMR 5/17/01 */
+       for field name list (bug #554) */
     status = VSsetfields(vs1, NULL);
     VERIFY(status, FAIL, "VSsetfields");
 
     status = VSsetfields(vs1, FIELD1);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     for (i = 0, count = 100; i < count; i++)
@@ -263,11 +231,6 @@ write_vset_stuff(void)
     /* store it */
     status = VSwrite(vs1, (unsigned char *)fbuf, count, FULL_INTERLACE);
     CHECK(status, FAIL, "VSwrite:vs1");
-
-    /* Test VSgetexternalfile on a vdata without external element */
-    /*  status = VSgetexternalfile(vs1, 0, NULL, NULL);
-    VERIFY(status, FAIL, "VSgetexternalfile");
- */
 
     /* Test VSgetexternalinfo on a vdata without external element */
     status = VSgetexternalinfo(vs1, 0, NULL, NULL, NULL);
@@ -287,23 +250,17 @@ write_vset_stuff(void)
     status = VSsetname(vs1, name);
     CHECK(status, FAIL, "VSsetname:vs1");
 
-    status = VSsetclass(vs1, "Test object");
+    status = VSsetclass(vs1, VGROUP2);
     CHECK(status, FAIL, "VSsetclass:vs1");
 
     status = VSfdefine(vs1, FIELD2, DFNT_INT32, 2);
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, FIELD2);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
     /* change this vdata to store in an external file */
     status = VSsetexternalfile(vs1, EXTFNM, (int32)0);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSsetexternalfile failed\n");
-    }
+    CHECK(status, FAIL, "VSsetexternalfile failed");
 
     /* create some bogus data */
     for (i = 0, count = 100; i < 2 * count; i++)
@@ -337,10 +294,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, "A, B");
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     p = gbuf;
@@ -383,10 +337,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, MX);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     p = gbuf;
@@ -436,10 +387,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, "max_order");
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     for (i = 0; i < MAX_ORDER; i++)
@@ -466,10 +414,7 @@ write_vset_stuff(void)
     CHECK(status, FAIL, "VSfdefine:vs1");
 
     status = VSsetfields(vs1, "max_fldsize");
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     /* create some bogus data */
     for (i = 0; i < max_order; i++)
@@ -494,16 +439,10 @@ write_vset_stuff(void)
 
     max_order = MAX_FIELD_SIZE / SIZE_FLOAT32 + 1;
     status    = VSfdefine(vs1, "bad_fldsize", DFNT_FLOAT32, max_order);
-    if (status != FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    VERIFY(status, FAIL, "VSfdefine");
 
     status = VSsetfields(vs1, "bad_fldsize");
-    if (status != FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", name);
-    }
+    VERIFY(status, FAIL, "VSsetfields");
 
     status = VSdetach(vs1);
     CHECK(status, FAIL, "VSdetach:vs1");
@@ -571,7 +510,9 @@ done:
     return SUCCEED;
 }
 
-/* read everything back in and check it */
+/*
+   Testing reading vgroup and vdata metadata and data.
+*/
 static int32
 read_vset_stuff(void)
 {
@@ -590,7 +531,7 @@ read_vset_stuff(void)
     float32  fl_expected;
     int32    in_expected;
     char8    c_expected;
-    uint16   name_len;
+    size_t   buf_size = 0;
 
     ibuf = (int32 *)malloc(sizeof(float32) * 2000);
     fbuf = (float32 *)malloc(sizeof(float32) * 2000);
@@ -600,10 +541,7 @@ read_vset_stuff(void)
     CHECK_ALLOC(gbuf, "gbuf", "write_vset_stuff");
 
     fid = Hopen(FNAME0, DFACC_RDONLY, 0);
-    if (fid == FAIL) {
-        num_errs++;
-        goto done;
-    }
+    CHECK(fid, FAIL, "Hopen");
 
     status = Vstart(fid);
     CHECK(status, FAIL, "Vstart:fid");
@@ -627,39 +565,41 @@ read_vset_stuff(void)
         printf(">>> Was not able to attach (r) Vgroup %d\n", (int)list[0]);
     }
 
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen:vg1");
+    /* Get the vgroup's name */
+    status = Vgetname(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "read_vset_stuff");
 
-    status = Vgetname(vg1, vgname);
+    buf_size++;
+    status = Vgetname(vg1, vgname, &buf_size);
     CHECK(status, FAIL, "Vgetname:vg1");
 
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetclassnamelen:vg1");
+    /* Get the vgroup's class */
+    status = Vgetclass(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "read_vset_stuff");
 
-    status = Vgetclass(vg1, vgclass);
+    buf_size++;
+    status = Vgetclass(vg1, vgclass, &buf_size);
     CHECK(status, FAIL, "Vgetclass:vg1");
 
-    if (strcmp(vgname, "Second Vgroup")) {
+    if (strcmp(vgname, SECONDVG)) {
         num_errs++;
         printf(">>> Got bogus Vgroup name : %s\n", vgname);
     }
 
-    free(vgname);
-    vgname = NULL;
+    HDfreenclear(vgname);
 
-    if (strcmp(vgclass, "Test object")) {
+    if (strcmp(vgclass, VGROUP2)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
-    free(vgclass);
-    vgclass = NULL;
+    HDfreenclear(vgclass);
 
     num    = 3;
     status = Vgettagrefs(vg1, tags, refs, 100);
@@ -692,10 +632,7 @@ read_vset_stuff(void)
 
     /* test Vgetid */
     ref = Vgetid(fid, -1);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> Vgetid was unable to find first Vgroup\n");
-    }
+    CHECK(ref, FAIL, "Vgetid was unable to find first Vgroup");
 
     ref = Vgetid(fid, ref);
     if (ref != list[0]) {
@@ -704,17 +641,12 @@ read_vset_stuff(void)
     }
 
     /*
-
      *   Verify the Vdatas
-     *
      */
 
     /* test VSgetid */
     ref = VSgetid(fid, -1);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find first Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find first Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -731,16 +663,13 @@ read_vset_stuff(void)
         printf(">>> Got bogus Vdata name (VSgetname) : %s\n", vsname);
     }
 
-    if (strcmp(vsclass, "Test object")) {
+    if (strcmp(vsclass, VGROUP2)) {
         num_errs++;
         printf(">>> Got bogus Vdata class : %s\n", vsclass);
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on float Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on float Vdata");
 
     if (strcmp(vsname, "Float Vdata")) {
         num_errs++;
@@ -793,10 +722,7 @@ read_vset_stuff(void)
 
     /* Move to the next one (integers) */
     ref = VSgetid(fid, ref);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find second Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find second Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -813,16 +739,13 @@ read_vset_stuff(void)
         printf(">>> Got bogus Vdata name (VSgetname) : %s\n", vsname);
     }
 
-    if (strcmp(vsclass, "Test object")) {
+    if (strcmp(vsclass, VGROUP2)) {
         num_errs++;
         printf(">>> Got bogus Vdata class : %s\n", vsclass);
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on float Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on float Vdata");
 
     if (strcmp(vsname, "Integer Vdata")) {
         num_errs++;
@@ -906,10 +829,7 @@ read_vset_stuff(void)
 
     /* Move to the next one (integers + floats) */
     ref = VSgetid(fid, ref);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find third Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find third Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -932,10 +852,7 @@ read_vset_stuff(void)
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on float Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on float Vdata");
 
     if (strcmp(vsname, "Mixed Vdata")) {
         num_errs++;
@@ -995,10 +912,7 @@ read_vset_stuff(void)
 
     /* Move to the next one (multi-order) */
     ref = VSgetid(fid, ref);
-    if (ref == FAIL) {
-        num_errs++;
-        printf(">>> VSgetid was unable to find multi-order Vdata\n");
-    }
+    CHECK(ref, FAIL, "VSgetid was unable to find multi-order Vdata");
 
     /* read in the first data and verify metadata and contents */
     vs1 = VSattach(fid, ref, "r");
@@ -1021,10 +935,7 @@ read_vset_stuff(void)
     }
 
     status = VSinquire(vs1, &count, &intr, fields, &sz, vsname);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> VSinquire failed on multi-order Vdata\n");
-    }
+    CHECK(status, FAIL, "VSinquire failed on multi-order Vdata");
 
     if (count != 10) {
         num_errs++;
@@ -1245,16 +1156,14 @@ done:
 }
 
 /*
-   Testing VSdelete for vdatas.
-   Modification:
-        2011/12/22: added a test for VSgetexternalinfo on non-external vdata.
- */
-static void
-test_vsdelete(void)
-{
+   Testing VSdelete for vdatas and VSgetexternalinfo on non-external vdata.
+*/
 #define FIELD_NAME     "Field Entries"
 #define NUMBER_OF_ROWS 10
 #define ORDER          3
+static void
+test_vsdelete(void)
+{
     int32 fid      = FAIL;
     int32 vdata_id = FAIL;
     int32 status;
@@ -1391,7 +1300,9 @@ done:
     return;
 }
 
-/* Testing Vdelete for vgroups. */
+/*
+   Testing Vdelete for vgroups.
+*/
 static void
 test_vdelete(void)
 {
@@ -1502,7 +1413,9 @@ done:
     return;
 }
 
-/* Testing Vdeletetagref() for vgroups. */
+/*
+   Testing Vdeletetagref() for vgroups.
+*/
 static void
 test_vdeletetagref(void)
 {
@@ -1692,6 +1605,9 @@ done:
     return;
 }
 
+/*
+   Testing behavior of empty vdata.
+*/
 static void
 test_emptyvdata(void)
 {
@@ -1763,7 +1679,7 @@ test_emptyvdata(void)
 
     /* Verify that VSgetfields will return FAIL when passing in a NULL
        for field name list (from bug #554), although this might never
-       happen - BMR 5/17/01 */
+       happen */
     status = VSgetfields(vs1, NULL);
     VERIFY(status, FAIL, "VSgetfields");
 
@@ -1811,10 +1727,7 @@ test_emptyvdata(void)
     CHECK(status, FAIL, "VSfdefine");
 
     status = VSsetfields(vs1, FIELD1 "," FIELD2);
-    if (status == FAIL) {
-        num_errs++;
-        printf(">>> Vsetfields failed for %s\n", vsname);
-    }
+    CHECK(status, FAIL, "VSsetfields");
 
     status = VSdetach(vs1);
     CHECK(status, FAIL, "Vdetach");
@@ -1879,14 +1792,17 @@ done:
     return;
 }
 
+/*
+   Testing vgroups with long name and class.
+*/
 static void
 test_vglongnames(void)
 {
-    int32  status;     /* Status values from routines */
-    int32  fid = FAIL; /* File ID */
-    int32  vg1 = FAIL; /* Vdata ID */
-    int32  ref;        /* Vdata ref */
-    uint16 name_len;   /* Length of a vgroup's name or class name */
+    int32  status;       /* Status values from routines */
+    int32  fid = FAIL;   /* File ID */
+    int32  vg1 = FAIL;   /* Vdata ID */
+    int32  ref;          /* Vdata ref */
+    size_t buf_size = 0; /* Size for name or class buffer */
     char  *vgname = NULL, *vgclass = NULL;
 
     /* Open the HDF file. */
@@ -1948,40 +1864,40 @@ test_vglongnames(void)
     CHECK(vg1, FAIL, "VSattach");
 
     /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    status = Vgetname(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size++;
+    status = Vgetname(vg1, vgname, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
 
     if (strcmp(vgname, VG_LONGNAME)) {
         num_errs++;
         printf(">>> Got bogus Vgroup name : %s\n", vgname);
     }
 
-    free(vgname);
-    vgname = NULL;
+    HDfreenclear(vgname);
 
     /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    status = Vgetclass(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size++;
+    status = Vgetclass(vg1, vgclass, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
 
     if (strcmp(vgclass, VG_LONGCLASS)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
-    free(vgclass);
-    vgclass = NULL;
+    HDfreenclear(vgclass);
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -1995,40 +1911,40 @@ test_vglongnames(void)
     CHECK(vg1, FAIL, "VSattach");
 
     /* get the vgroup's name */
-    status = Vgetnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    status = Vgetname(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
 
-    vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgname, "vgname", "test_vglongnames");
 
-    status = Vgetname(vg1, vgname);
-    CHECK(status, FAIL, "VSgetname");
+    buf_size++;
+    status = Vgetname(vg1, vgname, &buf_size);
+    CHECK(status, FAIL, "Vgetname");
 
     if (strcmp(vgname, VGROUP1)) {
         num_errs++;
         printf(">>> Got bogus Vgroup name : %s\n", vgname);
     }
 
-    free(vgname);
-    vgname = NULL;
+    HDfreenclear(vgname);
 
     /* get the vgroup's class */
-    status = Vgetclassnamelen(vg1, &name_len);
-    CHECK(status, FAIL, "Vgetnamelen");
+    status = Vgetclass(vg1, NULL, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
 
-    vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
     CHECK_ALLOC(vgclass, "vgclass", "test_vglongnames");
 
-    status = Vgetclass(vg1, vgclass);
-    CHECK(status, FAIL, "VSgetclass");
+    buf_size++;
+    status = Vgetclass(vg1, vgclass, &buf_size);
+    CHECK(status, FAIL, "Vgetclass");
 
     if (strcmp(vgclass, VG_LONGCLASS)) {
         num_errs++;
         printf(">>> Got bogus Vgroup class : %s\n", vgclass);
     }
 
-    free(vgclass);
-    vgclass = NULL;
+    HDfreenclear(vgclass);
 
     status = Vdetach(vg1);
     CHECK(status, FAIL, "Vdetach");
@@ -2054,6 +1970,9 @@ done:
     return;
 }
 
+/*
+   Testing Vgetvgroups.
+*/
 #define USERVGROUPS "tuservgs.hdf"
 #define NUM_VGROUPS 10
 static void
@@ -2393,19 +2312,30 @@ done:
     return;
 }
 
-int
-check_vgs(int32 id, unsigned start_vg, unsigned n_vgs,
-          const char *ident_text,  /* just for debugging, remove when done */
-          int         resultcount, /* expected number of vgroups */
-          uint16     *resultarray)     /* array containing expected values */
-{
-    uint16 *refarray = NULL;
-    int     count    = 0, ii;
-    char    message[30];
-    int     ret_value = SUCCEED;
+/*******************************************************************************
+NAME
+   check_vgs
 
-    strcpy(message, "Vgetvgroups: ");
-    strcat(message, ident_text);
+DESCRIPTION
+   Retrieves the refs of vgroups contained in the vgroup/file identified by
+   'id', starting at index 'start_vg' and retrieving up to 'n_vgs' of them
+   (or all of them, if 'n_vgs' is 0), and verifies the retrieved refs against
+   the expected values in 'resultarray'.
+
+RETURNS
+   SUCCEED/FAIL
+
+*******************************************************************************/
+static int
+check_vgs(int32    id,          /* IN: vgroup or file key */
+          unsigned start_vg,    /* IN: index of first vgroup to retrieve */
+          unsigned n_vgs,       /* IN: number of vgroups to retrieve, or 0 for all */
+          int      resultcount, /* IN: expected number of vgroups */
+          uint16  *resultarray /* IN: array containing expected ref values */)
+{
+    uint16 *refarray  = NULL;
+    int     count     = 0, ii;
+    int     ret_value = SUCCEED;
 
     /* Get and verify the number of vgroups in the file */
     count = Vgetvgroups(id, start_vg, n_vgs, NULL);
@@ -2414,10 +2344,7 @@ check_vgs(int32 id, unsigned start_vg, unsigned n_vgs,
 
     /* Allocate space to retrieve the reference numbers of 'count' vgroups */
     refarray = (uint16 *)malloc(sizeof(uint16) * (size_t)count);
-    if (refarray == NULL) {
-        fprintf(stderr, "check_vgs: Allocation refarray failed\n");
-        return -1;
-    }
+    CHECK_ALLOC(refarray, "refarray", "check_vgs");
 
     /* Get all the vgroups in the file */
     count = Vgetvgroups(id, start_vg, (unsigned)count, refarray);
@@ -2425,9 +2352,11 @@ check_vgs(int32 id, unsigned start_vg, unsigned n_vgs,
     VERIFY(count, resultcount, "Vgetvgroups");
 
     for (ii = 0; ii < count; ii++)
-        if (refarray[ii] != resultarray[ii])
-            fprintf(stderr, "%s: at index %d - read value=%d, should be %d\n", ident_text, ii, refarray[ii],
+        if (refarray[ii] != resultarray[ii]) {
+            num_errs++;
+            fprintf(stderr, "check_vgs: at index %d - read value=%d, should be %d\n", ii, refarray[ii],
                     resultarray[ii]);
+        }
 
     free(refarray);
     refarray = NULL;
@@ -2438,41 +2367,51 @@ done:
     return ret_value;
 }
 
-static int
-check_vds(int32 id, unsigned start_vd, unsigned n_vds,
-          const char *ident_text,  /* just for debugging, remove when done */
-          int         resultcount, /* expected number of vdatas */
-          uint16     *resultarray)     /* array containing expected values */
-{
-    uint16 *refarray = NULL;
-    int     count    = 0, ii;
-    char    message[30];
-    int     ret_value = SUCCEED;
+/*******************************************************************************
+NAME
+   check_vds
 
-    strcpy(message, "VSgetvdatas: ");
-    strcat(message, ident_text);
+DESCRIPTION
+   Retrieves the refs of vdatas contained in the vgroup/file identified by
+   'id', starting at index 'start_vd' and retrieving up to 'n_vds' of them
+   (or all of them, if 'n_vds' is 0), and verifies the retrieved refs against
+   the expected values in 'resultarray'.
+
+RETURNS
+   SUCCEED/FAIL
+
+*******************************************************************************/
+static int
+check_vds(int32    id,          /* IN: vgroup or file key */
+          unsigned start_vd,    /* IN: index of first vdata to retrieve */
+          unsigned n_vds,       /* IN: number of vdatas to retrieve, or 0 for all */
+          int      resultcount, /* IN: expected number of vdatas */
+          uint16  *resultarray /* IN: array containing expected ref values */)
+{
+    uint16 *refarray  = NULL;
+    int     count     = 0, ii;
+    int     ret_value = SUCCEED;
 
     /* Get and verify the number of vdatas in the file */
     count = VSgetvdatas(id, start_vd, n_vds, NULL);
-    CHECK(count, FAIL, message);
-    VERIFY(count, resultcount, message);
+    CHECK(count, FAIL, "VSgetvdatas");
+    VERIFY(count, resultcount, "VSgetvdatas");
 
     /* Allocate space to retrieve the reference numbers of 'count' vdatas */
     refarray = (uint16 *)malloc(sizeof(uint16) * (size_t)count);
-    if (refarray == NULL) {
-        fprintf(stderr, "check_vds: Allocation refarray failed\n");
-        return -1;
-    }
+    CHECK_ALLOC(refarray, "refarray", "check_vds");
 
     /* Get all the vdatas in the file */
     count = VSgetvdatas(id, start_vd, (unsigned)count, refarray);
-    CHECK(count, FAIL, message);
-    VERIFY(count, resultcount, message);
+    CHECK(count, FAIL, "VSgetvdatas");
+    VERIFY(count, resultcount, "VSgetvdatas");
 
     for (ii = 0; ii < count; ii++)
-        if (refarray[ii] != resultarray[ii])
-            fprintf(stderr, "%s: at index %d - read value=%d, should be %d\n", ident_text, ii, refarray[ii],
+        if (refarray[ii] != resultarray[ii]) {
+            num_errs++;
+            fprintf(stderr, "check_vds: at index %d - read value=%d, should be %d\n", ii, refarray[ii],
                     resultarray[ii]);
+        }
 
     free(refarray);
     refarray = NULL;
@@ -2714,14 +2653,14 @@ test_getvdatas(void)
     /* Test getting all vgroups in the file: fid, start_vg=0, n_vgs=0 */
     {
         uint16 result[] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-        status          = check_vgs(fid, 0, 0, "file, 0, 0", NUM_VGROUPS, result);
+        status          = check_vgs(fid, 0, 0, NUM_VGROUPS, result);
         CHECK(status, FAIL, "Vgetvgroups fid");
     }
 
     /* Test getting all vdatas in the file: fid, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {12, 13, 14, 15, 16, 17, 18, 19};
-        status          = check_vds(fid, 0, 0, "file, 0, 0", NUM_VDATAS, result);
+        status          = check_vds(fid, 0, 0, NUM_VDATAS, result);
         CHECK(status, FAIL, "VSgetvdatas fid");
     }
 
@@ -2731,14 +2670,14 @@ test_getvdatas(void)
     /* Test getting vgroups in vg0: vgroup0_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {9, 11};
-        status          = check_vgs(vgroup0_id, 0, 0, "vgroup0_id, 0, 0", 2, result);
+        status          = check_vgs(vgroup0_id, 0, 0, 2, result);
         CHECK(status, FAIL, "VSgetvgroups vgroup0_id");
     }
 
     /* Test getting vdatas in vg0: vgroup0_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {13, 14};
-        status          = check_vds(vgroup0_id, 0, 0, "vgroup0_id, 0, 0", 2, result);
+        status          = check_vds(vgroup0_id, 0, 0, 2, result);
         CHECK(status, FAIL, "VSgetvdatas fid");
     }
 
@@ -2748,14 +2687,14 @@ test_getvdatas(void)
     /* Test getting vgroups in vg1: vgroup1_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {6, 8}; /* vg4 and vg6 */
-        status          = check_vgs(vgroup1_id, 0, 0, "vgroup1_id, 0, 0", 2, result);
+        status          = check_vgs(vgroup1_id, 0, 0, 2, result);
         CHECK(status, FAIL, "Vgetvgroups vgroup1_id");
     }
 
     /* Test getting vdatas in vg1: vgroup1_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {19}; /* vd7 */
-        status          = check_vds(vgroup1_id, 0, 0, "vgroup1_id, 0, 0", 1, result);
+        status          = check_vds(vgroup1_id, 0, 0, 1, result);
         CHECK(status, FAIL, "VSgetvdata vgroup1_id");
     }
 
@@ -2765,14 +2704,14 @@ test_getvdatas(void)
     /* Test getting vgroups in vg6: vgroup6_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {4}; /* vg2 */
-        status          = check_vgs(vgroup6_id, 0, 0, "vgroup6_id, 0, 0", 1, result);
+        status          = check_vgs(vgroup6_id, 0, 0, 1, result);
         CHECK(status, FAIL, "Vgetvgroups vgroup6_id");
     }
 
     /* Test getting vdatas in vg6: vgroup6_id, start_vd=0, n_vds=0 */
     {
         uint16 result[] = {18}; /* vd6 */
-        status          = check_vds(vgroup6_id, 0, 0, "vgroup6_id, 0, 0", 1, result);
+        status          = check_vds(vgroup6_id, 0, 0, 1, result);
         CHECK(status, FAIL, "VSgetvdata vgroup6_id");
     }
 
@@ -2797,14 +2736,14 @@ test_getvdatas(void)
     /* Test getting vdatas in vg9: vgroup9_id, start_vd=2, n_vds=2 */
     {
         uint16 result[] = {17}; /* vd5 */
-        status          = check_vds(vgroup9_id, 2, 2, "vgroup9_id, 2, 2", 1, result);
+        status          = check_vds(vgroup9_id, 2, 2, 1, result);
         CHECK(status, FAIL, "VSgetvdata vgroup9_id");
     }
 
     /* Test getting vgroups in vg1: vgroup1_id, start_vd=1, n_vds=3 */
     {
         uint16 result[] = {8}; /* vg6 */
-        status          = check_vgs(vgroup1_id, 1, 3, "vgroup1_id, 1, 3", 1, result);
+        status          = check_vgs(vgroup1_id, 1, 3, 1, result);
         CHECK(status, FAIL, "Vgetvgroups vgroup1_id");
     }
 
@@ -3002,24 +2941,6 @@ test_extfile(void)
     /* Create the first vdata */
     vdata1_id = VSattach(fid, vdata1_ref, "r");
     CHECK(vdata1_id, FAIL, "VSattach");
-
-    { /* This is an old test, will be removed when VSgetexternalfile is */
-        /* Get the length of the external file name first - VSgetexternalfile
-           is deprecated as of 4.2.7 */
-        name_len = VSgetexternalfile(vdata1_id, 0, NULL, NULL);
-        VERIFY(name_len, (int)strlen(EXTERNAL_FILE), "VSgetexternalfile");
-
-        extfile_name = (char *)malloc(sizeof(char) * (size_t)(name_len + 1));
-        CHECK_ALLOC(extfile_name, "extfile_name", "test_extfile");
-
-        /* Old function: Get the external file name - VSgetexternalfile
-           is deprecated as of 4.2.7 */
-        name_len = VSgetexternalfile(vdata1_id, (unsigned)name_len + 1, extfile_name, &offset);
-        VERIFY(name_len, (int)strlen(EXTERNAL_FILE), "VSgetexternalfile");
-        VERIFY_CHAR(extfile_name, EXTERNAL_FILE, "VSgetexternalfile");
-        free(extfile_name);
-        extfile_name = NULL;
-    } /* old test */
 
     /* Get the length of the external file name first */
     name_len = VSgetexternalinfo(vdata1_id, 0, NULL, NULL, NULL);

--- a/hdf/util/vshow.c
+++ b/hdf/util/vshow.c
@@ -117,7 +117,7 @@ main(int ac, char **av)
         free(vgname);
         vgname = vgetvgname(vg);
         if (vgname == NULL || strlen(vgname) == 0) {
-            free(vgname); // Safe
+            free(vgname);
             vgname = strdup("NoName");
         }
 
@@ -125,7 +125,7 @@ main(int ac, char **av)
         free(vgclass);
         vgclass = vgetvgclass(vg);
         if (vgclass == NULL || strlen(vgclass) == 0) {
-            free(vgclass); // Safe
+            free(vgclass);
             vgclass = strdup("NoClass");
         }
 

--- a/hdf/util/vshow.c
+++ b/hdf/util/vshow.c
@@ -62,11 +62,9 @@ main(int ac, char **av)
     int32   vsid = -1;
     int32   vsno = 0;
     int32   vstag;
-
-    int32  i, t, nvg, nentries, ne, nv, interlace, vsize;
-    int32 *lonevs;   /* array to store refs of all lone vdatas */
-    int32  nlone;    /* total number of lone vdatas */
-    uint16 name_len; /* length of vgroup's name or classname */
+    int32   i, t, nvg, nentries = 0, nv, interlace, vsize;
+    int32  *lonevs;   /* array to store refs of all lone vdatas */
+    int32   nlone;    /* total number of lone vdatas */
 
     char  fields[VSFIELDMAX * FIELDNAMELENMAX];
     char *vgname = NULL, *vgclass = NULL;
@@ -116,6 +114,7 @@ main(int ac, char **av)
         }
 
         /* get the vgname */
+        free(vgname);
         vgname = vgetvgname(vg);
         if (vgname == NULL || strlen(vgname) == 0) {
             free(vgname); // Safe
@@ -123,6 +122,7 @@ main(int ac, char **av)
         }
 
         /* get the vgclass */
+        free(vgclass);
         vgclass = vgetvgclass(vg);
         if (vgclass == NULL || strlen(vgclass) == 0) {
             free(vgclass); // Safe
@@ -131,12 +131,12 @@ main(int ac, char **av)
 
         if (Vinquire(vg, &nentries, 0, NULL) == FAIL)
             printf("cannot retrieve number of entries for vg id=%d\n", (int)vgid);
+        else {
+            vgotag = VQuerytag(vg);
+            vgoref = VQueryref(vg);
 
-        vgotag = VQuerytag(vg);
-        vgoref = VQueryref(vg);
-
-        printf("\nvg:%d <%d/%d> (%s {%s}) has %d entries:\n", (int)nvg, (int)vgotag, (int)vgoref, vgname,
-               vgclass, (int)nentries);
+            printf("\nvg:%d <%d/%d> (%s {%s}) has %d entries:\n", (int)nvg, (int)vgotag, (int)vgoref, vgname, vgclass, (int)nentries);
+        }
         free(vgname);
         free(vgclass);
 
@@ -183,25 +183,30 @@ main(int ac, char **av)
                 }
 
                 /* get the vgname */
+                free(vgname);
                 vgname = vgetvgname(vgt);
-                if (!vgname)
-                    if (strlen(vgname) == 0)
-                        strcpy(vgname, "NoName");
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgname);
+                    vgname = strdup("NoName");
+                }
 
                 /* get the vgclass */
+                free(vgclass);
                 vgclass = vgetvgclass(vgt);
-                if (!vgclass)
-                    if (strlen(vgclass) == 0)
-                        strcpy(vgclass, "NoClass");
+                if (vgclass == NULL || strlen(vgclass) == 0) {
+                    free(vgclass);
+                    vgclass = strdup("NoClass");
+                }
 
+                nentries = 0;
                 if (Vinquire(vg, &nentries, 0, NULL) == FAIL)
                     printf("cannot retrieve number of entries for vg id=%d\n", (int)vgid);
+                else {
+                    vgotag = VQuerytag(vgt);
+                    vgoref = VQueryref(vgt);
 
-                vgotag = VQuerytag(vgt);
-                vgoref = VQueryref(vgt);
-
-                printf("  vg:%d <%d/%d> ne=%d (%s {%s})\n", (int)t, (int)vgotag, (int)vgoref, (int)ne, vgname,
-                       vgclass);
+                    printf("  vg:%d <%d/%d> nentries=%d (%s {%s})\n", (int)t, (int)vgotag, (int)vgoref, (int)nentries, vgname, vgclass);
+                }
 
                 /* Dump the attribute */
                 dumpattr(vg, fulldump, 0);
@@ -221,7 +226,7 @@ main(int ac, char **av)
                     free(name);
                 }
             }
-        } /* while */
+        }
 
         Vdetach(vg);
         nvg++;

--- a/hdf/util/vshow.c
+++ b/hdf/util/vshow.c
@@ -63,13 +63,13 @@ main(int ac, char **av)
     int32   vsno = 0;
     int32   vstag;
 
-    int32  i, t, nvg, n, ne, nv, interlace, vsize;
+    int32  i, t, nvg, nentries, ne, nv, interlace, vsize;
     int32 *lonevs;   /* array to store refs of all lone vdatas */
     int32  nlone;    /* total number of lone vdatas */
     uint16 name_len; /* length of vgroup's name or classname */
 
     char  fields[VSFIELDMAX * FIELDNAMELENMAX];
-    char *vgname, *vgclass;
+    char *vgname = NULL, *vgclass = NULL;
     char  vsname[VSNAMELENMAX];
     char  vsclass[VSNAMELENMAX];
     char *name;
@@ -114,33 +114,33 @@ main(int ac, char **av)
         if (vg == FAIL) {
             printf("cannot open vg id=%d\n", (int)vgid);
         }
-        /* get the length of the vgname to allocate enough space */
-        Vgetnamelen(vg, &name_len);
-        vgname = (char *)malloc(sizeof(char *) * (name_len + 1));
-        if (vgname == NULL) {
-            printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-            return (0);
+
+        /* get the vgname */
+        vgname = vgetvgname(vg);
+        if (vgname == NULL || strlen(vgname) == 0) {
+            free(vgname); // Safe
+            vgname = strdup("NoName");
         }
-        Vinquire(vg, &n, vgname);
-        if (strlen(vgname) == 0)
-            strcat(vgname, "NoName");
+
+        /* get the vgclass */
+        vgclass = vgetvgclass(vg);
+        if (vgclass == NULL || strlen(vgclass) == 0) {
+            free(vgclass); // Safe
+            vgclass = strdup("NoClass");
+        }
+
+        if (Vinquire(vg, &nentries, 0, NULL) == FAIL)
+            printf("cannot retrieve number of entries for vg id=%d\n", (int)vgid);
 
         vgotag = VQuerytag(vg);
         vgoref = VQueryref(vg);
 
-        /* get the length of the vgname to allocate enough space */
-        Vgetclassnamelen(vg, &name_len);
-        vgclass = (char *)malloc(sizeof(char *) * (name_len + 1));
-        if (vgclass == NULL) {
-            printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-            return (0);
-        }
-        Vgetclass(vg, vgclass);
-        if (strlen(vgclass) == 0)
-            strcat(vgclass, "NoClass");
-
         printf("\nvg:%d <%d/%d> (%s {%s}) has %d entries:\n", (int)nvg, (int)vgotag, (int)vgoref, vgname,
-               vgclass, (int)n);
+               vgclass, (int)nentries);
+        free(vgname);
+        free(vgclass);
+
+        /* Dump the attribute */
         dumpattr(vg, fulldump, 0);
         for (t = 0; t < Vntagrefs(vg); t++) {
             Vgettagref(vg, t, &vstag, &vsid);
@@ -182,34 +182,35 @@ main(int ac, char **av)
                     continue;
                 }
 
-                /* get length of the vgclass to allocate enough space */
-                Vgetclassnamelen(vgt, &name_len);
-                vgclass = (char *)malloc(sizeof(char *) * (name_len + 1));
-                if (vgclass == NULL) {
-                    printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-                    return (0);
-                }
-                Vgetclass(vg, vgclass);
-                if (strlen(vgclass) == 0)
-                    strcat(vgclass, "NoClass");
+                /* get the vgname */
+                vgname = vgetvgname(vgt);
+                if (!vgname)
+                    if (strlen(vgname) == 0)
+                        strcpy(vgname, "NoName");
 
-                /* get length of the vgname to allocate enough space */
-                Vgetnamelen(vgt, &name_len);
-                vgname = (char *)malloc(sizeof(char *) * (name_len + 1));
-                if (vgname == NULL) {
-                    printf("Error: Out of memory. Cannot allocate %d bytes space. Quit.\n", name_len + 1);
-                    return (0);
-                }
-                Vinquire(vgt, &ne, vgname);
-                if (strlen(vgname) == 0)
-                    strcat(vgname, "NoName");
+                /* get the vgclass */
+                vgclass = vgetvgclass(vgt);
+                if (!vgclass)
+                    if (strlen(vgclass) == 0)
+                        strcpy(vgclass, "NoClass");
+
+                if (Vinquire(vg, &nentries, 0, NULL) == FAIL)
+                    printf("cannot retrieve number of entries for vg id=%d\n", (int)vgid);
+
                 vgotag = VQuerytag(vgt);
                 vgoref = VQueryref(vgt);
-                Vgetclass(vgt, vgclass);
+
                 printf("  vg:%d <%d/%d> ne=%d (%s {%s})\n", (int)t, (int)vgotag, (int)vgoref, (int)ne, vgname,
                        vgclass);
+
+                /* Dump the attribute */
                 dumpattr(vg, fulldump, 0);
-                Vdetach(vgt);
+
+                /* Release resources */
+                if (Vdetach(vgt) == FAIL)
+                    printf("cannot end access to vgroup\n");
+                free(vgname);
+                free(vgclass);
             }
             else {
                 name = HDgettagsname((uint16)vstag);

--- a/hdf/util/vshow.c
+++ b/hdf/util/vshow.c
@@ -63,8 +63,8 @@ main(int ac, char **av)
     int32   vsno = 0;
     int32   vstag;
     int32   i, t, nvg, nentries = 0, nv, interlace, vsize;
-    int32  *lonevs;   /* array to store refs of all lone vdatas */
-    int32   nlone;    /* total number of lone vdatas */
+    int32  *lonevs; /* array to store refs of all lone vdatas */
+    int32   nlone;  /* total number of lone vdatas */
 
     char  fields[VSFIELDMAX * FIELDNAMELENMAX];
     char *vgname = NULL, *vgclass = NULL;
@@ -135,7 +135,8 @@ main(int ac, char **av)
             vgotag = VQuerytag(vg);
             vgoref = VQueryref(vg);
 
-            printf("\nvg:%d <%d/%d> (%s {%s}) has %d entries:\n", (int)nvg, (int)vgotag, (int)vgoref, vgname, vgclass, (int)nentries);
+            printf("\nvg:%d <%d/%d> (%s {%s}) has %d entries:\n", (int)nvg, (int)vgotag, (int)vgoref, vgname,
+                   vgclass, (int)nentries);
         }
         free(vgname);
         free(vgclass);
@@ -205,7 +206,8 @@ main(int ac, char **av)
                     vgotag = VQuerytag(vgt);
                     vgoref = VQueryref(vgt);
 
-                    printf("  vg:%d <%d/%d> nentries=%d (%s {%s})\n", (int)t, (int)vgotag, (int)vgoref, (int)nentries, vgname, vgclass);
+                    printf("  vg:%d <%d/%d> nentries=%d (%s {%s})\n", (int)t, (int)vgotag, (int)vgoref,
+                           (int)nentries, vgname, vgclass);
                 }
 
                 /* Dump the attribute */

--- a/java/src/jni/hdfvgroupImp.c
+++ b/java/src/jni/hdfvgroupImp.c
@@ -117,8 +117,8 @@ done:
 JNIEXPORT void JNICALL
 Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, jobjectArray hdfclassname)
 {
-    int32   rval = FAIL;
-    char   *data = NULL;
+    int32   rval     = FAIL;
+    char   *data     = NULL;
     size_t  buf_size = 0;
     jstring rstring;
 
@@ -140,9 +140,9 @@ Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, 
     /* get the null-terminated class name of the vgroup */
     if ((rval = Vgetclass((int32)vgroup_id, data, &buf_size)) == FAIL)
 
-    /* convert it to java string */
-    if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
-        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+        /* convert it to java string */
+        if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
+            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
     ENVPTR->SetObjectArrayElement(ENVONLY, hdfclassname, 0, rstring);
     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -181,9 +181,9 @@ Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, j
     /* get the null-terminated name of the vgroup */
     if ((rval = Vgetname((int32)vgroup_id, data, &buf_size)) == FAIL)
 
-    /* convert it to java string */
-    if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
-        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+        /* convert it to java string */
+        if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
+            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
     ENVPTR->SetObjectArrayElement(ENVONLY, hdfname, 0, rstring);
     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -476,10 +476,10 @@ JNIEXPORT jboolean JNICALL
 Java_hdf_hdflib_HDFLibrary_Vinquire(JNIEnv *env, jclass clss, jlong vgroup_id, jintArray n_entries,
                                     jobjectArray vgroup_name)
 {
-    int    rval     = FAIL;
-    jint  *theArg   = NULL;
-    char  *data     = NULL;
-    size_t buf_size = 0;
+    int      rval     = FAIL;
+    jint    *theArg   = NULL;
+    char    *data     = NULL;
+    size_t   buf_size = 0;
     jstring  rstring;
     jboolean isCopy;
 

--- a/java/src/jni/hdfvgroupImp.c
+++ b/java/src/jni/hdfvgroupImp.c
@@ -119,12 +119,10 @@ Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, 
 {
     int32   rval = FAIL;
     char   *data = NULL;
+    size_t  buf_size = 0;
     jstring rstring;
 
     UNUSED(clss);
-
-    if ((data = (char *)malloc(H4_MAX_NC_CLASS + 1)) == NULL)
-        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetclass: failed to allocate data buffer");
 
     if (hdfclassname == NULL)
         H4_NULL_ARGUMENT_ERROR(ENVONLY, "Vgetclass: hdfclassname is NULL");
@@ -132,11 +130,16 @@ Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, 
     if (ENVPTR->GetArrayLength(ENVONLY, hdfclassname) < 1)
         H4_BAD_ARGUMENT_ERROR(ENVONLY, "Vgetclass: output array hdfclassname < order 1");
 
-    /* get the class name of the vgroup */
-    if ((rval = Vgetclass((int32)vgroup_id, data)) < 0)
+    /* query the actual length of the class name first */
+    if ((rval = Vgetclass((int32)vgroup_id, NULL, &buf_size)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
-    data[H4_MAX_NC_CLASS] = '\0';
+    if ((data = (char *)malloc(buf_size + 1)) == NULL)
+        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetclass: failed to allocate data buffer");
+
+    /* get the null-terminated class name of the vgroup */
+    if ((rval = Vgetclass((int32)vgroup_id, data, &buf_size)) == FAIL)
+
     /* convert it to java string */
     if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -155,14 +158,12 @@ done:
 JNIEXPORT void JNICALL
 Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, jobjectArray hdfname)
 {
-    int32   rval = FAIL;
-    char   *data = NULL;
+    int32   rval     = FAIL;
+    char   *data     = NULL;
+    size_t  buf_size = 0;
     jstring rstring;
 
     UNUSED(clss);
-
-    if ((data = (char *)malloc(H4_MAX_GR_NAME + 1)) == NULL)
-        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetname: failed to allocate data buffer");
 
     if (hdfname == NULL)
         H4_NULL_ARGUMENT_ERROR(ENVONLY, "Vgetname: hdfname is NULL");
@@ -170,10 +171,16 @@ Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, j
     if (ENVPTR->GetArrayLength(ENVONLY, hdfname) < 1)
         H4_BAD_ARGUMENT_ERROR(ENVONLY, "Vgetname: array hdfname < order 1");
 
-    if ((rval = Vgetname((int32)vgroup_id, data)) == FAIL)
+    /* query the actual name length first */
+    if ((rval = Vgetname((int32)vgroup_id, NULL, &buf_size)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
-    data[H4_MAX_GR_NAME] = '\0';
+    if ((data = (char *)malloc(buf_size + 1)) == NULL)
+        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetname: failed to allocate data buffer");
+
+    /* get the null-terminated name of the vgroup */
+    if ((rval = Vgetname((int32)vgroup_id, data, &buf_size)) == FAIL)
+
     /* convert it to java string */
     if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -469,16 +476,14 @@ JNIEXPORT jboolean JNICALL
 Java_hdf_hdflib_HDFLibrary_Vinquire(JNIEnv *env, jclass clss, jlong vgroup_id, jintArray n_entries,
                                     jobjectArray vgroup_name)
 {
-    int      rval   = FAIL;
-    jint    *theArg = NULL;
-    char    *data   = NULL;
+    int    rval     = FAIL;
+    jint  *theArg   = NULL;
+    char  *data     = NULL;
+    size_t buf_size = 0;
     jstring  rstring;
     jboolean isCopy;
 
     UNUSED(clss);
-
-    if ((data = (char *)malloc(H4_MAX_NC_NAME + 1)) == NULL)
-        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vinquire: failed to allocate data buffer");
 
     if (n_entries == NULL)
         H4_NULL_ARGUMENT_ERROR(ENVONLY, "Vinquire: n_entries is NULL");
@@ -494,10 +499,16 @@ Java_hdf_hdflib_HDFLibrary_Vinquire(JNIEnv *env, jclass clss, jlong vgroup_id, j
 
     PIN_INT_ARRAY(ENVONLY, n_entries, theArg, &isCopy, "Vinquire:  n_entries not pinned");
 
-    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), data)) == FAIL)
+    /* query the actual name length first */
+    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), &buf_size, NULL)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
-    data[H4_MAX_NC_NAME] = '\0';
+    if ((data = (char *)malloc(buf_size + 1)) == NULL)
+        H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vinquire: failed to allocate data buffer");
+
+    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), &buf_size, data)) == FAIL)
+        H4_LIBRARY_ERROR(ENVONLY);
+
     /* convert it to java string */
     if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);

--- a/java/src/jni/hdfvgroupImp.c
+++ b/java/src/jni/hdfvgroupImp.c
@@ -138,11 +138,13 @@ Java_hdf_hdflib_HDFLibrary_Vgetclass(JNIEnv *env, jclass clss, jlong vgroup_id, 
         H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetclass: failed to allocate data buffer");
 
     /* get the null-terminated class name of the vgroup */
+    buf_size++; /* for the null-terminator */
     if ((rval = Vgetclass((int32)vgroup_id, data, &buf_size)) == FAIL)
+        H4_LIBRARY_ERROR(ENVONLY);
 
-        /* convert it to java string */
-        if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+    /* convert it to java string */
+    if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
+        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
     ENVPTR->SetObjectArrayElement(ENVONLY, hdfclassname, 0, rstring);
     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -179,11 +181,13 @@ Java_hdf_hdflib_HDFLibrary_Vgetname(JNIEnv *env, jclass clss, jlong vgroup_id, j
         H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vgetname: failed to allocate data buffer");
 
     /* get the null-terminated name of the vgroup */
+    buf_size++; /* for the null-terminator */
     if ((rval = Vgetname((int32)vgroup_id, data, &buf_size)) == FAIL)
+        H4_LIBRARY_ERROR(ENVONLY);
 
-        /* convert it to java string */
-        if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+    /* convert it to java string */
+    if (NULL == (rstring = ENVPTR->NewStringUTF(ENVONLY, data)))
+        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
     ENVPTR->SetObjectArrayElement(ENVONLY, hdfname, 0, rstring);
     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -500,13 +504,14 @@ Java_hdf_hdflib_HDFLibrary_Vinquire(JNIEnv *env, jclass clss, jlong vgroup_id, j
     PIN_INT_ARRAY(ENVONLY, n_entries, theArg, &isCopy, "Vinquire:  n_entries not pinned");
 
     /* query the actual name length first */
-    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), &buf_size, NULL)) == FAIL)
+    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), NULL, &buf_size)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
     if ((data = (char *)malloc(buf_size + 1)) == NULL)
         H4_OUT_OF_MEMORY_ERROR(ENVONLY, "Vinquire: failed to allocate data buffer");
 
-    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), &buf_size, data)) == FAIL)
+    buf_size++; /* for the null-terminator */
+    if ((rval = Vinquire((int32)vgroup_id, (int32 *)&(theArg[0]), data, &buf_size)) == FAIL)
         H4_LIBRARY_ERROR(ENVONLY);
 
     /* convert it to java string */

--- a/mfhdf/hdiff/hdiff_list.c
+++ b/mfhdf/hdiff/hdiff_list.c
@@ -146,7 +146,6 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
     int32  ref_vg;
     char  *vg_name  = NULL;
     char  *vg_class = NULL;
-    size_t name_len;
     int32  i;
 
     /* initialize the V interface */
@@ -194,14 +193,14 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
             /* Get vgroup's name */
             vg_name = vgetvgname(vg_id);
             if (!vg_name) {
-                printf("Error: Could not get name length for group with ref <%d>\n", ref);
+                printf("Error: Could not get name for group with ref <%d>\n", ref);
                 goto out;
             }
 
             /* Get vgroup's class */
             vg_class = vgetvgclass(vg_id);
             if (!vg_class) {
-                printf("Error: Could not get class length for group with ref <%d>\n", ref);
+                printf("Error: Could not get class for group with ref <%d>\n", ref);
                 goto out;
             }
 
@@ -260,9 +259,7 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
             }
 
             HDfreenclear(vg_name);
-            vg_name = NULL;
             HDfreenclear(vg_class);
-            vg_class = NULL;
         } /* for */
 
         /* free the space allocated */
@@ -316,7 +313,6 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
     char  *vg_class = NULL;
     char  *path     = NULL;
     int    i;
-    size_t name_len;
 
     for (i = 0; i < npairs; i++) {
         tag = in_tags[i];
@@ -341,6 +337,7 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
                 }
 
                 /* Get vgroup's name */
+                free(vg_name);
                 vg_name = vgetvgname(vg_id);
                 if (!vg_name) {
                     printf("Error: Could not get name for group with ref <%d>\n", ref);
@@ -348,9 +345,10 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
                 }
 
                 /* Get vgroup's class */
+                free(vg_class);
                 vg_class = vgetvgclass(vg_id);
                 if (!vg_class) {
-                    printf("Error: Could not get class length for group with ref <%d>\n", ref);
+                    printf("Error: Could not get class for group with ref <%d>\n", ref);
                     break;
                 }
 

--- a/mfhdf/hdiff/hdiff_list.c
+++ b/mfhdf/hdiff/hdiff_list.c
@@ -17,6 +17,7 @@
 
 #include "hdf.h"
 #include "mfhdf.h"
+#include "vg_priv.h"
 #include "hdiff_list.h"
 
 static int   is_reserved(char *vg_class);
@@ -145,7 +146,7 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
     int32  ref_vg;
     char  *vg_name  = NULL;
     char  *vg_class = NULL;
-    uint16 name_len;
+    size_t name_len;
     int32  i;
 
     /* initialize the V interface */
@@ -190,29 +191,17 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
                 goto out;
             }
 
-            if (Vgetnamelen(vg_id, &name_len) == FAIL) {
+            /* Get vgroup's name */
+            vg_name = vgetvgname(vg_id);
+            if (!vg_name) {
                 printf("Error: Could not get name length for group with ref <%d>\n", ref);
                 goto out;
             }
 
-            free(vg_name);
-            vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetname(vg_id, vg_name) == FAIL) {
-                printf("Error: Could not get name for group with ref <%d>\n", ref);
-                goto out;
-            }
-
-            if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                printf("Error: Could not get classname length for group with ref <%d>\n", ref);
-                goto out;
-            }
-
-            free(vg_class);
-            vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetclass(vg_id, vg_class) == FAIL) {
-                printf("Error: Could not get class for group with ref <%d>\n", ref);
+            /* Get vgroup's class */
+            vg_class = vgetvgclass(vg_id);
+            if (!vg_class) {
+                printf("Error: Could not get class length for group with ref <%d>\n", ref);
                 goto out;
             }
 
@@ -270,17 +259,15 @@ hdiff_list_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface ide
                 goto out;
             }
 
-            free(vg_name);
+            HDfreenclear(vg_name);
             vg_name = NULL;
-            free(vg_class);
+            HDfreenclear(vg_class);
             vg_class = NULL;
         } /* for */
 
         /* free the space allocated */
         free(ref_array);
     } /* if */
-    free(vg_name);
-    free(vg_class);
 
     /* terminate access to the V interface */
     if (Vend(file_id) == FAIL) {
@@ -329,7 +316,7 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
     char  *vg_class = NULL;
     char  *path     = NULL;
     int    i;
-    uint16 name_len;
+    size_t name_len;
 
     for (i = 0; i < npairs; i++) {
         tag = in_tags[i];
@@ -348,25 +335,24 @@ insert_vg(const char *fname, int32 file_id, int32 sd_id, /* SD interface identif
                 }
 
                 vg_id = Vattach(file_id, ref, "r");
-                if (Vgetnamelen(vg_id, &name_len) == FAIL) {
-                    printf("Error: Could not get name length for group with ref <%d>\n", ref);
+                if (vg_id == FAIL) {
+                    printf("Error: Could not attach group with ref <%d>\n", ref);
                     break;
                 }
 
-                free(vg_name);
-                vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-
-                Vgetname(vg_id, vg_name);
-
-                if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                    printf("Error: Could not get classname length for group with ref <%d>\n", ref);
+                /* Get vgroup's name */
+                vg_name = vgetvgname(vg_id);
+                if (!vg_name) {
+                    printf("Error: Could not get name for group with ref <%d>\n", ref);
                     break;
                 }
 
-                free(vg_class);
-                vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-
-                Vgetclass(vg_id, vg_class);
+                /* Get vgroup's class */
+                vg_class = vgetvgclass(vg_id);
+                if (!vg_class) {
+                    printf("Error: Could not get class length for group with ref <%d>\n", ref);
+                    break;
+                }
 
                 /* ignore reserved HDF groups/vdatas */
                 if (is_reserved(vg_class)) {

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -257,8 +257,7 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
         }
 
         if (FAIL == Vdetach(vg_id))
-            ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref",
-                         (int)*find_ref);
+            ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
         vg_id = FAIL;
 
         /* if the vg's name or vg's class is the given string, return the
@@ -270,10 +269,10 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
             (*index)++;
             goto done;
         }
-            (*index)++;
+        (*index)++;
 
         SAFE_FREE(name); /* free name and set it to NULL */
-    }   /* end while getting vgroups */
+    }                    /* end while getting vgroups */
 
     /* when Vgetid returned FAIL in while above, search should stop */
     ret_value = FAIL;
@@ -479,7 +478,7 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
 
 done:
     if (ret_value == FAIL) {
-        HDfreenclear(*vgname); /* free temp memory */
+        HDfreenclear(*vgname);  /* free temp memory */
         HDfreenclear(*vgclass); /* free temp memory */
     }
 
@@ -1311,7 +1310,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
             status = get_VGandInfo(&vg_id, file_id, vg_ref, file_name, &n_entries, &vgname, &vgclass);
             if (status == FAIL)
                 ERROR_NOTIFY_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
-                             (int)vg_ref);
+                               (int)vg_ref);
 
             /* since the succeeding processing depends heavily on these
                we decided to just skip the current file */

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -13,7 +13,7 @@
 
 #include <math.h>
 
-#include "vg_priv.h" 
+#include "vg_priv.h"
 #include "vg.h"
 #include "hdp.h"
 
@@ -422,9 +422,9 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
               char **vgname, char **vgclass)
 {
     int    status, ret_value = SUCCEED;
-    size_t buf_size = 0;
-    char *tmp_vgname = NULL;
-    char *tmp_vgclass = NULL;
+    size_t buf_size    = 0;
+    char  *tmp_vgname  = NULL;
+    char  *tmp_vgclass = NULL;
 
     /* detach the current vgroup if it's attached to cover the case
       where a library routine fails and must continue to the next vgroup
@@ -490,9 +490,9 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         strcpy(tmp_vgclass, NONAME_TXT);
     }
 
-    *vgname = tmp_vgname;
-    tmp_vgname = NULL;
-    *vgclass = tmp_vgclass;
+    *vgname     = tmp_vgname;
+    tmp_vgname  = NULL;
+    *vgclass    = tmp_vgclass;
     tmp_vgclass = NULL;
 
 done:

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -13,7 +13,6 @@
 
 #include <math.h>
 
-#include "vg_priv.h"
 #include "vg.h"
 #include "hdp.h"
 
@@ -226,59 +225,67 @@ int32
 Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
          int is_name, int32 *find_ref, int32 *index) /* index of the vgroup w/ref# *find_ref */
 {
-    int32 vg_id     = FAIL;
-    char *name      = NULL;
-    int32 status_32 = FAIL;
-    int32 ret_value = FAIL;
+    int32  vg_id     = FAIL;
+    char  *name      = NULL;
+    uint16 name_len  = 0;
+    int32  status_32 = FAIL;
+    int32  ret_value = FAIL;
 
     /* starting from the ref# *find_ref, search for the vgroup having a
        name or class the same as the given string searched_name; when no
        more vgroups to search, return FAIL */
     while ((*find_ref = Vgetid(file_id, *find_ref)) != FAIL) {
         vg_id = Vattach(file_id, *find_ref, "r");
-        if (vg_id == FAIL)
+        if (FAIL == vg_id)
             ERROR_GOTO_2("in %s: Vattach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
 
-        /* get the vg name/class */
-        if (is_name) {
-            name = vgetvgname(vg_id);
-            if (!name) {
-                ERROR_GOTO_2("in %s: Failed to get name for vgroup with ref#(%d)", "Vstr_ref",
-                             (int)*find_ref);
-            }
+        /* get the length of the vgname to allocate enough space */
+        if (is_name)
+            status_32 = Vgetnamelen(vg_id, &name_len);
+        else
+            status_32 = Vgetclassnamelen(vg_id, &name_len);
+        if (FAIL == status_32) /* go to done and return a FAIL */
+        {
+            ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "Vstr_ref", (int)*find_ref);
         }
-        else {
-            name = vgetvgclass(vg_id);
-            if (!name) {
-                ERROR_GOTO_2("in %s: Failed to get class name for vgroup with ref#(%d)", "Vstr_ref",
-                             (int)*find_ref);
+        name = (char *)malloc(sizeof(char) * (name_len + 1));
+        /* If allocation fails, Vstr_ref simply terminates hdp. */
+        CHECK_ALLOC(name, "vgroup classname", "Vstr_ref");
+
+        if (name_len > 0) {
+            if (is_name) {
+                if (FAIL == Vgetname(vg_id, name))
+                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
+                                 (int)*find_ref);
             }
-        }
+            else {
+                if (FAIL == Vgetclass(vg_id, name))
+                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
+                                 (int)*find_ref);
+            }
 
-        if (FAIL == Vdetach(vg_id))
-            ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
-        vg_id = FAIL;
+            if (FAIL == Vdetach(vg_id))
+                ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
 
-        /* if the vg's name or vg's class is the given string, return the
-        index of the vgroup found */
-        if (strcmp(name, searched_str) == 0) {
-            /* return the current ref# */
-            ret_value = *find_ref;
-            /* increment index for next vgroup - same class vgroups*/
+            /* if the vg's name or vg's class is the given string, return the
+            index of the vgroup found */
+            if (strcmp(name, searched_str) == 0) {
+                /* return the current ref# */
+                ret_value = *find_ref;
+                /* increment index for next vgroup - same class vgroups*/
+                (*index)++;
+                goto done;
+            }
             (*index)++;
-            goto done;
-        }
-        (*index)++;
+        } /* name_len > 0 */
 
         SAFE_FREE(name); /* free name and set it to NULL */
     }                    /* end while getting vgroups */
 
-    /* when Vgetid returned FAIL in while above, search should stop */
+    /* when VSgetid returned FAIL in while above, search should stop */
     ret_value = FAIL;
 
 done:
-    if (vg_id != FAIL)
-        Vdetach(vg_id);
     SAFE_FREE(name); /* free name and set it to NULL */
 
     return ret_value;
@@ -409,7 +416,8 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
               char **vgname, char **vgclass)
 {
     int    status, ret_value = SUCCEED;
-    size_t buf_size = 0;
+    int32  status_32;
+    uint16 name_len = 0;
 
     /* detach the current vgroup if it's attached to cover the case
       where a library routine fails and must continue to the next vgroup
@@ -421,18 +429,18 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         ERROR_GOTO_2("in %s: Vattach failed for vgroup ref=%d", "get_VGandInfo", (int)vg_ref);
 
     /* get the length of the vgname to allocate enough space */
-    status = Vgetname(*vg_id, NULL, &buf_size);
-    if (status == FAIL) /* go to done and return a FAIL */
-        ERROR_GOTO_2("in %s: Vgetname failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
-
-    if (buf_size > 0) {
-        *vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
+    status_32 = Vgetnamelen(*vg_id, &name_len);
+    if (FAIL == status_32) /* go to done and return a FAIL */
+    {
+        ERROR_GOTO_2("in %s: Vgetnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
+    }
+    if (name_len > 0) {
+        *vgname = (char *)malloc(sizeof(char) * (name_len + 1));
 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
         CHECK_ALLOC(*vgname, "*vgname", "get_VGandInfo");
 
-        buf_size++;
-        status = Vinquire(*vg_id, n_entries, *vgname, &buf_size);
+        status = Vinquire(*vg_id, n_entries, *vgname);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -442,7 +450,7 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     else {
         *vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
         strcpy(*vgname, "<Undefined>");
-        status = Vinquire(*vg_id, n_entries, NULL, &buf_size);
+        status = Vinquire(*vg_id, n_entries, NULL);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -451,20 +459,19 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     }
 
     /* get the length of the vgclass to allocate enough space */
-    status = Vgetclass(*vg_id, NULL, &buf_size);
-    if (status == FAIL) /* go to done and return a FAIL */
+    status_32 = Vgetclassnamelen(*vg_id, &name_len);
+    if (FAIL == status_32) /* go to done and return a FAIL */
     {
-        ERROR_GOTO_2("in %s: Vgetclass failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
+        ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
-    if (buf_size > 0) {
-        *vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
+    if (name_len > 0) {
+        *vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
         CHECK_ALLOC(*vgclass, "*vgclass", "get_VGandInfo");
 
-        buf_size++;
-        status = Vgetclass(*vg_id, *vgclass, &buf_size);
-        if (status == FAIL) /* go to done and return a FAIL */
+        status_32 = Vgetclass(*vg_id, *vgclass);
+        if (FAIL == status_32) /* go to done and return a FAIL */
         {
             ERROR_GOTO_2("in %s: Vgetclass failed for vgroup ref#=%d", "get_VGandInfo", (int)vg_ref);
         }
@@ -476,8 +483,11 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
 
 done:
     if (ret_value == FAIL) {
-        HDfreenclear(*vgname);  /* free temp memory */
-        HDfreenclear(*vgclass); /* free temp memory */
+        free(*vgname); /* free temp memory */
+        *vgname = NULL;
+
+        free(*vgclass); /* free temp memory */
+        *vgclass = NULL;
     }
 
     return (ret_value);
@@ -523,6 +533,9 @@ alloc_list_of_strings(int32 num_entries)
 {
     char **ptr = NULL;
 
+    /* I don't know why +1 here and only i<num_entries at for loop - BMR*/
+    /* probably, +1 so that malloc won't fail when num_entries = 0, was */
+    /* added in r1842.  But, that means possible memory leak! */
     ptr = (char **)malloc(sizeof(char *) * (size_t)num_entries);
 
     /* If allocation fails, alloc_list_of_string simply terminates hdp. */
@@ -571,7 +584,7 @@ print_fields(const char *fields, const char *field_title, FILE *fp)
     CHECK_ALLOC(tempflds, "tempflds", "print_fields");
 
     /* if fields are not defined by VSsetfields and VSfdefine */
-    if (fields == NULL || fields[0] == '\0')
+    if (fields[0] == '\0' || fields == NULL)
         fprintf(fp, "%s <Undefined>;\n", field_title);
 
     else { /* there are fields to print */
@@ -845,27 +858,22 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 /* get the current vgroup and its information */
                 status =
                     get_VGandInfo(&vgt, file_id, elem_ref, file_name, &elem_n_entries, &vgname, &vgclass);
-                if (status == FAIL) {
+                if (status == FAIL)
                     ERROR_NOTIFY_3("in %s: %s failed in getting vgroup with ref#=%d", "vgBuildGraph",
                                    "get_VGandInfo", (int)vg_ref);
 
-                    /* attach itself failed - nothing usable for this entry, skip it */
-                    if (vgt == FAIL) {
-                        *skipfile = TRUE; /* severe failure, skip this file */
-                        ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
-                                       "vgBuildGraph", "get_VGandInfo", (int)entry_num);
-                        continue;
-                    }
-                    /* attach succeeded but if name/class fetch failed, get_VGandInfo
-                       already freed and NULL'd vgname/vgclass on this path */
+                /* although get_VGandInfo failed to get a valid id for this vgroup,
+                   the node for the vgroup is not affected, so build it anyway */
+                if (vgt == FAIL) {
+                    *skipfile = TRUE; /* severe failure, skip this file */
+                    ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
+                                   "vgBuildGraph", "get_VGandInfo", (int)entry_num);
                 }
 
                 /* vgroup has no name */
-                if (vgname == NULL || strlen(vgname) == 0) {
-                    free(vgname);
+                if (strlen(vgname) == 0 || vgname == NULL) {
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    CHECK_ALLOC(vgname, "vgname", "vgBuildGraph");
-                    strcpy(vgname, "<Undefined>");
+                    strcat(vgname, "<Undefined>");
                 }
 
                 resetVG(&vgt, file_name);
@@ -925,7 +933,6 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 aNode->children[entry_num] = alloc_string_of_chars("***");
 
                 if (!strcmp(name, "Unknown Tag")) {
-                    free(name);
                     aNode->type[entry_num] = alloc_string_of_chars("Unknown Object");
                 }
                 else
@@ -935,8 +942,8 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
         }     /* for */
     }
 done:
-    free(vgname);
-    free(vgclass);
+    SAFE_FREE(vgname);  /* free vg name and set it to NULL */
+    SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
 
     return ret_value;
 } /* vgBuildGraph */
@@ -1001,34 +1008,24 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 /* get the current vgroup and its information */
                 status =
                     get_VGandInfo(&vgt, file_id, elem_ref, file_name, &elem_n_entries, &vgname, &vgclass);
-                if (status == FAIL) {
-                    ERROR_NOTIFY_3("in %s: %s failed in getting vgroup with ref#=%d", "vgdumpfull",
-                                   "get_VGandInfo", (int)vg_ref);
+                if (status == FAIL)
+                    ERROR_GOTO_3("in %s: %s failed in getting vgroup with ref#=%d", "vgdumpfull",
+                                 "get_VGandInfo", (int)vg_ref);
 
-                    /* attach itself failed - nothing usable for this entry, skip it */
-                    if (vgt == FAIL) {
-                        *skipfile = TRUE; /* severe failure, skip this file */
-                        ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
-                                       "vgdumpfull", "get_VGandInfo", (int)entry_num);
-                        continue;
-                    }
-                    /* attach succeeded but if name/class fetch failed, get_VGandInfo
-                       already freed and NULL'd vgname/vgclass on this path */
+                /* since the succeeding processing depends on this vg id, we
+                   decided to just skip the current file.  Note that elem_n_entries
+                   is not checked here since it does not effect the following
+                   processing as in the case of the parent's vgroup */
+                if (vgt == FAIL) {
+                    /* return to caller to go to next file */
+                    *skipfile = TRUE;
+                    ERROR_GOTO_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
+                                 "vgdumpfull", "get_VGandInfo", (int)entry_num);
                 }
                 /* vgroup has no name */
-                if (vgname == NULL || strlen(vgname) == 0) {
-                    free(vgname);
+                if (strlen(vgname) == 0 || vgname == NULL) {
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    CHECK_ALLOC(vgname, "vgname", "vgdumpfull");
-                    strcpy(vgname, "<Undefined>");
-                }
-
-                /* vgroup has no class */
-                if (vgclass == NULL || strlen(vgclass) == 0) {
-                    free(vgclass);
-                    vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    CHECK_ALLOC(vgclass, "vgclass", "vgdumpfull");
-                    strcpy(vgclass, "<Undefined>");
+                    strcat(vgname, "<Undefined>");
                 }
 
                 /* add the name and type of this element to the current graph */
@@ -1062,16 +1059,11 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
 
             }                                 /* if current element is vgroup */
             else if (elem_tag == VSDESCTAG) { /* vdata */
-                                              /* add type of this element to the current graph */
-                aNode->type[entry_num] = alloc_string_of_chars("vd");
 
                 vs = VSattach(file_id, elem_ref, "r");
-                if (vs == FAIL) {
+                if (vs == FAIL)
                     ERROR_NOTIFY_2("in %s: VSattach failed for vdata with ref#=%d", "vgdumpfull",
                                    (int)elem_ref);
-                    aNode->children[entry_num] = alloc_string_of_chars("<Invalid>");
-                    continue;
-                }
 
                 /* get and print vdata's information */
                 status = VSinquire(vs, &nv, &interlace, fields, &vsize, vsname);
@@ -1134,8 +1126,9 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 if (strlen(vsname) == 0)
                     strcat(vsname, "<Undefined>");
 
-                /* add the name of this element to the list node */
+                /* add the name and type of this element to the list node */
                 aNode->children[entry_num] = alloc_string_of_chars(vsname);
+                aNode->type[entry_num]     = alloc_string_of_chars("vd");
 
             }    /* if current element is a vdata */
             else /* else something else */
@@ -1315,33 +1308,14 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
             /* attaches the current vgroup and gets its tag, name, and class */
             status = get_VGandInfo(&vg_id, file_id, vg_ref, file_name, &n_entries, &vgname, &vgclass);
             if (status == FAIL)
-                ERROR_NOTIFY_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
-                               (int)vg_ref);
+                ERROR_CONT_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
+                             (int)vg_ref);
 
             /* since the succeeding processing depends heavily on these
                we decided to just skip the current file */
             if (vg_id == FAIL || n_entries == -1) {
                 skipfile = TRUE; /* so Graphical Rep won't be printed */
                 break;           /* to get out of this current file */
-            }
-
-            /* attach succeeded but if name/class fetch failed, get_VGandInfo
-               already freed and NULL'd vgname/vgclass on this path */
-
-            /* vgroup has no name */
-            if (vgname == NULL || strlen(vgname) == 0) {
-                free(vgname);
-                vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                CHECK_ALLOC(vgname, "vgname", "dvg");
-                strcpy(vgname, "<Undefined>");
-            }
-
-            /* vgroup has no class */
-            if (vgclass == NULL || strlen(vgclass) == 0) {
-                free(vgclass);
-                vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                CHECK_ALLOC(vgclass, "vgclass", "dvg");
-                strcpy(vgclass, "<Undefined>");
             }
 
             if (!skipvg)
@@ -1357,7 +1331,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
                 CHECK_ALLOC(list, "list", "dvg");
             }
 
-            list[curr_vg] = (vg_info_t *)calloc(1, sizeof(vg_info_t));
+            list[curr_vg] = (vg_info_t *)malloc(sizeof(vg_info_t));
             CHECK_ALLOC(list[curr_vg], "list[curr_vg]", "dvg");
             list[curr_vg]->children = NULL;
             list[curr_vg]->type     = NULL;
@@ -1477,8 +1451,8 @@ done:
         resetVG(&vg_id, file_name);
         list = free_vginfo_list(list, curr_vg);
         closeVG(&file_id, &vg_chosen, file_name);
-        free(vgname);
-        free(vgclass);
+        SAFE_FREE(vgname);  /* free vg name and set it to NULL */
+        SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
     }
 
     return ret_value;

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -1023,6 +1023,14 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                     strcpy(vgname, "<Undefined>");
                 }
 
+                /* vgroup has no class */
+                if (vgclass == NULL || strlen(vgclass) == 0) {
+                    free(vgclass);
+                    vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
+                    CHECK_ALLOC(vgclass, "vgclass", "vgdumpfull");
+                    strcpy(vgclass, "<Undefined>");
+                }
+
                 /* add the name and type of this element to the current graph */
                 aNode->children[entry_num] = alloc_string_of_chars(vgname);
                 aNode->type[entry_num]     = alloc_string_of_chars("vg");
@@ -1315,6 +1323,25 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
             if (vg_id == FAIL || n_entries == -1) {
                 skipfile = TRUE; /* so Graphical Rep won't be printed */
                 break;           /* to get out of this current file */
+            }
+
+            /* attach succeeded but if name/class fetch failed, get_VGandInfo
+               already freed and NULL'd vgname/vgclass on this path */
+
+            /* vgroup has no name */
+            if (vgname == NULL || strlen(vgname) == 0) {
+                free(vgname);
+                vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
+                CHECK_ALLOC(vgname, "vgname", "dvg");
+                strcpy(vgname, "<Undefined>");
+            }
+
+            /* vgroup has no class */
+            if (vgclass == NULL || strlen(vgclass) == 0) {
+                free(vgclass);
+                vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
+                CHECK_ALLOC(vgclass, "vgclass", "dvg");
+                strcpy(vgclass, "<Undefined>");
             }
 
             if (!skipvg)

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -13,6 +13,7 @@
 
 #include <math.h>
 
+#include "vg_priv.h"
 #include "vg.h"
 #include "hdp.h"
 
@@ -225,67 +226,61 @@ int32
 Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
          int is_name, int32 *find_ref, int32 *index) /* index of the vgroup w/ref# *find_ref */
 {
-    int32  vg_id     = FAIL;
-    char  *name      = NULL;
-    uint16 name_len  = 0;
-    int32  status_32 = FAIL;
-    int32  ret_value = FAIL;
+    int32   vg_id     = FAIL;
+    char   *name      = NULL;
+    ssize_t name_len  = 0;
+    int32   status_32 = FAIL;
+    int32   ret_value = FAIL;
 
     /* starting from the ref# *find_ref, search for the vgroup having a
        name or class the same as the given string searched_name; when no
        more vgroups to search, return FAIL */
     while ((*find_ref = Vgetid(file_id, *find_ref)) != FAIL) {
         vg_id = Vattach(file_id, *find_ref, "r");
-        if (FAIL == vg_id)
+        if (vg_id == FAIL)
             ERROR_GOTO_2("in %s: Vattach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
 
-        /* get the length of the vgname to allocate enough space */
-        if (is_name)
-            status_32 = Vgetnamelen(vg_id, &name_len);
-        else
-            status_32 = Vgetclassnamelen(vg_id, &name_len);
-        if (FAIL == status_32) /* go to done and return a FAIL */
-        {
-            ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "Vstr_ref", (int)*find_ref);
+        /* get the vg name/class */
+        if (is_name) {
+            name = vgetvgname(vg_id);
+            if (!name) {
+                ERROR_GOTO_2("in %s: Failed to get name for vgroup with ref#(%d)", "Vstr_ref",
+                             (int)*find_ref);
+            }
         }
-        name = (char *)malloc(sizeof(char) * (name_len + 1));
-        /* If allocation fails, Vstr_ref simply terminates hdp. */
-        CHECK_ALLOC(name, "vgroup classname", "Vstr_ref");
-
-        if (name_len > 0) {
-            if (is_name) {
-                if (FAIL == Vgetname(vg_id, name))
-                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
-                                 (int)*find_ref);
+        else {
+            name = vgetvgclass(vg_id);
+            if (!name) {
+                ERROR_GOTO_2("in %s: Failed to get class name for vgroup with ref#(%d)", "Vstr_ref",
+                             (int)*find_ref);
             }
-            else {
-                if (FAIL == Vgetclass(vg_id, name))
-                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
-                                 (int)*find_ref);
-            }
+        }
 
-            if (FAIL == Vdetach(vg_id))
-                ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
+        if (FAIL == Vdetach(vg_id))
+            ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref",
+                         (int)*find_ref);
+        vg_id = FAIL;
 
-            /* if the vg's name or vg's class is the given string, return the
-            index of the vgroup found */
-            if (strcmp(name, searched_str) == 0) {
-                /* return the current ref# */
-                ret_value = *find_ref;
-                /* increment index for next vgroup - same class vgroups*/
-                (*index)++;
-                goto done;
-            }
+        /* if the vg's name or vg's class is the given string, return the
+        index of the vgroup found */
+        if (strcmp(name, searched_str) == 0) {
+            /* return the current ref# */
+            ret_value = *find_ref;
+            /* increment index for next vgroup - same class vgroups*/
             (*index)++;
-        } /* name_len > 0 */
+            goto done;
+        }
+            (*index)++;
 
         SAFE_FREE(name); /* free name and set it to NULL */
-    }                    /* end while getting vgroups */
+    }   /* end while getting vgroups */
 
-    /* when VSgetid returned FAIL in while above, search should stop */
+    /* when Vgetid returned FAIL in while above, search should stop */
     ret_value = FAIL;
 
 done:
+    if (vg_id != FAIL)
+        Vdetach(vg_id);
     SAFE_FREE(name); /* free name and set it to NULL */
 
     return ret_value;
@@ -416,8 +411,7 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
               char **vgname, char **vgclass)
 {
     int    status, ret_value = SUCCEED;
-    int32  status_32;
-    uint16 name_len = 0;
+    size_t buf_size = 0;
 
     /* detach the current vgroup if it's attached to cover the case
       where a library routine fails and must continue to the next vgroup
@@ -429,18 +423,19 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         ERROR_GOTO_2("in %s: Vattach failed for vgroup ref=%d", "get_VGandInfo", (int)vg_ref);
 
     /* get the length of the vgname to allocate enough space */
-    status_32 = Vgetnamelen(*vg_id, &name_len);
-    if (FAIL == status_32) /* go to done and return a FAIL */
+    status = Vgetname(*vg_id, NULL, &buf_size);
+    if (status == FAIL) /* go to done and return a FAIL */
     {
-        ERROR_GOTO_2("in %s: Vgetnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
+        ERROR_GOTO_2("in %s: Vgetname failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
-    if (name_len > 0) {
-        *vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    if (buf_size > 0) {
+        *vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
         CHECK_ALLOC(*vgname, "*vgname", "get_VGandInfo");
 
-        status = Vinquire(*vg_id, n_entries, *vgname);
+        buf_size++;
+        status = Vinquire(*vg_id, n_entries, *vgname, &buf_size);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -450,7 +445,7 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     else {
         *vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
         strcpy(*vgname, "<Undefined>");
-        status = Vinquire(*vg_id, n_entries, NULL);
+        status = Vinquire(*vg_id, n_entries, NULL, &buf_size);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -459,19 +454,20 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     }
 
     /* get the length of the vgclass to allocate enough space */
-    status_32 = Vgetclassnamelen(*vg_id, &name_len);
-    if (FAIL == status_32) /* go to done and return a FAIL */
+    status = Vgetclass(*vg_id, NULL, &buf_size);
+    if (status == FAIL) /* go to done and return a FAIL */
     {
-        ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
+        ERROR_GOTO_2("in %s: Vgetclass failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
-    if (name_len > 0) {
-        *vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    if (buf_size > 0) {
+        *vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
         CHECK_ALLOC(*vgclass, "*vgclass", "get_VGandInfo");
 
-        status_32 = Vgetclass(*vg_id, *vgclass);
-        if (FAIL == status_32) /* go to done and return a FAIL */
+        buf_size++;
+        status = Vgetclass(*vg_id, *vgclass, &buf_size);
+        if (status == FAIL) /* go to done and return a FAIL */
         {
             ERROR_GOTO_2("in %s: Vgetclass failed for vgroup ref#=%d", "get_VGandInfo", (int)vg_ref);
         }
@@ -483,11 +479,8 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
 
 done:
     if (ret_value == FAIL) {
-        free(*vgname); /* free temp memory */
-        *vgname = NULL;
-
-        free(*vgclass); /* free temp memory */
-        *vgclass = NULL;
+        HDfreenclear(*vgname); /* free temp memory */
+        HDfreenclear(*vgclass); /* free temp memory */
     }
 
     return (ret_value);
@@ -533,9 +526,6 @@ alloc_list_of_strings(int32 num_entries)
 {
     char **ptr = NULL;
 
-    /* I don't know why +1 here and only i<num_entries at for loop - BMR*/
-    /* probably, +1 so that malloc won't fail when num_entries = 0, was */
-    /* added in r1842.  But, that means possible memory leak! */
     ptr = (char **)malloc(sizeof(char *) * (size_t)num_entries);
 
     /* If allocation fails, alloc_list_of_string simply terminates hdp. */
@@ -584,7 +574,7 @@ print_fields(const char *fields, const char *field_title, FILE *fp)
     CHECK_ALLOC(tempflds, "tempflds", "print_fields");
 
     /* if fields are not defined by VSsetfields and VSfdefine */
-    if (fields[0] == '\0' || fields == NULL)
+    if (fields == NULL || fields[0] == '\0')
         fprintf(fp, "%s <Undefined>;\n", field_title);
 
     else { /* there are fields to print */
@@ -858,22 +848,27 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 /* get the current vgroup and its information */
                 status =
                     get_VGandInfo(&vgt, file_id, elem_ref, file_name, &elem_n_entries, &vgname, &vgclass);
-                if (status == FAIL)
+                if (status == FAIL) {
                     ERROR_NOTIFY_3("in %s: %s failed in getting vgroup with ref#=%d", "vgBuildGraph",
                                    "get_VGandInfo", (int)vg_ref);
 
-                /* although get_VGandInfo failed to get a valid id for this vgroup,
-                   the node for the vgroup is not affected, so build it anyway */
-                if (vgt == FAIL) {
-                    *skipfile = TRUE; /* severe failure, skip this file */
-                    ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
-                                   "vgBuildGraph", "get_VGandInfo", (int)entry_num);
+                    /* attach itself failed - nothing usable for this entry, skip it */
+                    if (vgt == FAIL) {
+                        *skipfile = TRUE; /* severe failure, skip this file */
+                        ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
+                                       "vgBuildGraph", "get_VGandInfo", (int)entry_num);
+                        continue;
+                    }
+                    /* attach succeeded but if name/class fetch failed, get_VGandInfo
+                       already freed and NULL'd vgname/vgclass on this path */
                 }
 
                 /* vgroup has no name */
-                if (strlen(vgname) == 0 || vgname == NULL) {
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgname);
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    strcat(vgname, "<Undefined>");
+                    CHECK_ALLOC(vgname, "vgname", "vgBuildGraph");
+                    strcpy(vgname, "<Undefined>");
                 }
 
                 resetVG(&vgt, file_name);
@@ -933,6 +928,7 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 aNode->children[entry_num] = alloc_string_of_chars("***");
 
                 if (!strcmp(name, "Unknown Tag")) {
+                    free(name);
                     aNode->type[entry_num] = alloc_string_of_chars("Unknown Object");
                 }
                 else
@@ -942,8 +938,8 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
         }     /* for */
     }
 done:
-    SAFE_FREE(vgname);  /* free vg name and set it to NULL */
-    SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
+    free(vgname);
+    free(vgclass);
 
     return ret_value;
 } /* vgBuildGraph */
@@ -1008,24 +1004,26 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 /* get the current vgroup and its information */
                 status =
                     get_VGandInfo(&vgt, file_id, elem_ref, file_name, &elem_n_entries, &vgname, &vgclass);
-                if (status == FAIL)
-                    ERROR_GOTO_3("in %s: %s failed in getting vgroup with ref#=%d", "vgdumpfull",
-                                 "get_VGandInfo", (int)vg_ref);
+                if (status == FAIL) {
+                    ERROR_NOTIFY_3("in %s: %s failed in getting vgroup with ref#=%d", "vgdumpfull",
+                                   "get_VGandInfo", (int)vg_ref);
 
-                /* since the succeeding processing depends on this vg id, we
-                   decided to just skip the current file.  Note that elem_n_entries
-                   is not checked here since it does not effect the following
-                   processing as in the case of the parent's vgroup */
-                if (vgt == FAIL) {
-                    /* return to caller to go to next file */
-                    *skipfile = TRUE;
-                    ERROR_GOTO_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
-                                 "vgdumpfull", "get_VGandInfo", (int)entry_num);
+                    /* attach itself failed - nothing usable for this entry, skip it */
+                    if (vgt == FAIL) {
+                        *skipfile = TRUE; /* severe failure, skip this file */
+                        ERROR_NOTIFY_3("in %s: %s failed to return a valid vgroup id for the %d'th entry",
+                                       "vgdumpfull", "get_VGandInfo", (int)entry_num);
+                        continue;
+                    }
+                    /* attach succeeded but if name/class fetch failed, get_VGandInfo
+                       already freed and NULL'd vgname/vgclass on this path */
                 }
                 /* vgroup has no name */
-                if (strlen(vgname) == 0 || vgname == NULL) {
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgname);
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    strcat(vgname, "<Undefined>");
+                    CHECK_ALLOC(vgname, "vgname", "vgdumpfull");
+                    strcpy(vgname, "<Undefined>");
                 }
 
                 /* add the name and type of this element to the current graph */
@@ -1059,11 +1057,16 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
 
             }                                 /* if current element is vgroup */
             else if (elem_tag == VSDESCTAG) { /* vdata */
+                                              /* add type of this element to the current graph */
+                aNode->type[entry_num] = alloc_string_of_chars("vd");
 
                 vs = VSattach(file_id, elem_ref, "r");
-                if (vs == FAIL)
+                if (vs == FAIL) {
                     ERROR_NOTIFY_2("in %s: VSattach failed for vdata with ref#=%d", "vgdumpfull",
                                    (int)elem_ref);
+                    aNode->children[entry_num] = alloc_string_of_chars("<Invalid>");
+                    continue;
+                }
 
                 /* get and print vdata's information */
                 status = VSinquire(vs, &nv, &interlace, fields, &vsize, vsname);
@@ -1126,9 +1129,8 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 if (strlen(vsname) == 0)
                     strcat(vsname, "<Undefined>");
 
-                /* add the name and type of this element to the list node */
+                /* add the name of this element to the list node */
                 aNode->children[entry_num] = alloc_string_of_chars(vsname);
-                aNode->type[entry_num]     = alloc_string_of_chars("vd");
 
             }    /* if current element is a vdata */
             else /* else something else */
@@ -1308,7 +1310,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
             /* attaches the current vgroup and gets its tag, name, and class */
             status = get_VGandInfo(&vg_id, file_id, vg_ref, file_name, &n_entries, &vgname, &vgclass);
             if (status == FAIL)
-                ERROR_CONT_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
+                ERROR_NOTIFY_2("in dvg: %s failed in getting vgroup with ref#=%d", "get_VGandInfo",
                              (int)vg_ref);
 
             /* since the succeeding processing depends heavily on these
@@ -1331,7 +1333,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
                 CHECK_ALLOC(list, "list", "dvg");
             }
 
-            list[curr_vg] = (vg_info_t *)malloc(sizeof(vg_info_t));
+            list[curr_vg] = (vg_info_t *)calloc(1, sizeof(vg_info_t));
             CHECK_ALLOC(list[curr_vg], "list[curr_vg]", "dvg");
             list[curr_vg]->children = NULL;
             list[curr_vg]->type     = NULL;
@@ -1451,8 +1453,8 @@ done:
         resetVG(&vg_id, file_name);
         list = free_vginfo_list(list, curr_vg);
         closeVG(&file_id, &vg_chosen, file_name);
-        SAFE_FREE(vgname);  /* free vg name and set it to NULL */
-        SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
+        free(vgname);
+        free(vgclass);
     }
 
     return ret_value;

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -13,10 +13,12 @@
 
 #include <math.h>
 
+#include "vg_priv.h" 
 #include "vg.h"
 #include "hdp.h"
 
 #define NONAME_LEN 12
+#define NONAME_TXT "<Undefined>"
 
 void   dumpvg_usage(int argc, char *argv[]);
 int32  Vref_index(int32 file_id, int32 vg_ref);
@@ -227,8 +229,8 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
 {
     int32  vg_id     = FAIL;
     char  *name      = NULL;
-    uint16 name_len  = 0;
-    int32  status_32 = FAIL;
+    size_t buf_size  = 0;
+    int32  status    = FAIL;
     int32  ret_value = FAIL;
 
     /* starting from the ref# *find_ref, search for the vgroup having a
@@ -236,36 +238,38 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
        more vgroups to search, return FAIL */
     while ((*find_ref = Vgetid(file_id, *find_ref)) != FAIL) {
         vg_id = Vattach(file_id, *find_ref, "r");
-        if (FAIL == vg_id)
+        if (vg_id == FAIL)
             ERROR_GOTO_2("in %s: Vattach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
 
         /* get the length of the vgname to allocate enough space */
         if (is_name)
-            status_32 = Vgetnamelen(vg_id, &name_len);
+            status = Vgetname(vg_id, NULL, &buf_size);
         else
-            status_32 = Vgetclassnamelen(vg_id, &name_len);
-        if (FAIL == status_32) /* go to done and return a FAIL */
+            status = Vgetclass(vg_id, NULL, &buf_size);
+        if (FAIL == status) /* go to done and return a FAIL */
         {
             ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "Vstr_ref", (int)*find_ref);
         }
-        name = (char *)malloc(sizeof(char) * (name_len + 1));
+        name = (char *)malloc(sizeof(char) * (buf_size + 1));
         /* If allocation fails, Vstr_ref simply terminates hdp. */
-        CHECK_ALLOC(name, "vgroup classname", "Vstr_ref");
+        CHECK_ALLOC(name, "name", "Vstr_ref");
 
-        if (name_len > 0) {
+        if (buf_size > 0) {
+            buf_size++;
             if (is_name) {
-                if (FAIL == Vgetname(vg_id, name))
-                    ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
+                if (FAIL == Vgetname(vg_id, name, &buf_size))
+                    ERROR_GOTO_2("in %s: Vgetname failed for vgroup with ref#(%d)", "Vstr_ref",
                                  (int)*find_ref);
             }
             else {
-                if (FAIL == Vgetclass(vg_id, name))
+                if (FAIL == Vgetclass(vg_id, name, &buf_size))
                     ERROR_GOTO_2("in %s: Vgetclass failed for vgroup with ref#(%d)", "Vstr_ref",
                                  (int)*find_ref);
             }
 
             if (FAIL == Vdetach(vg_id))
                 ERROR_GOTO_2("in %s: Vdetach failed for vgroup with ref#(%d)", "Vstr_ref", (int)*find_ref);
+            vg_id = FAIL;
 
             /* if the vg's name or vg's class is the given string, return the
             index of the vgroup found */
@@ -277,7 +281,7 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
                 goto done;
             }
             (*index)++;
-        } /* name_len > 0 */
+        } /* buf_size > 0 */
 
         SAFE_FREE(name); /* free name and set it to NULL */
     }                    /* end while getting vgroups */
@@ -286,6 +290,8 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
     ret_value = FAIL;
 
 done:
+    if (vg_id != FAIL)
+        Vdetach(vg_id);
     SAFE_FREE(name); /* free name and set it to NULL */
 
     return ret_value;
@@ -416,8 +422,9 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
               char **vgname, char **vgclass)
 {
     int    status, ret_value = SUCCEED;
-    int32  status_32;
-    uint16 name_len = 0;
+    size_t buf_size = 0;
+    char *tmp_vgname = NULL;
+    char *tmp_vgclass = NULL;
 
     /* detach the current vgroup if it's attached to cover the case
       where a library routine fails and must continue to the next vgroup
@@ -429,18 +436,19 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         ERROR_GOTO_2("in %s: Vattach failed for vgroup ref=%d", "get_VGandInfo", (int)vg_ref);
 
     /* get the length of the vgname to allocate enough space */
-    status_32 = Vgetnamelen(*vg_id, &name_len);
-    if (FAIL == status_32) /* go to done and return a FAIL */
+    status = Vgetname(*vg_id, NULL, &buf_size);
+    if (FAIL == status) /* go to done and return a FAIL */
     {
         ERROR_GOTO_2("in %s: Vgetnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
-    if (name_len > 0) {
-        *vgname = (char *)malloc(sizeof(char) * (name_len + 1));
+    if (buf_size > 0) {
+        tmp_vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
-        CHECK_ALLOC(*vgname, "*vgname", "get_VGandInfo");
+        CHECK_ALLOC(tmp_vgname, "tmp_vgname", "get_VGandInfo");
 
-        status = Vinquire(*vg_id, n_entries, *vgname);
+        buf_size++;
+        status = Vinquire(*vg_id, n_entries, tmp_vgname, &buf_size);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -448,9 +456,9 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
         }
     }
     else {
-        *vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-        strcpy(*vgname, "<Undefined>");
-        status = Vinquire(*vg_id, n_entries, NULL);
+        tmp_vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
+        strcpy(tmp_vgname, NONAME_TXT);
+        status = Vinquire(*vg_id, n_entries, NULL, &buf_size);
         if (FAIL == status) /* go to done and return a FAIL */
         {
             *n_entries = -1;
@@ -459,35 +467,38 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     }
 
     /* get the length of the vgclass to allocate enough space */
-    status_32 = Vgetclassnamelen(*vg_id, &name_len);
-    if (FAIL == status_32) /* go to done and return a FAIL */
+    status = Vgetclass(*vg_id, NULL, &buf_size);
+    if (FAIL == status) /* go to done and return a FAIL */
     {
         ERROR_GOTO_2("in %s: Vgetclassnamelen failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
     }
-    if (name_len > 0) {
-        *vgclass = (char *)malloc(sizeof(char) * (name_len + 1));
+    if (buf_size > 0) {
+        tmp_vgclass = (char *)malloc(sizeof(char) * (buf_size + 1));
 
         /* If allocation fails, get_VGandInfo simply terminates hdp. */
-        CHECK_ALLOC(*vgclass, "*vgclass", "get_VGandInfo");
+        CHECK_ALLOC(tmp_vgclass, "tmp_vgclass", "get_VGandInfo");
 
-        status_32 = Vgetclass(*vg_id, *vgclass);
-        if (FAIL == status_32) /* go to done and return a FAIL */
+        buf_size++;
+        status = Vgetclass(*vg_id, tmp_vgclass, &buf_size);
+        if (FAIL == status) /* go to done and return a FAIL */
         {
             ERROR_GOTO_2("in %s: Vgetclass failed for vgroup ref#=%d", "get_VGandInfo", (int)vg_ref);
         }
     }
     else {
-        *vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
-        strcpy(*vgclass, "<Undefined>");
+        tmp_vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
+        strcpy(tmp_vgclass, NONAME_TXT);
     }
+
+    *vgname = tmp_vgname;
+    tmp_vgname = NULL;
+    *vgclass = tmp_vgclass;
+    tmp_vgclass = NULL;
 
 done:
     if (ret_value == FAIL) {
-        free(*vgname); /* free temp memory */
-        *vgname = NULL;
-
-        free(*vgclass); /* free temp memory */
-        *vgclass = NULL;
+        free(tmp_vgname);
+        free(tmp_vgclass);
     }
 
     return (ret_value);
@@ -533,9 +544,6 @@ alloc_list_of_strings(int32 num_entries)
 {
     char **ptr = NULL;
 
-    /* I don't know why +1 here and only i<num_entries at for loop - BMR*/
-    /* probably, +1 so that malloc won't fail when num_entries = 0, was */
-    /* added in r1842.  But, that means possible memory leak! */
     ptr = (char **)malloc(sizeof(char *) * (size_t)num_entries);
 
     /* If allocation fails, alloc_list_of_string simply terminates hdp. */
@@ -584,7 +592,7 @@ print_fields(const char *fields, const char *field_title, FILE *fp)
     CHECK_ALLOC(tempflds, "tempflds", "print_fields");
 
     /* if fields are not defined by VSsetfields and VSfdefine */
-    if (fields[0] == '\0' || fields == NULL)
+    if (fields == NULL || fields[0] == '\0')
         fprintf(fp, "%s <Undefined>;\n", field_title);
 
     else { /* there are fields to print */
@@ -871,9 +879,11 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 }
 
                 /* vgroup has no name */
-                if (strlen(vgname) == 0 || vgname == NULL) {
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgname);
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    strcat(vgname, "<Undefined>");
+                    CHECK_ALLOC(vgname, "vgname", "vgBuildGraph");
+                    strcpy(vgname, NONAME_TXT);
                 }
 
                 resetVG(&vgt, file_name);
@@ -881,10 +891,8 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 /* add the name and type of this element to the current graph */
                 aNode->children[entry_num] = alloc_string_of_chars(vgname);
                 aNode->type[entry_num]     = alloc_string_of_chars("vg");
-                free(vgname);
-                vgname = NULL;
-                free(vgclass);
-                vgclass = NULL;
+                HDfreenclear(vgname);
+                HDfreenclear(vgclass);
 
             }                                 /* if current element is vgroup */
             else if (elem_tag == VSDESCTAG) { /* vdata */
@@ -933,6 +941,7 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
                 aNode->children[entry_num] = alloc_string_of_chars("***");
 
                 if (!strcmp(name, "Unknown Tag")) {
+                    free(name);
                     aNode->type[entry_num] = alloc_string_of_chars("Unknown Object");
                 }
                 else
@@ -942,8 +951,8 @@ vgBuildGraph(int32 vg_id, int32 file_id, int32 num_entries, const char *file_nam
         }     /* for */
     }
 done:
-    SAFE_FREE(vgname);  /* free vg name and set it to NULL */
-    SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
+    free(vgname);
+    free(vgclass);
 
     return ret_value;
 } /* vgBuildGraph */
@@ -1024,8 +1033,18 @@ vgdumpfull(int32 vg_id, dump_info_t *dumpvg_opts, int32 file_id, int32 num_entri
                 }
                 /* vgroup has no name */
                 if (strlen(vgname) == 0 || vgname == NULL) {
+                    free(vgname);
                     vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
-                    strcat(vgname, "<Undefined>");
+                    CHECK_ALLOC(vgname, "vgname", "vgdumpfull");
+                    strcat(vgname, NONAME_TXT);
+                }
+
+                /* vgroup has no class */
+                if (vgname == NULL || strlen(vgname) == 0) {
+                    free(vgclass);
+                    vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
+                    CHECK_ALLOC(vgclass, "vgclass", "vgdumpfull");
+                    strcat(vgclass, NONAME_TXT);
                 }
 
                 /* add the name and type of this element to the current graph */
@@ -1318,6 +1337,22 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
                 break;           /* to get out of this current file */
             }
 
+            /* vgroup has no name */
+            if (vgname == NULL || strlen(vgname) == 0) {
+                free(vgname);
+                vgname = (char *)malloc(sizeof(char) * (NONAME_LEN));
+                CHECK_ALLOC(vgname, "vgname", "dvg");
+                strcpy(vgname, NONAME_TXT);
+            }
+
+            /* vgroup has no class */
+            if (vgclass == NULL || strlen(vgclass) == 0) {
+                free(vgclass);
+                vgclass = (char *)malloc(sizeof(char) * (NONAME_LEN));
+                CHECK_ALLOC(vgclass, "vgclass", "dvg");
+                strcpy(vgclass, NONAME_TXT);
+            }
+
             if (!skipvg)
                 vg_count++;
 
@@ -1331,7 +1366,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
                 CHECK_ALLOC(list, "list", "dvg");
             }
 
-            list[curr_vg] = (vg_info_t *)malloc(sizeof(vg_info_t));
+            list[curr_vg] = (vg_info_t *)calloc(1, sizeof(vg_info_t));
             CHECK_ALLOC(list[curr_vg], "list[curr_vg]", "dvg");
             list[curr_vg]->children = NULL;
             list[curr_vg]->type     = NULL;
@@ -1373,8 +1408,7 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
                     ERROR_NOTIFY_3("in dvg: %s failed on vgroup with ref=%d in file %s", "dumpattr",
                                    (int)vg_ref, file_name);
             } /* not skipped */
-            free(vgclass);
-            vgclass = NULL;
+            HDfreenclear(vgclass);
 
             if (skipvg || dumpvg_opts->contents == DHEADER) {
                 status = vgBuildGraph(vg_id, file_id, n_entries, file_name, list[curr_vg], &skipfile);
@@ -1406,9 +1440,8 @@ dvg(dump_info_t *dumpvg_opts, int curr_arg, int argc, char *argv[])
             list[curr_vg]->vg_name = (char *)malloc(sizeof(char) * (strlen(vgname) + 1));
             strcpy(list[curr_vg]->vg_name, vgname);
             list[curr_vg]->displayed     = FALSE;
-            list[curr_vg]->treedisplayed = FALSE; /* BMR - 01/16/99 */
-            free(vgname);
-            vgname = NULL;
+            list[curr_vg]->treedisplayed = FALSE;
+            HDfreenclear(vgname);
 
             vg_ref = Vgetid(file_id, vg_ref);
             if (vg_ref != FAIL)
@@ -1451,8 +1484,8 @@ done:
         resetVG(&vg_id, file_name);
         list = free_vginfo_list(list, curr_vg);
         closeVG(&file_id, &vg_chosen, file_name);
-        SAFE_FREE(vgname);  /* free vg name and set it to NULL */
-        SAFE_FREE(vgclass); /* free vg class name and set it to NULL */
+        free(vgname);
+        free(vgclass);
     }
 
     return ret_value;

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -228,7 +228,6 @@ Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
 {
     int32   vg_id     = FAIL;
     char   *name      = NULL;
-    ssize_t name_len  = 0;
     int32   status_32 = FAIL;
     int32   ret_value = FAIL;
 

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -226,10 +226,10 @@ int32
 Vstr_ref(int32 file_id, char *searched_str,          /* vg's class name */
          int is_name, int32 *find_ref, int32 *index) /* index of the vgroup w/ref# *find_ref */
 {
-    int32   vg_id     = FAIL;
-    char   *name      = NULL;
-    int32   status_32 = FAIL;
-    int32   ret_value = FAIL;
+    int32 vg_id     = FAIL;
+    char *name      = NULL;
+    int32 status_32 = FAIL;
+    int32 ret_value = FAIL;
 
     /* starting from the ref# *find_ref, search for the vgroup having a
        name or class the same as the given string searched_name; when no

--- a/mfhdf/hdp/hdp_vg.c
+++ b/mfhdf/hdp/hdp_vg.c
@@ -423,9 +423,8 @@ get_VGandInfo(int32 *vg_id, int32 file_id, int32 vg_ref, const char *file_name, 
     /* get the length of the vgname to allocate enough space */
     status = Vgetname(*vg_id, NULL, &buf_size);
     if (status == FAIL) /* go to done and return a FAIL */
-    {
         ERROR_GOTO_2("in %s: Vgetname failed for vg ref=%d", "get_VGandInfo", (int)vg_ref);
-    }
+
     if (buf_size > 0) {
         *vgname = (char *)malloc(sizeof(char) * (buf_size + 1));
 

--- a/mfhdf/hrepack/hrepack_list.c
+++ b/mfhdf/hrepack/hrepack_list.c
@@ -386,7 +386,7 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
             /* Get vgroup's class */
             vg_class = vgetvgclass(vg_id);
             if (!vg_class) {
-                printf("Error: Could not get class length for group with ref <%d>\n", ref);
+                printf("Error: Could not get class name for vgroup with ref <%d>\n", ref);
                 goto out;
             }
 
@@ -578,14 +578,14 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                 /* Get vgroup's name */
                 vg_name = vgetvgname(vg_id);
                 if (!vg_name) {
-                    printf("Error: Could not get name length for group with ref <%d>\n", ref);
+                    printf("Error: Could not get name for vgroup with ref <%d>\n", ref);
                     goto out;
                 }
 
                 /* Get vgroup's class name */
                 vg_class = vgetvgclass(vg_id);
                 if (!vg_class) {
-                    printf("Error: Could not get class length for group with ref <%d>\n", ref);
+                    printf("Error: Could not get class name for vgroup with ref <%d>\n", ref);
                     goto out;
                 }
 

--- a/mfhdf/hrepack/hrepack_list.c
+++ b/mfhdf/hrepack/hrepack_list.c
@@ -16,6 +16,7 @@
 
 #include "hdf.h"
 #include "mfhdf.h"
+#include "vg_priv.h"
 #include "hrepack.h"
 #include "hrepack_utils.h"
 #include "hrepack_parse.h"
@@ -235,6 +236,7 @@ list_main(const char *infname, const char *outfname, options_t *options)
         printf("Failed to close file <%s>\n", infname);
     if (Hclose(infile_id) == FAIL)
         printf("Failed to close file <%s>\n", infname);
+    infile_id = FAIL;
 
     if (options->trip == 1) {
         if (has_GRelems)
@@ -284,6 +286,7 @@ out:
     if (infile_id != FAIL) {
         if (Hclose(infile_id) == FAIL)
             printf("Failed to close file <%s>\n", infname);
+        infile_id = FAIL;
     }
     if (outfile_id != FAIL) {
         if (Hclose(outfile_id) == FAIL)
@@ -361,8 +364,7 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
          */
         for (i = 0; i < nlones; i++) {
 
-            int32  ref = ref_array[i];
-            uint16 name_len;
+            int32 ref = ref_array[i];
 
             /*
              * attach to the current vgroup then get its
@@ -375,30 +377,16 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
             }
 
             /* Get vgroup's name */
-            if (Vgetnamelen(vg_id, &name_len) == FAIL) {
-                printf("Error: Could not get name length for group with ref <%d>\n", ref);
+            vg_name = vgetvgname(vg_id);
+            if (!vg_name) {
+                printf("Error: Could not get name for group with ref <%d>\n", ref);
                 goto out;
             }
 
-            free(vg_name);
-            vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetname(vg_id, vg_name) == FAIL) {
-                printf("Could not get name for group\n");
-                goto out;
-            }
-
-            /* Get vgroup's class name */
-            if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                printf("Error: Could not get name length for group with ref <%d>\n", ref);
-                goto out;
-            }
-
-            free(vg_class);
-            vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-
-            if (Vgetclass(vg_id, vg_class) == FAIL) {
-                printf("Could not get class for group\n");
+            /* Get vgroup's class */
+            vg_class = vgetvgclass(vg_id);
+            if (!vg_class) {
+                printf("Error: Could not get class length for group with ref <%d>\n", ref);
                 goto out;
             }
 
@@ -472,10 +460,8 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
                     goto out;
                 }
 
-                free(tags);
-                tags = NULL;
-                free(refs);
-                refs = NULL;
+                HDfreenclear(tags);
+                HDfreenclear(refs);
             }
 
             if (Vdetach(vg_id) == FAIL) {
@@ -489,14 +475,12 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
                 }
             }
 
-            free(vg_class);
-            vg_class = NULL;
-            free(vg_name);
-            vg_name = NULL;
+            HDfreenclear(vg_class);
+            HDfreenclear(vg_name);
         } /* for nlones */
 
         /* free the space allocated */
-        free(ref_array);
+        HDfreenclear(ref_array);
 
     } /* if  nlones */
 
@@ -509,6 +493,7 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
         printf("Error: Could not end infile group interface\n");
         return FAIL;
     }
+    infile_id = FAIL;
     if (options->trip == 1) {
         if (Vend(outfile_id) == FAIL) {
             printf("Error: Could not end outfile group interface\n");
@@ -516,8 +501,8 @@ list_vg(int32 infile_id, int32 outfile_id, int32 sd_id, int32 sd_out, int32 gr_i
         }
     }
 
-    free(vg_class);
-    free(vg_name);
+    HDfreenclear(vg_class);
+    HDfreenclear(vg_name);
 
     return SUCCEED;
 
@@ -565,7 +550,6 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
     char  *vg_name       = NULL;
     char  *vg_class      = NULL;
     char  *path          = NULL;
-    uint16 name_len;
     int    visited;
     int32  tag;
     int32  ref;
@@ -592,27 +576,16 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                 vg_id = Vattach(infile_id, ref, "r");
 
                 /* Get vgroup's name */
-                if (Vgetnamelen(vg_id, &name_len) == FAIL) {
+                vg_name = vgetvgname(vg_id);
+                if (!vg_name) {
                     printf("Error: Could not get name length for group with ref <%d>\n", ref);
-                    goto out;
-                }
-                free(vg_name);
-                vg_name = (char *)malloc(sizeof(char) * (name_len + 1));
-                if (Vgetname(vg_id, vg_name) == FAIL) {
-                    printf("Could not get name for group\n");
                     goto out;
                 }
 
                 /* Get vgroup's class name */
-                if (Vgetclassnamelen(vg_id, &name_len) == FAIL) {
-                    printf("Error: Could not get name length for group with ref <%d>\n", ref);
-                    goto out;
-                }
-
-                free(vg_class);
-                vg_class = (char *)malloc(sizeof(char) * (name_len + 1));
-                if (Vgetclass(vg_id, vg_class) == FAIL) {
-                    printf("Could not get class for group\n");
+                vg_class = vgetvgclass(vg_id);
+                if (!vg_class) {
+                    printf("Error: Could not get class length for group with ref <%d>\n", ref);
                     goto out;
                 }
 
@@ -629,6 +602,7 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                         printf("Could not detach group\n");
                         goto out;
                     }
+                    vg_id = FAIL;
                     continue;
                 }
 
@@ -774,8 +748,8 @@ vgroup_insert(int32 infile_id, int32 outfile_id, int32 sd_id, /* SD interface id
                 }
                 break;
         } /* switch */
-        free(vg_name);
-        vg_name = NULL;
+        HDfreenclear(vg_name);
+        HDfreenclear(vg_class);
     } /* i */
     free(vg_class);
     free(vg_name);

--- a/mfhdf/src/cdf.c
+++ b/mfhdf/src/cdf.c
@@ -15,11 +15,12 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "nc_priv.h"
+#include "vg_priv.h"
 #include "herr_priv.h"
 
 #include "hfile_priv.h"
 
-int32 hdf_get_magicnum(const char *filename);
+static int32 hdf_get_magicnum(const char *filename);
 
 static int hdf_num_attrs(NC   *handle, /* IN: handle to SDS */
                          int32 vg /* IN: ref of top Vgroup */);
@@ -79,6 +80,13 @@ NC_free_cdf(NC *handle)
     }
 
 done:
+    if (ret_value == FAIL) {
+        if (handle->file_type == HDF_FILE) {
+            Vend(handle->hdf_file);
+            Hclose(handle->hdf_file);
+        }
+    }
+
     return ret_value;
 }
 
@@ -88,7 +96,7 @@ done:
   can be used to determine the format type of a file, such as HDF, CDF, or
   netCDF/64-bit.
 */
-int32
+static int32
 hdf_get_magicnum(const char *filename)
 {
     hdf_file_t fp;
@@ -1153,15 +1161,16 @@ done:
 int
 hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
 {
-    char     vgname[H4_MAX_NC_NAME]   = "";
-    char     vsclass[H4_MAX_NC_CLASS] = "";
-    char     vgclass[H4_MAX_NC_CLASS] = "";
     int      id, count, i, found;
     int      sub_id;
+    char    *vgname                   = NULL; /* name of a vgroup, used by new Vgetname */
+    char    *vgclass                  = NULL; /* class of a vgroup, used by new Vgetclass */
+    size_t   buf_size                 = 0;    /* length of the name or class of a vgroup */
+    char     vsclass[H4_MAX_NC_CLASS] = "";   /* name of vdata */
     int32    dim_size;
     NC_dim **dimension = NULL;
-    int32    dim, entries;
-    int32    vs;
+    int32    dimvg     = -1;
+    int32    vs        = -1;
     int      ret_value = SUCCEED;
 
     (void)xdrs;
@@ -1181,34 +1190,40 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
     }
 
     /*
-     * Look through for a Vgroup of class _HDF_DIMENSION
+     * Look through cdf vg for a Vgroup of class _HDF_[U]DIMENSION, then in that dim
+     * Vgroup, look for the Vdata of class DIM_VALS01 or DIM_VALS to get the size
      */
     while ((id = Vgetnext(vg, id)) != FAIL) {
         if (Visvg(vg, id)) {
-            dim = Vattach(handle->hdf_file, id, "r");
-            if (dim == FAIL)
-                continue; /* why do we continue? does this failure here
-                                not matter? -GV */
-            if (Vgetclass(dim, vgclass) == FAIL)
+            dimvg = Vattach(handle->hdf_file, id, "r");
+            if (dimvg == FAIL)
+                continue; /* to the next vg */
+
+            /* Get the class of the vgroup, should be a dimension */
+            vgclass = vgetvgclass(dimvg);
+            if (!vgclass)
                 HGOTO_FAIL(FAIL);
 
+            /* Process if the dimension vgroup */
             if (!strcmp(vgclass, _HDF_DIMENSION) || !strcmp(vgclass, _HDF_UDIMENSION)) {
                 int is_dimval, is_dimval01;
 
-                /* init both flags to FALSE  */
+                /* Init both flags to FALSE  */
                 is_dimval   = FALSE;
                 is_dimval01 = FALSE;
 
-                if (Vinquire(dim, &entries, vgname) == FAIL)
+                /* Get the vgroup name */
+                vgname = vgetvgname(dimvg);
+                if (!vgname)
                     HGOTO_FAIL(FAIL);
 
                 /*
-                 * look through for a Vdata of class DIM_VALS01 and/or DIM_VALS
+                 * Look through for a Vdata of class DIM_VALS01 and/or DIM_VALS
                  * to get size
                  */
                 sub_id = -1;
-                while (((sub_id = Vgetnext(dim, sub_id)) != FAIL)) {
-                    if (Visvs(dim, sub_id)) {
+                while (((sub_id = Vgetnext(dimvg, sub_id)) != FAIL)) {
+                    if (Visvs(dimvg, sub_id)) {
                         vs = VSattach(handle->hdf_file, sub_id, "r");
                         if (vs == FAIL)
                             HGOTO_FAIL(FAIL);
@@ -1285,7 +1300,7 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
                                 dimension[count]->dim00_compat = 0;
 
                             /* record vgroup id here so we can use later */
-                            /* Note: this is only for later file -BMR */
+                            /* Note: this is only for later file */
                             dimension[count]->vgid = id;
 
                             count++;
@@ -1294,8 +1309,13 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
                 }         /* while in dimension vg  */
             }             /* is vg  */
 
-            if (Vdetach(dim) == FAIL)
+            if (Vdetach(dimvg) == FAIL)
                 HGOTO_FAIL(FAIL);
+            dimvg = FAIL;
+            free(vgclass);
+            vgclass = NULL;
+            free(vgname);
+            vgname = NULL;
         } /* while */
     }
 
@@ -1309,6 +1329,8 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
 
 done:
     if (ret_value == FAIL) {
+        if (dimvg != -1)
+            Vdetach(dimvg);
         if (handle->dims != NULL) {
             NC_free_array(handle->dims);
             handle->dims = NULL;
@@ -1316,6 +1338,8 @@ done:
     }
 
     free(dimension);
+    free(vgname);
+    free(vgclass);
 
     return ret_value;
 } /* hdf_read_dims */
@@ -1505,11 +1529,8 @@ done:
 int
 hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
 {
-    char vgname[H4_MAX_NC_NAME]  = "";
-    char subname[H4_MAX_NC_NAME] = "";
-    char class[H4_MAX_NC_CLASS]  = "";
-    NC_var      **variables      = NULL;
-    NC_var       *vp             = NULL;
+    NC_var      **variables = NULL;
+    NC_var       *vp        = NULL;
     int           ndims, *dims = NULL;
     uint8         ntstring[4];
     int           data_ref, is_rec_var, vg_size, count;
@@ -1517,7 +1538,6 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
     int32         HDFtype = FAIL;
     int32         tag;
     int32         id;
-    int32         n;
     int32         sub_id;
     int32         entries;
     int32         ndg_ref = 0;
@@ -1526,8 +1546,13 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
     hdf_vartype_t var_type = UNKNOWN;
     int           t, i;
     nc_type       type;
-    int32         var, sub;
-    int           ret_value = SUCCEED;
+    int32         varvg, subvg;
+    char         *vgname     = NULL;
+    char         *vgclass    = NULL;
+    char         *dimvgname  = NULL;
+    char         *dimvgclass = NULL;
+    size_t        buf_size   = 0; /* Length of buffer for name or class */
+    int           ret_value  = SUCCEED;
 
     count = 0;
     id    = -1;
@@ -1561,17 +1586,18 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
         }
 
         if (tag == DFTAG_VG) {
-            var = Vattach(handle->hdf_file, id, "r");
-            if (var == FAIL)
-                continue; /* isn't this bad? -GV */
+            varvg = Vattach(handle->hdf_file, id, "r");
+            if (varvg == FAIL)
+                continue; /* skip a bad var */
 
-            if (Vgetclass(var, class) == FAIL) {
+            /* Get the class of the variable vgroup */
+            vgclass = vgetvgclass(varvg);
+            if (!vgclass)
                 HGOTO_FAIL(FAIL);
-            }
 
             /* Process as below if this VGroup represents a Variable or
             a Coordinate Variable */
-            if (!strcmp(class, _HDF_VARIABLE)) {
+            if (!strcmp(vgclass, _HDF_VARIABLE)) {
 
                 /*
                  * We have found a VGroup representing a Variable or a
@@ -1584,59 +1610,62 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                 rag_ref    = 0;
                 is_rec_var = FALSE;
 
-                if (Vinquire(var, &n, vgname) == FAIL) {
+                /* Get the number of entries in the variable vgroup */
+                if (Vinquire(varvg, &entries, NULL, &buf_size) == FAIL)
                     HGOTO_FAIL(FAIL);
-                }
 
                 /*
                  * Loop through contents looking for dimensions
                  */
-                for (t = 0; t < n; t++) {
-                    char dimclass[H4_MAX_NC_CLASS] = "";
-                    char vsclass[H4_MAX_NC_CLASS]  = "";
-                    if (Vgettagref(var, t, &tag, &sub_id) == FAIL) {
+                for (t = 0; t < entries; t++) {
+                    char vsclass[H4_MAX_NC_CLASS] = "";
+                    if (Vgettagref(varvg, t, &tag, &sub_id) == FAIL) {
                         HGOTO_FAIL(FAIL);
                     }
 
                     switch (tag) {
                         case DFTAG_VG: /* ------ V G R O U P ---------- */
-                            sub = Vattach(handle->hdf_file, sub_id, "r");
-                            if (FAIL == sub) {
+                            subvg = Vattach(handle->hdf_file, sub_id, "r");
+                            if (FAIL == subvg) {
                                 HGOTO_FAIL(FAIL);
                             }
-
-                            if (FAIL == Vgetclass(sub, dimclass)) {
+                            /* Get the class of the dimension vgroup */
+                            dimvgclass = vgetvgclass(subvg);
+                            if (!dimvgclass)
                                 HGOTO_FAIL(FAIL);
-                            }
 
-                            if (!strcmp(dimclass, _HDF_DIMENSION) || !strcmp(dimclass, _HDF_UDIMENSION)) {
+                            if (!strcmp(dimvgclass, _HDF_DIMENSION) || !strcmp(dimvgclass, _HDF_UDIMENSION)) {
 
-                                if (!strcmp(dimclass, _HDF_UDIMENSION))
+                                /* Mark if the dimension is an unlimited dimension */
+                                if (!strcmp(dimvgclass, _HDF_UDIMENSION))
                                     is_rec_var = TRUE;
 
-                                if (FAIL == Vinquire(sub, &entries, subname)) {
+                                /* Get the name of the dimension vg */
+                                dimvgname = vgetvgname(subvg);
+                                if (!dimvgname)
                                     HGOTO_FAIL(FAIL);
-                                }
 
-                                dims[ndims] = (int)NC_dimid(handle, subname);
-                                if (-1 == dims[ndims]) /* should change to FAIL */
-                                {
+                                dims[ndims] = NC_dimid(handle, dimvgname);
+                                free(dimvgname);
+                                if (dims[ndims] == -1)
                                     HGOTO_FAIL(FAIL);
-                                }
 
+                                /* Increment the number of dimensions in varvg */
                                 ndims++;
                             }
-                            if (FAIL == Vdetach(sub)) {
+                            if (FAIL == Vdetach(subvg)) {
                                 HGOTO_FAIL(FAIL);
                             }
+                            subvg = FAIL;
+                            HDfreenclear(dimvgclass);
 
                             break;
                         case DFTAG_VH: /* ----- V D A T A ----- */
-                            sub = VSattach(handle->hdf_file, sub_id, "r");
-                            if (FAIL == sub)
+                            subvg = VSattach(handle->hdf_file, sub_id, "r");
+                            if (FAIL == subvg)
                                 HGOTO_FAIL(FAIL);
 
-                            if (FAIL == VSgetclass(sub, vsclass))
+                            if (FAIL == VSgetclass(subvg, vsclass))
                                 HGOTO_FAIL(FAIL);
 
                             if (!strcmp(vsclass, _HDF_SDSVAR))
@@ -1646,7 +1675,7 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                             else
                                 var_type = UNKNOWN;
 
-                            if (FAIL == VSdetach(sub))
+                            if (FAIL == VSdetach(subvg))
                                 HGOTO_FAIL(FAIL);
                             break;
                         case DFTAG_NDG: /* ----- NDG Tag for HDF 3.2 ----- */
@@ -1709,6 +1738,11 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                     }
                 }
 
+                /* Get the name of the variable vgroup */
+                vgname = vgetvgname(varvg);
+                if (!vgname)
+                    HGOTO_FAIL(FAIL);
+
                 variables[count] = NC_new_var(vgname, type, ndims, dims);
                 /* BMR: put back hdf type that was set wrong by
                 NC_new_var; please refer to the cvs history of
@@ -1722,8 +1756,8 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                 }
 
                 /* Read in the attributes if any */
-                if ((nattrs = hdf_num_attrs(handle, var)) > 0)
-                    vp->attrs = hdf_read_attrs(xdrs, handle, var);
+                if ((nattrs = hdf_num_attrs(handle, varvg)) > 0)
+                    vp->attrs = hdf_read_attrs(xdrs, handle, varvg);
                 else
                     vp->attrs = NULL;
 
@@ -1772,12 +1806,8 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
                          * Deallocate the shape info as it will be recomputed
                          *  at a higher level later
                          */
-                        free(vp->shape);
-                        free(vp->dsizes);
-                        /* Reset these two pointers to NULL after
-                            freeing.  BMR 4/11/01 */
-                        vp->shape  = NULL;
-                        vp->dsizes = NULL;
+                        HDfreenclear(vp->shape);
+                        HDfreenclear(vp->dsizes);
                     }
                     else {
                         /* Not a rec var, don't worry about it */
@@ -1789,8 +1819,12 @@ hdf_read_vars(XDR *xdrs, NC *handle, int32 vg)
 
 bad_number_type: /* ? */
 
-            if (FAIL == Vdetach(var))
+            if (FAIL == Vdetach(varvg))
                 HGOTO_FAIL(FAIL);
+            varvg = FAIL;
+
+            HDfreenclear(vgclass);
+            HDfreenclear(vgname);
 
         } /* end if DTAG_VG */
     }     /* end for vg_size */
@@ -1812,6 +1846,9 @@ done:
 
     free(variables);
     free(dims);
+    free(vgname);
+    free(vgclass);
+    free(dimvgclass);
 
     return ret_value;
 } /* hdf_read_vars */
@@ -1996,7 +2033,7 @@ done:
 int
 hdf_cdf_clobber(NC *handle)
 {
-    int32 vg, tag, ref;
+    int32 vg = FAIL, tag, ref;
     int   n, t, status;
     int   ret_value = SUCCEED;
 
@@ -2064,6 +2101,7 @@ hdf_cdf_clobber(NC *handle)
     if (FAIL == Vdetach(vg)) {
         HGOTO_FAIL(FAIL);
     }
+    vg = FAIL;
 
     status = Vdelete(handle->hdf_file, (int32)handle->vgid);
     if (FAIL == status) {
@@ -2073,6 +2111,9 @@ hdf_cdf_clobber(NC *handle)
     handle->vgid = 0; /* reset ref of SDS vgroup to invalid ref */
 
 done:
+    if (vg != FAIL)
+        Vdetach(vg);
+
     return ret_value;
 } /* hdf_cdf_clobber */
 
@@ -2097,10 +2138,10 @@ hdf_close(NC *handle)
     uint8_t  *vars = NULL;
     int       i;
     int       id, sub_id;
-    int32     vg, dim;
-    int32     vs;
-    char class[H4_MAX_NC_CLASS] = "";
-    int ret_value               = SUCCEED;
+    int32     vg = FAIL, dim = FAIL, vs = FAIL;
+    char     *vgclass                  = NULL;
+    char      vsclass[H4_MAX_NC_CLASS] = "";
+    int       ret_value                = SUCCEED;
 
     /* loop through and detach from variable data VDatas */
     if (handle->vars) {
@@ -2138,12 +2179,12 @@ hdf_close(NC *handle)
                     HGOTO_FAIL(FAIL);
                 }
 
-                if (FAIL == Vgetclass(dim, class)) {
+                vgclass = vgetvgclass(dim);
+                if (!vgclass)
                     HGOTO_FAIL(FAIL);
-                }
 
                 /* look for proper vgroup */
-                if (!strcmp(class, _HDF_UDIMENSION)) {
+                if (!strcmp(vgclass, _HDF_UDIMENSION)) {
                     sub_id = -1;
                     /* look for vdata in vgroup */
                     while ((sub_id = Vgetnext(dim, sub_id)) != FAIL) {
@@ -2154,12 +2195,12 @@ hdf_close(NC *handle)
                                 /* HEprint(stdout, 0); */
                             }
                             /* get class of vdata */
-                            if (FAIL == VSgetclass(vs, class)) {
+                            if (FAIL == VSgetclass(vs, vsclass)) {
                                 HGOTO_FAIL(FAIL);
                             }
 
                             /* are these dimension vdatas? */
-                            if (!strcmp(class, DIM_VALS) || !strcmp(class, DIM_VALS01)) { /* yes */
+                            if (!strcmp(vsclass, DIM_VALS) || !strcmp(vsclass, DIM_VALS01)) { /* yes */
                                 int32 val = handle->numrecs;
 
                                 if (FAIL == VSsetfields(vs, "Values")) {
@@ -2177,9 +2218,9 @@ hdf_close(NC *handle)
                             }
 
                             /* detach from vdata */
-                            if (FAIL == VSdetach(vs)) {
+                            if (FAIL == VSdetach(vs))
                                 HGOTO_FAIL(FAIL);
-                            }
+                            vs = FAIL;
 
                         } /* end if vdata */
                     }     /* end while looking for vdata in vgroup */
@@ -2189,17 +2230,29 @@ hdf_close(NC *handle)
                     fprintf(stderr, "hdf_close: Vdetach failed for vgroup ref %d\n", id);
                     HGOTO_FAIL(FAIL);
                 }
+                dim = FAIL;
+                HDfreenclear(vgclass);
 
             } /* end if vgroup */
         }     /* end if looking through toplevel vgroup hierarchy */
 
-        if (FAIL == Vdetach(vg)) {
+        if (FAIL == Vdetach(vg))
             HGOTO_FAIL(FAIL);
-        }
+        vg = FAIL;
 
     } /* end if we need to flush out unlimited dimensions? */
 
 done:
+    if (ret_value == FAIL) {
+        if (dim != FAIL)
+            Vdetach(dim);
+        if (vs != FAIL)
+            VSdetach(vs);
+        if (vg != FAIL)
+            Vdetach(vg);
+        free(vgclass);
+    }
+
     return ret_value;
 } /* hdf_close */
 

--- a/mfhdf/src/cdf.c
+++ b/mfhdf/src/cdf.c
@@ -58,35 +58,37 @@ NC_free_cdf(NC *handle)
 {
     int ret_value = SUCCEED;
 
-    if (handle != NULL) {
-        if (NC_free_xcdf(handle) == FAIL)
-            HGOTO_FAIL(FAIL);
+    if (handle == NULL) {
+        return FAIL;
+    }
 
-        /* destroy xdr struct */
+    /* Free internal XDR structures */
+    if (NC_free_xcdf(handle) == FAIL) {
+        ret_value = FAIL;
+        goto done;
+    }
+
+    if (handle->xdrs != NULL) {
         hdf_xdr_destroy(handle->xdrs);
         free(handle->xdrs);
         handle->xdrs = NULL;
-
-        if (handle->file_type == HDF_FILE) {
-            if (Vend(handle->hdf_file) == FAIL)
-                HGOTO_FAIL(FAIL);
-
-            if (Hclose(handle->hdf_file) == FAIL)
-                HGOTO_FAIL(FAIL);
-        }
-
-        free(handle);
-        handle = NULL;
     }
 
+    /* Close file descriptors if it's an HDF file */
+    if (handle->file_type == HDF_FILE) {
+        if (Vend(handle->hdf_file) == FAIL) {
+            ret_value = FAIL;
+            goto done; /* skip Hclose if Vend fails */
+        }
+
+        if (Hclose(handle->hdf_file) == FAIL) {
+            ret_value = FAIL;
+            goto done;
+        }
+    }
 done:
-    if (ret_value == FAIL) {
-        if (handle->file_type == HDF_FILE) {
-            Vend(handle->hdf_file);
-            Hclose(handle->hdf_file);
-        }
-    }
-
+    /* Free the top-level handle, even on failure paths */
+    free(handle);
     return ret_value;
 }
 
@@ -1165,7 +1167,6 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
     int      sub_id;
     char    *vgname                   = NULL; /* name of a vgroup, used by new Vgetname */
     char    *vgclass                  = NULL; /* class of a vgroup, used by new Vgetclass */
-    size_t   buf_size                 = 0;    /* length of the name or class of a vgroup */
     char     vsclass[H4_MAX_NC_CLASS] = "";   /* name of vdata */
     int32    dim_size;
     NC_dim **dimension = NULL;
@@ -1329,6 +1330,8 @@ hdf_read_dims(XDR *xdrs, NC *handle, int32 vg)
 
 done:
     if (ret_value == FAIL) {
+        if (vs != -1)
+            VSdetach(vs);
         if (dimvg != -1)
             Vdetach(dimvg);
         if (handle->dims != NULL) {

--- a/mfhdf/test/tmixed_apis.c
+++ b/mfhdf/test/tmixed_apis.c
@@ -29,6 +29,7 @@
 #include <string.h>
 
 #include "mfhdf.h"
+#include "vg_priv.h"
 #include "hdftest.h"
 
 #define IDTYPE_FILE "idtypes.hdf" /* data file to test ID types */
@@ -265,7 +266,6 @@ test_vdatavgroups()
     float32     att1_values[2] = {2., 10.};
     char8       att2_values[]  = "Seconds";
     uint16     *refarray       = NULL;
-    uint16      name_len       = 0;
     int         ii, status;
     char       *vg_name           = NULL, vd_name[10];
     const char *check_vg_names[3] = {"Vgroup_1", "Vgroup_2", "Vgroup_3"};
@@ -395,24 +395,16 @@ test_vdatavgroups()
         vgroup_id = Vattach(fid, refarray[ii], "r");
         CHECK(vgroup_id, FAIL, "Vattach");
 
-        status = Vgetnamelen(vgroup_id, &name_len);
-        CHECK(status, FAIL, "Vgetnamelen");
+        vg_name = vgetvgname(vgroup_id);
+        CHECK(vg_name, NULL, "vgetvgname");
 
-        vg_name = (char *)malloc((sizeof(char) * name_len) + 1);
-        CHECK_ALLOC(vg_name, "vg_name", "test_vdatavgroups");
-
-        status = Vgetname(vgroup_id, vg_name);
-        CHECK(status, FAIL, "Vgetname");
-        VERIFY_CHAR(vg_name, check_vg_names[ii], "");
-
-        if (strncmp(vg_name, check_vg_names[ii], name_len) != 0)
+        if (strcmp(vg_name, check_vg_names[ii]) != 0)
             fprintf(stderr, "vg %d: name is %s, should be %s\n", ii, vg_name, check_vg_names[ii]);
 
         /* Release resource */
-        free(vg_name);
-        vg_name = NULL;
-        status  = Vdetach(vgroup_id);
+        status = Vdetach(vgroup_id);
         CHECK(status, FAIL, "Vdetach");
+        HDfreenclear(vg_name);
     }
     /* Release resource */
     free(refarray);
@@ -442,7 +434,7 @@ test_vdatavgroups()
 
         VERIFY_CHAR(vd_name, check_vd_names[ii], "");
 
-        if (strncmp(vd_name, check_vd_names[ii], name_len) != 0)
+        if (strcmp(vd_name, check_vd_names[ii]) != 0)
             fprintf(stderr, "vd %d: name is %s, should be %s\n", ii, vd_name, check_vd_names[ii]);
         status = VSdetach(vdata_id);
         CHECK(status, FAIL, "VSdetach");

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -279,10 +279,10 @@ New features and changes
     - Vgroup API breaking changes: Vgetname, Vgetclass, Vinquire
 
       The unbounded write in Vgetname, Vgetclass, and Vinquire could
-      overflow caller-supplied buffers.  Their signature of these
-      functions changed to take a size_t *buf_size (IN/OUT) parameter
+      previously overflow caller-supplied buffers.  The signature of these
+      functions has been changed to take a size_t *buf_size (IN/OUT) parameter
       to address that security vulnerability. In addition, Vgetnamelen
-      and Vgetclassnamelen are removed because applications can now use
+      and Vgetclassnamelen were removed because applications can now use
       Vgetname/Vgetclass to query the required length instead.
 
       The new prototypes are:
@@ -298,7 +298,7 @@ New features and changes
 
       The Fortran bindings (VFGNAM, VFGCLS, VFINQ) had no buffer-length
       information anywhere in the call chain and were independently
-      exposed to the same overflow. This is fixed as part of the
+      exposed to the same overflow. This was fixed as part of the
       same change — the Fortran stubs now query the actual length
       internally and allocate correctly-sized buffers before copying
       into the caller's CHARACTER variable.

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -276,6 +276,42 @@ New features and changes
       retained in hdf.h so old code will compile, but other public headers
       now use int and unsigned in place of these types.
 
+    - Vgroup API breaking changes: Vgetname, Vgetclass, Vinquire
+
+      The unbounded write in Vgetname, Vgetclass, and Vinquire could
+      overflow caller-supplied buffers.  Their signature of these
+      functions changed to take a size_t *buf_size (IN/OUT) parameter
+      to address that security vulnerability. In addition, Vgetnamelen
+      and Vgetclassnamelen are removed because applications can now use
+      Vgetname/Vgetclass to query the required length instead.
+
+      The new prototypes are:
+        int Vgetname(int32 vkey, char *vgname, size_t *buf_size);
+        int Vgetclass(int32 vkey, char *vgclass, size_t *buf_size);
+        int Vinquire(int32 vkey, int32 *nentries, char *vgname, size_t *buf_size);
+
+      Callers must update all call sites accordingly by calling
+      Vgetname/Vgetclass the first time passing in NULL for the buffer
+      to retrieve the size of the name/class.  The size then must be
+      incremented to account for the null-terminator prior to being
+      passed into the fetch call.
+
+      The Fortran bindings (VFGNAM, VFGCLS, VFINQ) had no buffer-length
+      information anywhere in the call chain and were independently
+      exposed to the same overflow. This is fixed as part of the
+      same change — the Fortran stubs now query the actual length
+      internally and allocate correctly-sized buffers before copying
+      into the caller's CHARACTER variable.
+
+      For the Java API, no changes to public method signatures —
+      buf_size handling is fully internal to the JNI layer. The
+      old JNI implementations exposed Java applications to the same
+      overflow risk as C by writing directly into fixed-size buffers
+      (H4_MAX_NC_CLASS/H4_MAX_GR_NAME). The JNI layer now queries the
+      actual required length and allocates correctly-sized buffers
+      before fetching.
+
+
 Bugs fixed since HDF 4.3.1
 ===========================
     -


### PR DESCRIPTION
Vgetname, Vgetclass, and Vinquire performed unbounded strcpy into caller-supplied buffers with no length parameter, allowing stack buffer overflows on names/classes longer than the caller anticipated.

Each function now takes a buf_size parameter (size_t *, IN/OUT) and returns SUCCEED/FAIL. To query a name/class's length without copying, callers pass NULL for the buffer; the actual length is written back into *buf_size. This makes Vgetnamelen and Vgetclassnamelen redundant, so they're removed. To fetch the name/class itself, callers allocate *buf_size + 1 bytes and pass that allocated size (*buf_size + 1) back in via buf_size, along with the buffer.

Two utility functions were added, vgetvgname/vgetvgclass. They return the name/class of a vgroup, allocating the buffer internally so the caller does not need to know the length of the name/class in advance. Strictly intended for use within the library and tools, by including the private header file vg_priv.h; the caller is responsible for freeing the returned buffer.

BREAKING: callers must update call sites to pass a size_t *buf_size to any of these three functions, and replace calls to Vgetnamelen/Vgetclassnamelen with the appropriate Vgetname/Vgetclass call — passing NULL for the buffer and a pointer to a size_t (initialized to any value) for buf_size to query the length alone.

Fixes https://github.com/HDFGroup/hdf4/issues/872