### PR TITLE
Fix pkg-config {include,lib}dir paths.

### DIFF
--- a/mfhdf/src/CMakeLists.txt
+++ b/mfhdf/src/CMakeLists.txt
@@ -130,8 +130,8 @@ install (
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${HDF4_INSTALL_LIB_DIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${HDF4_INSTALL_INCLUDE_DIR})
 set (_PKG_CONFIG_LIBNAME "${HDF4_SRC_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF4_PACKAGE_VERSION}")
 set (PKGCONFIG_LIBNAME "${HDF4_SRC_LIB_CORENAME}")


### PR DESCRIPTION
The `includedir` & `libdir` variables in the `pkg-config` file are incorrect when non-default paths are used using `HDF4_INSTALL_INCLUDE_DIR` & `HDF4_INSTALL_LIB_DIR`.

This is fixed by not hardcoding the subdirectories.

The resulting `hdf.pc` still has an issue, the private libs contain CMake targets:
```
Libs.private:  -lhdf -lmfhdf  -lm -l/usr/lib/x86_64-linux-gnu/libjpeg.so -lZLIB::ZLIB -llibaec::sz -llibaec::aec
```
I don't know how to fix this, so left this out of scope for this PR.
Hopefully someone more familiar with CMake knows how to resolve these targets.