### PR TITLE
Fixes memory issues atom code and low level V code

### DIFF
--- a/hdf/src/hfiledd.c
+++ b/hdf/src/hfiledd.c
@@ -1853,23 +1853,11 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, unsigned *all_c
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {
                         t_all_cnt += (unsigned)block->ndds;
 
-                        idx    = 0;
                         dd_ptr = block->ddlist;
-                        if (block->ndds % 2 == 1)
-                            if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag) {
-                                t_real_cnt++;
-                                idx++;
-                                dd_ptr++;
-                            } /* end if */
-                        for (; idx < block->ndds; idx++, dd_ptr++) {
+                        for (idx = 0; idx < block->ndds; idx++, dd_ptr++)
                             if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
                                 t_real_cnt++;
-                            idx++;
-                            dd_ptr++;
-                            if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
-                                t_real_cnt++;
-                        } /* end for */
-                    }     /* end for */
+                    } /* end for */
                 }         /* end if */
                 else {
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {

--- a/hdf/src/hfiledd.c
+++ b/hdf/src/hfiledd.c
@@ -1858,7 +1858,7 @@ HTIcount_dd(filerec_t *file_rec, uint16 cnt_tag, uint16 cnt_ref, unsigned *all_c
                             if (dd_ptr->tag == cnt_tag || dd_ptr->tag == special_tag)
                                 t_real_cnt++;
                     } /* end for */
-                }         /* end if */
+                }     /* end if */
                 else {
                     for (block = file_rec->ddhead; block != NULL; block = block->next) {
                         t_all_cnt += (unsigned)block->ndds;

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -941,6 +941,8 @@ vunpackvg(VGROUP *vg,    /* IN/OUT: */
         if (uint16var == 0)
             vg->vgname = NULL;
         else {
+            if (NULL == (vg->vgname = (char *)malloc(uint16var + 1)))
+                HGOTO_ERROR(DFE_NOSPACE, FAIL);
             vg->vgname = (char *)malloc(uint16var + 1);
             HIstrncpy(vg->vgname, (char *)bb, (int)uint16var + 1);
             bb += (size_t)uint16var;
@@ -951,7 +953,8 @@ vunpackvg(VGROUP *vg,    /* IN/OUT: */
         if (uint16var == 0)
             vg->vgclass = NULL;
         else {
-            vg->vgclass = (char *)malloc(uint16var + 1);
+            if (NULL == (vg->vgclass = (char *)malloc(uint16var + 1)))
+                HGOTO_ERROR(DFE_NOSPACE, FAIL);
             HIstrncpy(vg->vgclass, (char *)bb, (int)uint16var + 1);
             bb += (size_t)uint16var;
         }
@@ -2838,6 +2841,20 @@ VPshutdown(void)
     vginstance_t *vg        = NULL;
     int           ret_value = SUCCEED;
 
+    if (vtree != NULL) {
+        /* Free the vfile tree */
+        tbbtdfree(vtree, vfdestroynode, NULL);
+
+        /* Destroy the atom groups for Vdatas and Vgroups */
+        if (HAdestroy_group(VSIDGROUP) == FAIL)
+            HGOTO_ERROR(DFE_INTERNAL, FAIL);
+
+        if (HAdestroy_group(VGIDGROUP) == FAIL)
+            HGOTO_ERROR(DFE_INTERNAL, FAIL);
+
+        vtree = NULL;
+    }
+
     /* Release the vdata free-list if it exists */
     if (vgroup_free_list != NULL) {
         while (vgroup_free_list != NULL) {
@@ -2858,23 +2875,8 @@ VPshutdown(void)
         }
     }
 
-    if (vtree != NULL) {
-        /* Free the vfile tree */
-        tbbtdfree(vtree, vfdestroynode, NULL);
-
-        /* Destroy the atom groups for Vdatas and Vgroups */
-        if (HAdestroy_group(VSIDGROUP) == FAIL)
-            HGOTO_ERROR(DFE_INTERNAL, FAIL);
-
-        if (HAdestroy_group(VGIDGROUP) == FAIL)
-            HGOTO_ERROR(DFE_INTERNAL, FAIL);
-
-        vtree = NULL;
-    }
-
     if (Vgbuf != NULL) {
-        free(Vgbuf);
-        Vgbuf     = NULL;
+        HDfreenclear(Vgbuf);
         Vgbufsize = 0;
     }
 

--- a/hdf/src/vgp.c
+++ b/hdf/src/vgp.c
@@ -943,7 +943,6 @@ vunpackvg(VGROUP *vg,    /* IN/OUT: */
         else {
             if (NULL == (vg->vgname = (char *)malloc(uint16var + 1)))
                 HGOTO_ERROR(DFE_NOSPACE, FAIL);
-            vg->vgname = (char *)malloc(uint16var + 1);
             HIstrncpy(vg->vgname, (char *)bb, (int)uint16var + 1);
             bb += (size_t)uint16var;
         }


### PR DESCRIPTION
1. The code that destroys the atom groups for Vdatas and Vgroups was placed after the free lists had already been freed, so, that code added more released memory to the free lists, which were never freed, causing many memory leaks.

Moving that block of code to the appropriate place removed all of those leaks. Also added allocation checks.
Fixes GH-819

2. HTIcount_dd had an incorrect block of code that caused invalid read errors. The original author provided the modified code that removed the invalid read errors.

Fixes GH-808