### PR TITLE
Update filename strings for non-intel windows binaries to vs2026 instead

### DIFF
--- a/.github/workflows/cmake-bintest.yml
+++ b/.github/workflows/cmake-bintest.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get published binary (Windows)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-              name: zip-vs2022_cl-${{ inputs.build_mode }}-binary
+              name: zip-vs2026_cl-${{ inputs.build_mode }}-binary
               path: ${{ github.workspace }}/hdf4
 
       - name: Uncompress hdf4 binary (Win)

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -173,14 +173,14 @@ jobs:
           Copy-Item -Path ${{ runner.workspace }}/hdf4/build/${{ inputs.preset_name }}-MSVC/README.txt -Destination ${{ runner.workspace }}/build/hdf4/
           Copy-Item -Path ${{ runner.workspace }}/hdf4/build/${{ inputs.preset_name }}-MSVC/* -Destination ${{ runner.workspace }}/build/hdf4/ -Include *.zip
           cd "${{ runner.workspace }}/build"
-          7z a -tzip ${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip hdf4
+          7z a -tzip ${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2026_cl.zip hdf4
         shell: pwsh
 
       - name: Publish msi binary (Windows)
         id: publish-ctest-msi-binary
         run: |
           mkdir "${{ runner.workspace }}/buildmsi"
-          Copy-Item -Path ${{ runner.workspace }}/hdf4/build/${{ inputs.preset_name }}-MSVC/* -Destination ${{ runner.workspace }}/buildmsi/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi -Include *.msi
+          Copy-Item -Path ${{ runner.workspace }}/hdf4/build/${{ inputs.preset_name }}-MSVC/* -Destination ${{ runner.workspace }}/buildmsi/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2026_cl.msi -Include *.msi
         shell: pwsh
 
       - name: List files in the space (Windows)
@@ -193,15 +193,15 @@ jobs:
       - name: Save published binary (Windows)
         uses: actions/upload-artifact@v7
         with:
-              name: zip-vs2022_cl-binary
-              path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
+              name: zip-vs2026_cl-binary
+              path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2026_cl.zip
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save published msi binary (Windows)
         uses: actions/upload-artifact@v7
         with:
-              name: msi-vs2022_cl-binary
-              path: ${{ runner.workspace }}/buildmsi/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi
+              name: msi-vs2026_cl-binary
+              path: ${{ runner.workspace }}/buildmsi/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2026_cl.msi
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_linux:

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Save published binary (Windows)
         uses: actions/upload-artifact@v7
         with:
-              name: zip-vs2022_cl-${{ inputs.build_mode }}-binary
+              name: zip-vs2026_cl-${{ inputs.build_mode }}-binary
               path: ${{ runner.workspace }}/build/HDF-*-win64.zip
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
         if:  ${{ (matrix.os == 'windows-latest') && (matrix.name != 'Ubuntu mingw CMake') && (inputs.shared == 'true') }}

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -71,13 +71,13 @@ jobs:
       - name: Get published binary (Windows)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-              name: zip-vs2022_cl-binary
+              name: zip-vs2026_cl-binary
               path: ${{ github.workspace }}
 
       - name: Get published msi binary (Windows)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-              name: msi-vs2022_cl-binary
+              name: msi-vs2026_cl-binary
               path: ${{ github.workspace }}
 
       - name: Get published binary (MacOS)
@@ -158,8 +158,8 @@ jobs:
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.tar.gz >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.deb >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
+          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.zip >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
+          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.msi >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_intel.tar.gz >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.msi >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
@@ -204,8 +204,8 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.deb
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.zip
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.msi
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.msi
@@ -234,8 +234,8 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.deb
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.zip
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.msi
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.msi

--- a/.github/workflows/remove-files.yml
+++ b/.github/workflows/remove-files.yml
@@ -55,8 +55,8 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.deb
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.zip
+              ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2026_cl.msi
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2404_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.msi


### PR DESCRIPTION
of vs 2022 as they are built with windows-latest which is currently windows-2025-vs2026.